### PR TITLE
Extract example procedure to separate file

### DIFF
--- a/lib/Technique/Evaluator.hs
+++ b/lib/Technique/Evaluator.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE GADTs #-}
+
+module Technique.Evaluator where
+
+-- TODO *not* Maybe! If we have two option types here then there are four
+-- possibilities we need to cater for [(Nothing,Nothing), ... (Just,Just)]
+-- which means there are four semantics for a given table row. Hm.
+
+-- TODO there's an ambiguity here between the type of a table and the type
+-- of an individual quantity. Which is "type"?
+
+{-
+data Value = Value
+    { valueType :: Type 
+    , valueLabel :: Maybe Label
+    , valueData :: Maybe Quantity
+    }
+
+data Type = Type
+     { typeName :: Rope
+--   , typeInternal :: t
+     }
+-}
+
+
+{-
+data Expression b where
+    Binding :: Variable b -> Expression a -> Expression b
+    Comment :: Rope -> Expression ()
+    Declaration :: (a -> b) -> Expression (a -> b)
+    Application :: Expression (a -> b) -> Expression a -> Expression b 
+    Attribute :: Role -> Expression a -> Expression a
+-}
+
+
+{-
+-- aka apply
+execute :: Procedure -> Value -> b
+execute proc value =
+  let
+    body = procedureBlock proc
+  in
+    evaluate body
+
+type Context = Map String Value -- ?
+
+
+evaluate = undefined
+
+evaluate :: Context -> Expression -> Value
+evaluate e = case e of
+    Comment _ -> ()
+    _ -> undefined
+-}

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -58,7 +58,7 @@ instance Render Procedure where
       let
         name = pretty . procedureName $ proc
         params = commaCat . procedureParams $ proc
-        from = pretty . typeName . procedureInput $ proc
+        from = commaCat . procedureInput $ proc
         into = pretty . typeName . procedureOutput $ proc
         block = intoDocA . procedureBlock $ proc
       in
@@ -75,6 +75,11 @@ punctuate a list with commas annotated with Symbol highlighting.
 -}
 commaCat :: (Render a, Token a ~ TechniqueToken)  => [a] -> Doc (Token a)
 commaCat = hcat . punctuate (annotate SymbolToken comma) . fmap intoDocA
+
+instance Render Type where
+    type Token Type = TechniqueToken
+    colourize = colourizeTechnique
+    intoDocA (Type name) = annotate TypeToken (pretty name)
 
 instance Render Block where
     type Token Block = TechniqueToken

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -57,7 +57,7 @@ instance Render Procedure where
     intoDocA proc =
       let
         name = pretty . procedureName $ proc
-        params = concatWith (surround (annotate SymbolToken comma)) (fmap intoDocA (procedureParams proc))
+        params = commaCat . procedureParams $ proc
         from = pretty . typeName . procedureInput $ proc
         into = pretty . typeName . procedureOutput $ proc
         block = intoDocA . procedureBlock $ proc
@@ -69,6 +69,12 @@ instance Render Procedure where
         annotate SymbolToken "->" <+>
         annotate TypeToken into <>
         block
+
+{-|
+punctuate a list with commas annotated with Symbol highlighting.
+-}
+commaCat :: (Render a, Token a ~ TechniqueToken)  => [a] -> Doc (Token a)
+commaCat = hcat . punctuate (annotate SymbolToken comma) . fmap intoDocA
 
 instance Render Block where
     type Token Block = TechniqueToken

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -26,6 +26,7 @@ data TechniqueToken
     = ProcedureToken
     | TypeToken
     | SymbolToken
+    | OperatorToken
     | VariableToken
     | ApplicationToken
     | LabelToken
@@ -43,6 +44,7 @@ colourizeTechnique token = case token of
     ProcedureToken -> colorDull Blue <> bold
     TypeToken -> colorDull Yellow
     SymbolToken -> colorDull Cyan <> bold
+    OperatorToken -> colorDull Yellow <> bold
     VariableToken -> color Cyan
     ApplicationToken -> color Blue <> bold
     LabelToken -> color Green <> bold
@@ -119,6 +121,7 @@ instance Render Role where
     intoDocA role =  case role of
         Any -> annotate RoleToken "@*"
         Role name -> annotate RoleToken ("@" <> pretty name)
+        Place name -> annotate RoleToken ("#" <> pretty name)
 
 instance Render Expression where
     type Token Expression = TechniqueToken
@@ -195,4 +198,4 @@ instance Render Operator where
     type Token Operator = TechniqueToken
     colourize = colourizeTechnique
     intoDocA (Operator symbol) =
