### PR TITLE
Parse Blocks of Statements

### DIFF
--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -153,6 +153,8 @@ instance Render Quantity where
     colourize = colourizeTechnique
     intoDocA qty = case qty of
         None ->
+            annotate SymbolToken ("()")
+        Undefined ->
             annotate ErrorToken "?"
         Number i ->
             annotate QuantityToken (pretty i)

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -177,12 +177,19 @@ pQuantity = do
 
 pExpression :: Parser Expression
 pExpression =
-    try pGrouping
-    <|> try pApplication
-    <|> try pLiteral
-    <|> try pVariable
-    <|> pNone
+    try pNone <|>
+    try pUndefined <|>
+    try pGrouping <|>
+    try pApplication <|>
+    try pLiteral <|>
+    try pVariable
   where
+    pNone = do
+        void (string "()")
+        return (Literal None)
+    pUndefined = do
+        void (char '?')
+        return (Literal Undefined)
     pGrouping = do
         between (char '(') (char ')') $ do
             subexpr <- pExpression
@@ -200,9 +207,6 @@ pExpression =
     pVariable = do
         name <- pIdentifier
         return (Variable name)
-    pNone = do
-        hidden eof              -- FIXME get rid of this
-        return (Literal None)   -- this is almost certainly bad. None should be Unit "()"
 
 pStatement :: Parser Statement
 pStatement =

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -239,10 +239,18 @@ pStatement =
 
 pBlock :: Parser Block
 pBlock = do
-    statements <- between
-        (char '{' <* skipSpace)
-        (skipSpace *> char '}')
-        (some (skipSpace *> pStatement <* newline))
+    statements <-
+        -- handle bare cases first
+        try (do
+            void (string "{}")
+            return []) <|>
+        between
+            (char '{')
+            (char '}')
+            (sepBy
+                (skipSpace *> pStatement <* skipSpace)
+                (newline <|> char ';'))
+
     return (Block statements)
 
 pProcedureFunction :: Parser Procedure

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -38,13 +38,13 @@ Skip /zero/ or more actual space characters. The __megaparsec__ function
 which is very unhelpful.
 -}
 skipSpace :: Parser ()
-skipSpace = void (many (char ' '))
+skipSpace = void (hidden (many (char ' ')))
 
 {-|
 Skip at least /one/ actual space character.
 -}
 skipSpace1 :: Parser ()
-skipSpace1 = void (some (char ' '))
+skipSpace1 = void (hidden (some (char ' ')))
 
 pMagicLine :: Parser Int
 pMagicLine = do
@@ -110,7 +110,7 @@ pProcedureDeclaration = do
     return (name,params,ins,out)
 
 identifierChar :: Parser Char
-identifierChar = lowerChar <|> digitChar <|> char '_'
+identifierChar = hidden (lowerChar <|> digitChar <|> char '_')
 
 pIdentifier :: Parser Identifier
 pIdentifier = label "a valid identifier" $ do
@@ -119,10 +119,10 @@ pIdentifier = label "a valid identifier" $ do
     return (Identifier (singletonRope first <> intoRope remainder))
 
 typeChar :: Parser Char
-typeChar = upperChar <|> lowerChar <|> digitChar
+typeChar = hidden (upperChar <|> lowerChar <|> digitChar)
 
 pType :: Parser Type
-pType = do
+pType = label "a valid type" $ do
     first <- upperChar
     remainder <- many typeChar
     return (Type (singletonRope first <> intoRope remainder))

--- a/lib/Technique/Quantity.hs
+++ b/lib/Technique/Quantity.hs
@@ -19,6 +19,7 @@ data Quantity
     | Number Int                -- FIXME not Int
     | Quantity Int Unit
     | Text Rope
+    | Undefined
     deriving (Show, Eq)
 
 type Symbol = Rope

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -123,31 +123,43 @@ checkSkeletonParser = do
                 `shouldBe` Just (Assignment (Identifier "answer") (Literal (Number 42)))
 
     describe "Parses blocks of statements" $ do
-        it "an empty block is a []" $ do
+        it "an empty block is a [] (special case)" $ do
             parseMaybe pBlock "{}" `shouldBe` Just (Block [])
 
         it "a block with a newline (only) is []" $ do
-            parseMaybe pBlock "{\n}" `shouldBe` Just (Block [])
+            parseMaybe pBlock "{\n}" `shouldBe` Just (Block [Blank, Blank])
 
-        it "a block with single statement terminated by a newline" $ do
+        it "a block with single statement surrounded by a newlines" $ do
             parseMaybe pBlock "{\nx\n}"
-                `shouldBe` Just (Block [Execute (Variable (Identifier "x"))])
+                `shouldBe` Just (Block
+                    [ Blank
+                    , Execute (Variable (Identifier "x"))
+                    , Blank
+                    ])
             parseMaybe pBlock "{\nanswer = 42\n}"
-                `shouldBe` Just (Block [Assignment (Identifier "answer") (Literal (Number 42))])
+                `shouldBe` Just (Block
+                    [ Blank
+                    , Assignment (Identifier "answer") (Literal (Number 42))
+                    , Blank
+                    ])
 
         it "a block with a blank line contains a Blank" $ do
             parseMaybe pBlock "{\nx1\n\nx2\n}"
                 `shouldBe` Just (Block
-                    [ Execute (Variable (Identifier "x1"))
+                    [ Blank
+                    , Execute (Variable (Identifier "x1"))
                     , Blank
                     , Execute (Variable (Identifier "x2"))
+                    , Blank
                     ])
 
-        it "a block with multiple statements terminated by newlines" $ do
+        it "a block with multiple statements separated by newlines" $ do
             parseMaybe pBlock "{\nx\nanswer = 42\n}"
                 `shouldBe` Just (Block
-                    [ Execute (Variable (Identifier "x"))
+                    [ Blank
+                    , Execute (Variable (Identifier "x"))
                     , Assignment (Identifier "answer") (Literal (Number 42))
+                    , Blank
                     ])
 
         it "a block with multiple statements separated by semicolons" $ do

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -92,8 +92,11 @@ checkSkeletonParser = do
             parseMaybe numberLiteral "1a" `shouldBe` Nothing
 
     describe "Parses expressions" $ do
-        it "an empty input is None" $ do
-            parseMaybe pExpression "" `shouldBe` Just (Literal None)
+        it "an empty input an error" $ do
+            parseMaybe pExpression "" `shouldBe` Nothing
+
+        it "an pair of parentheses is None" $ do
+            parseMaybe pExpression "()" `shouldBe` Just (Literal None)
 
         it "a bare identifier is a Variable" $ do
             parseMaybe pExpression "x" `shouldBe` Just (Variable (Identifier "x"))

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -149,3 +149,10 @@ checkSkeletonParser = do
                     [ Execute (Variable (Identifier "x"))
                     , Assignment (Identifier "answer") (Literal (Number 42))
                     ])
+
+        it "a block with multiple statements separated by semicolons" $ do
+            parseMaybe pBlock "{x ; answer = 42}"
+                `shouldBe` Just (Block
+                    [ Execute (Variable (Identifier "x"))
+                    , Assignment (Identifier "answer") (Literal (Number 42))
+                    ])

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -104,13 +104,23 @@ checkSkeletonParser = do
         it "a bare number is a Literal Number" $ do
             parseMaybe pExpression "42" `shouldBe` Just (Literal (Number 42))
 
-    describe "Parses statements and expressions" $ do
+    describe "Parses statements containing expressions" $ do
         it "a blank line is a Blank" $ do
-            parseMaybe pStatement "\n" `shouldBe` Just Blank
+            parseMaybe pStatement "" `shouldBe` Just Blank
 
         it "considers a single identifier an Execute" $ do
-            parseMaybe pStatement "x\n"
+            parseMaybe pStatement "x"
                 `shouldBe` Just (Execute (Variable (Identifier "x")))
-            parseMaybe pStatement "answer = 42\n"
+            parseMaybe pStatement "answer = 42"
                 `shouldBe` Just (Assignment (Identifier "answer") (Literal (Number 42)))
 
+
+    describe "Parses blocks of statements" $ do
+        it "a blank line is a Blank" $ do
+            parseMaybe pStatement "" `shouldBe` Just Blank
+
+        it "considers a single identifier an Execute" $ do
+            parseMaybe pStatement "x"
+                `shouldBe` Just (Execute (Variable (Identifier "x")))
+            parseMaybe pStatement "answer = 42"
+                `shouldBe` Just (Assignment (Identifier "answer") (Literal (Number 42)))

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -98,7 +98,7 @@ exampleRoastTurkey =
                     , Execute
                         (Variable (Identifier "preheat"))
                     , Execute
-                        (Literal None)
+                        (Literal Undefined)
                     , Blank
                     , Execute
                         (Operation (Operator "&")


### PR DESCRIPTION
Implement parsing of Blocks, currently as a list of Statements. Much complexity arises from our desire to quietly support semicolon as an optional statement separator. At present those wouldn't be preserved on output but we can correct that with a better intermediate type between Block and Statement.