-        annotate SymbolToken (pretty symbol)
+        annotate OperatorToken (pretty symbol)

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -68,7 +68,7 @@ instance Render Procedure where
         annotate TypeToken from <+>
         annotate SymbolToken "->" <+>
         annotate TypeToken into <>
-        block
+        line <> block
 
 {-|
 punctuate a list with commas annotated with Symbol highlighting.
@@ -85,7 +85,6 @@ instance Render Block where
     type Token Block = TechniqueToken
     colourize = colourizeTechnique
     intoDocA (Block statements) =
-        line <>
         nest 4 (
             annotate SymbolToken lbrace <>
             foldl' f emptyDoc statements

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -117,8 +117,8 @@ instance Render Role where
     type Token Role = TechniqueToken
     colourize = colourizeTechnique
     intoDocA role =  case role of
-        Any -> annotate RoleToken "$*"
-        Role name -> annotate RoleToken ("$" <> pretty name)
+        Any -> annotate RoleToken "@*"
+        Role name -> annotate RoleToken ("@" <> pretty name)
 
 instance Render Expression where
     type Token Expression = TechniqueToken

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -52,7 +52,7 @@ data Type = Type
 data Procedure = Procedure
     { procedureName :: Rope
     , procedureParams :: [Name]
-    , procedureInput :: Type
+    , procedureInput :: [Type]
     , procedureOutput :: Type
     , procedureLabel :: Maybe Markdown
     , procedureDescription :: Maybe Markdown

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -14,39 +14,14 @@ data Name where
 -- newlines, perhaps.
 type Label = Rope
 
--- TODO *not* Maybe! If we have two option types here then there are four
--- possibilities we need to cater for [(Nothing,Nothing), ... (Just,Just)]
--- which means there are four semantics for a given table row. Hm.
-
--- TODO there's an ambiguity here between the type of a table and the type
--- of an individual quantity. Which is "type"?
-
-{-
-data Value = Value
-    { valueType :: Type 
-    , valueLabel :: Maybe Label
-    , valueData :: Maybe Quantity
-    }
--}
 data Role
     = Any
     | Role Rope
 
 data Markdown = Markdown Rope
 
-{-
-data Expression b where
-    Binding :: Variable b -> Expression a -> Expression b
-    Comment :: Rope -> Expression ()
-    Declaration :: (a -> b) -> Expression (a -> b)
-    Application :: Expression (a -> b) -> Expression a -> Expression b 
-    Attribute :: Role -> Expression a -> Expression a
--}
-
-
 data Type = Type
     { typeName :: Rope
---  , typeInternal :: t
     }
 
 data Procedure = Procedure
@@ -86,24 +61,3 @@ data Binding where
 
 data Operator where
     Operator :: Rope -> Operator
-
-
-{-
--- aka apply
-execute :: Procedure -> Value -> b
-execute proc value =
-  let
-    body = procedureBlock proc
-  in
-    evaluate body
-
-type Context = Map String Value -- ?
-
-
-evaluate = undefined
-
-evaluate :: Context -> Expression -> Value
-evaluate e = case e of
-    Comment _ -> ()
-    _ -> undefined
--}

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -17,6 +17,7 @@ type Label = Rope
 data Role
     = Any
     | Role Rope
+    | Place Rope
 
 data Markdown = Markdown Rope
 

--- a/package.yaml
+++ b/package.yaml
@@ -39,7 +39,8 @@ library:
    - Technique.Quantity
    - Technique.Formatter
    - Technique.Parser
-  other-modules: []
+  other-modules:
+   - Technique.Evaluator
 
 executables:
   technique:

--- a/tests/CheckAbstractSyntax.hs
+++ b/tests/CheckAbstractSyntax.hs
@@ -3,135 +3,18 @@
 
 module CheckAbstractSyntax
     ( checkAbstractSyntax
-    , main
     )
 where
 
-import Core.Data.Structures
 import Core.Text.Rope ()
 import Core.Text.Utilities ()
--- import Data.Text.Prettyprint.Doc (Pretty(pretty))
-import Core.Program.Execute hiding (None)
-import Core.Program.Logging
-import Data.Maybe (fromJust)
 import Test.Hspec
 
 import Technique.Language
 import Technique.Quantity
-import Technique.Formatter ()
+import Technique.Formatter
 
-{-
-    roast_turkey i : Ingredients -> Turkey
-    {
-        @chef
-        {
-            preheat = oven (180 °C)
-            task "Bacon strips onto bird"
-            preheat
-
-            task "Put bird into oven"
-
-            t = timer (3 h)
-            t
-
-            temp = record "Probe bird temperature"
-            [
-                "Final temperature" ~ temp
-            ]
-        }
--}
-
-exampleProcedureOven :: Procedure
-exampleProcedureOven =
-    Procedure
-        { procedureName = "oven"
-        , procedureParams = []
-        , procedureInput = Type "Temperature"
-        , procedureOutput = Type "()" -- ?
-        , procedureLabel = Just (Markdown "Set oven temperature")
-        , procedureDescription = Nothing
-        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
-        }
-
-
--- TODO these two are actual builin standard library procedures, so a
--- future change to this test case will involve doing a lookup of these
--- names in some environment or context.
-
-builtinProcedureTask :: Procedure
-builtinProcedureTask =
-    Procedure
-        { procedureName = "task"
-        , procedureParams = []
-        , procedureInput = Type "Text"
-        , procedureOutput = Type "()" -- ?
-        , procedureLabel = Just (Markdown "A task")
-        , procedureDescription = Nothing
-        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
-        }
-
-builtinProcedureRecord :: Procedure
-builtinProcedureRecord =
-    Procedure
-        { procedureName = "record"
-        , procedureParams = []
-        , procedureInput = Type "Text"
-        , procedureOutput = Type "Text" -- ?
-        , procedureLabel = Just (Markdown "Record")
-        , procedureDescription = Just (Markdown "Record a quantity")
-        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
-        }
-
-
-exampleRoastTurkey :: Procedure
-exampleRoastTurkey =
-  let
-    i = Type { typeName = "Ingredients" }
-    o = Type { typeName = "Turkey" }
-    celsius = fromJust (lookupKeyValue "°C" units)
-    block = Block
-                [ Assignment
-                    (Name "preheat")
-                    (Application
-                        exampleProcedureOven
-                        (Grouping (Literal (Quantity 180 celsius))))
-                , Execute
-                    (Application
-                        builtinProcedureTask
-                        (Literal (Text "Bacon strips onto bird")))
-                , Execute
-                    (Variable (Name "preheat"))
-                , Execute
-                    (Literal None)
-                , Blank
-                , Execute
-                    (Operation (Operator "&")
-                        (Variable (Name "w1"))
-                        (Grouping (Operation (Operator "|")
-                            (Variable (Name "w2"))
-                            (Variable (Name "w3")))))
-                , Blank
-                , Assignment
-                    (Name "temp")
-                    (Application
-                        builtinProcedureRecord
-                        (Literal (Text "Probe bird temperature")))
-                , Execute
-                    (Table
-                        (Tablet
-                            [ Binding "Final temperature" (Variable (Name "temp")) ]))
-                ]
-  in
-    Procedure
-        { procedureName = "roast_turkey"
-        , procedureParams = [Name "i"]
-        , procedureInput = i
-        , procedureOutput = o
-        , procedureLabel = Just (Markdown "Roast Turkey")
-        , procedureDescription = Nothing
-        , procedureBlock = block
-        }
-
+import ExampleProcedure hiding (main)
 
 {-|
 These are less tests than a body of code that exercises construction of
@@ -146,8 +29,3 @@ checkAbstractSyntax = do
         it "Procedure's function name is correct" $ do
             procedureName exampleRoastTurkey `shouldBe` "roast_turkey"
 
-main :: IO ()
-main = execute $ do
-    setVerbosityLevel Event
-    writeR exampleRoastTurkey
---  writeS (pretty exampleRoastTurkey)

--- a/tests/CheckAbstractSyntax.hs
+++ b/tests/CheckAbstractSyntax.hs
@@ -29,3 +29,8 @@ checkAbstractSyntax = do
         it "Procedure's function name is correct" $ do
             procedureName exampleRoastTurkey `shouldBe` "roast_turkey"
 
+    describe "Rendering of abstract syntax tree to Technique language" $ do
+        it "renders a list as tuple" $ do
+            show (commaCat [Name "one", Name "two", Name "three"])
+                `shouldBe` "one,two,three"
+

--- a/tests/CheckAbstractSyntax.hs
+++ b/tests/CheckAbstractSyntax.hs
@@ -6,8 +6,11 @@ module CheckAbstractSyntax
     )
 where
 
+import Core.Data.Structures
 import Core.Text.Rope ()
-import Core.Text.Utilities ()
+import Core.Text.Utilities
+import Data.Maybe (fromJust)
+import Data.Text.Prettyprint.Doc (line)
 import Test.Hspec
 
 import Technique.Language
@@ -15,6 +18,14 @@ import Technique.Quantity
 import Technique.Formatter
 
 import ExampleProcedure hiding (main)
+
+{-|
+When we set the expectation using a [quote| ... |] here doc we get a
+trailing newline that is not present in the rendered AST element. So
+administratively add one here.
+-}
+renderTest :: Render a => a -> String
+renderTest x = show (intoDocA x <> line)
 
 {-|
 These are less tests than a body of code that exercises construction of
@@ -33,4 +44,19 @@ checkAbstractSyntax = do
         it "renders a list as tuple" $ do
             show (commaCat [Name "one", Name "two", Name "three"])
                 `shouldBe` "one,two,three"
+
+        it "renders a tablet as expected" $
+          let
+            hours = fromJust (lookupKeyValue "hr" units)
+            tablet = Tablet
+                        [ Binding "Final temperature" (Variable (Name "temp"))
+                        , Binding "Cooking time" (Grouping (Literal (Quantity 3 hours)))
+                        ]
+          in do
+            renderTest tablet `shouldBe` [quote|
+[
+    "Final temperature" ~ temp
+    "Cooking time" ~ (3 hr)
+]
+|]
 

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -40,7 +40,7 @@ exampleProcedureOven =
     Procedure
         { procedureName = "oven"
         , procedureParams = []
-        , procedureInput = Type "Temperature"
+        , procedureInput = [Type "Temperature"]
         , procedureOutput = Type "()" -- ?
         , procedureLabel = Just (Markdown "Set oven temperature")
         , procedureDescription = Nothing
@@ -57,7 +57,7 @@ builtinProcedureTask =
     Procedure
         { procedureName = "task"
         , procedureParams = []
-        , procedureInput = Type "Text"
+        , procedureInput = [Type "Text"]
         , procedureOutput = Type "()" -- ?
         , procedureLabel = Just (Markdown "A task")
         , procedureDescription = Nothing
@@ -69,7 +69,7 @@ builtinProcedureRecord =
     Procedure
         { procedureName = "record"
         , procedureParams = []
-        , procedureInput = Type "Text"
+        , procedureInput = [Type "Text"]
         , procedureOutput = Type "Text" -- ?
         , procedureLabel = Just (Markdown "Record")
         , procedureDescription = Just (Markdown "Record a quantity")
@@ -119,7 +119,7 @@ exampleRoastTurkey =
     Procedure
         { procedureName = "roast_turkey"
         , procedureParams = [Name "i", Name "j", Name "k"]
-        , procedureInput = i
+        , procedureInput = [i]
         , procedureOutput = o
         , procedureLabel = Just (Markdown "Roast Turkey")
         , procedureDescription = Nothing

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module ExampleProcedure where
+
+import Core.Data.Structures
+import Core.Text.Rope ()
+import Core.Text.Utilities ()
+import Core.Program.Execute hiding (None)
+import Core.Program.Logging
+import Data.Maybe (fromJust)
+
+import Technique.Language
+import Technique.Quantity
+import Technique.Formatter () -- Render instances for main function
+
+{-
+    roast_turkey i : Ingredients -> Turkey
+    {
+        @chef
+        {
+            preheat = oven (180 °C)
+            task "Bacon strips onto bird"
+            preheat
+
+            task "Put bird into oven"
+
+            t = timer (3 h)
+            t
+
+            temp = record "Probe bird temperature"
+            [
+                "Final temperature" ~ temp
+            ]
+        }
+-}
+
+exampleProcedureOven :: Procedure
+exampleProcedureOven =
+    Procedure
+        { procedureName = "oven"
+        , procedureParams = []
+        , procedureInput = Type "Temperature"
+        , procedureOutput = Type "()" -- ?
+        , procedureLabel = Just (Markdown "Set oven temperature")
+        , procedureDescription = Nothing
+        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
+        }
+
+
+-- TODO these two are actual builin standard library procedures, so a
+-- future change to this test case will involve doing a lookup of these
+-- names in some environment or context.
+
+builtinProcedureTask :: Procedure
+builtinProcedureTask =
+    Procedure
+        { procedureName = "task"
+        , procedureParams = []
+        , procedureInput = Type "Text"
+        , procedureOutput = Type "()" -- ?
+        , procedureLabel = Just (Markdown "A task")
+        , procedureDescription = Nothing
+        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
+        }
+
+builtinProcedureRecord :: Procedure
+builtinProcedureRecord =
+    Procedure
+        { procedureName = "record"
+        , procedureParams = []
+        , procedureInput = Type "Text"
+        , procedureOutput = Type "Text" -- ?
+        , procedureLabel = Just (Markdown "Record")
+        , procedureDescription = Just (Markdown "Record a quantity")
+        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
+        }
+
+
+exampleRoastTurkey :: Procedure
+exampleRoastTurkey =
+  let
+    i = Type { typeName = "Ingredients" }
+    o = Type { typeName = "Turkey" }
+    celsius = fromJust (lookupKeyValue "°C" units)
+    block = Block
+                [ Assignment
+                    (Name "preheat")
+                    (Application
+                        exampleProcedureOven
+                        (Grouping (Literal (Quantity 180 celsius))))
+                , Execute
+                    (Application
+                        builtinProcedureTask
+                        (Literal (Text "Bacon strips onto bird")))
+                , Execute
+                    (Variable (Name "preheat"))
+                , Execute
+                    (Literal None)
+                , Blank
+                , Execute
+                    (Operation (Operator "&")
+                        (Variable (Name "w1"))
+                        (Grouping (Operation (Operator "|")
+                            (Variable (Name "w2"))
+                            (Variable (Name "w3")))))
+                , Blank
+                , Assignment
+                    (Name "temp")
+                    (Application
+                        builtinProcedureRecord
+                        (Literal (Text "Probe bird temperature")))
+                , Execute
+                    (Table
+                        (Tablet
+                            [ Binding "Final temperature" (Variable (Name "temp")) ]))
+                ]
+  in
+    Procedure
+        { procedureName = "roast_turkey"
+        , procedureParams = [Name "i", Name "j", Name "k"]
+        , procedureInput = i
+        , procedureOutput = o
+        , procedureLabel = Just (Markdown "Roast Turkey")
+        , procedureDescription = Nothing
+        , procedureBlock = block
+        }
+
+main :: IO ()
+main = execute $ do
+    writeR exampleRoastTurkey

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -83,37 +83,40 @@ exampleRoastTurkey =
     i = Type { typeName = "Ingredients" }
     o = Type { typeName = "Turkey" }
     celsius = fromJust (lookupKeyValue "°C" units)
+    chef = Role "chef"
     block = Block
-                [ Assignment
-                    (Name "preheat")
-                    (Application
-                        exampleProcedureOven
-                        (Grouping (Literal (Quantity 180 celsius))))
-                , Execute
-                    (Application
-                        builtinProcedureTask
-                        (Literal (Text "Bacon strips onto bird")))
-                , Execute
-                    (Variable (Name "preheat"))
-                , Execute
-                    (Literal None)
-                , Blank
-                , Execute
-                    (Operation (Operator "&")
-                        (Variable (Name "w1"))
-                        (Grouping (Operation (Operator "|")
-                            (Variable (Name "w2"))
-                            (Variable (Name "w3")))))
-                , Blank
-                , Assignment
-                    (Name "temp")
-                    (Application
-                        builtinProcedureRecord
-                        (Literal (Text "Probe bird temperature")))
-                , Execute
-                    (Table
-                        (Tablet
-                            [ Binding "Final temperature" (Variable (Name "temp")) ]))
+                [ Attribute chef (Block
+                    [ Assignment
+                        (Name "preheat")
+                        (Application
+                            exampleProcedureOven
+                            (Grouping (Literal (Quantity 180 celsius))))
+                    , Execute
+                        (Application
+                            builtinProcedureTask
+                            (Literal (Text "Bacon strips onto bird")))
+                    , Execute
+                        (Variable (Name "preheat"))
+                    , Execute
+                        (Literal None)
+                    , Blank
+                    , Execute
+                        (Operation (Operator "&")
+                            (Variable (Name "w1"))
+                            (Grouping (Operation (Operator "|")
+                                (Variable (Name "w2"))
+                                (Variable (Name "w3")))))
+                    , Blank
+                    , Assignment
+                        (Name "temp")
+                        (Application
+                            builtinProcedureRecord
+                            (Literal (Text "Probe bird temperature")))
+                    , Execute
+                        (Table
+                            (Tablet
+                                [ Binding "Final temperature" (Variable (Name "temp")) ]))
+                    ])
                 ]
   in
     Procedure


### PR DESCRIPTION
Reorganize test suite so that _tests/CheckAbstractSyntax.hs_ only has actual unit tests and _tests/ExampleProcedure.hs_ has the sample instance of the AST for experimenting with.