### PR TITLE
Add support for series of statements

### DIFF
--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -113,7 +113,6 @@ instance Render Statement where
             intoDocA role <>
             line <>
             intoDocA block        -- TODO some nesting?
-        Blank -> emptyDoc
 
 instance Render Role where
     type Token Role = TechniqueToken

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -89,13 +89,15 @@ instance Render Block where
     intoDocA (Block statements) =
         nest 4 (
             annotate SymbolToken lbrace <>
-            foldl' f emptyDoc statements
+            go statements
         ) <>
         line <>
         annotate SymbolToken rbrace
       where
-        f :: Doc TechniqueToken -> Statement -> Doc TechniqueToken
-        f built statement = built <> line <> intoDocA statement
+        go :: [Statement] -> Doc TechniqueToken
+        go [] = emptyDoc
+        go (Series:x1:xs) = intoDocA Series <> intoDocA x1 <> go xs
+        go (x:xs) = line <> intoDocA x <> go xs
 
 instance Render Statement where
     type Token Statement = TechniqueToken
@@ -113,6 +115,10 @@ instance Render Statement where
             intoDocA role <>
             line <>
             intoDocA block        -- TODO some nesting?
+        Blank ->
+            emptyDoc
+        Series ->
+            annotate SymbolToken " ; "
 
 instance Render Role where
     type Token Role = TechniqueToken

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -49,10 +49,17 @@ data Procedure = Procedure
 data Block = Block [Flow Statement]
     deriving (Show, Eq)
 
-data Flow a
-    = Newline a
-    | Separator Char a
-    | Edge a
+{-|
+A "flow" is a line in Statements, or a binding in a Tablet, the distinction
+being the separator used.
+-}
+data Flow a = Flow a Ending
+    deriving (Show, Eq)
+
+data Ending
+    = Newline
+    | Separator Char
+    | Edge
     deriving (Show, Eq)
 
 data Statement

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -46,20 +46,7 @@ data Procedure = Procedure
     }
     deriving (Show, Eq)
 
-data Block = Block [Flow Statement]
-    deriving (Show, Eq)
-
-{-|
-A "flow" is a line in Statements, or a binding in a Tablet, the distinction
-being the separator used.
--}
-data Flow a = Flow a Ending
-    deriving (Show, Eq)
-
-data Ending
-    = Newline
-    | Separator Char
-    | Edge
+data Block = Block [Statement]
     deriving (Show, Eq)
 
 data Statement
@@ -69,6 +56,7 @@ data Statement
     | Declaration Procedure
     | Attribute Role Block     -- Role, Location, and ...?
     | Blank
+    | Horizontal [Statement]
     deriving (Show, Eq)
 
 data Expression

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -56,7 +56,7 @@ data Statement
     | Declaration Procedure
     | Attribute Role Block     -- Role, Location, and ...?
     | Blank
-    | Horizontal [Statement]
+    | Series
     deriving (Show, Eq)
 
 data Expression

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -46,7 +46,13 @@ data Procedure = Procedure
     }
     deriving (Show, Eq)
 
-data Block = Block [Statement]
+data Block = Block [Flow Statement]
+    deriving (Show, Eq)
+
+data Flow a
+    = Newline a
+    | Separator Char a
+    | Edge a
     deriving (Show, Eq)
 
 data Statement

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -244,14 +244,14 @@ pStatement =
 -- { z\n }          Newline z
 -- {\n    z\n}      Newline Blank, Newline z
 
-pFlow :: Show a => Parser a -> Char -> Parser (Flow a)
+pFlow :: Parser a -> Char -> Parser (Flow a)
 pFlow parser separator = do
     void skipSpace
     result <- parser
     void skipSpace
-    (newline *> return (Newline result))
-        <|> (char separator *> return (Separator separator result))
-        <|> (char '}' *> return (Edge result))
+    (newline *> return (Flow result Newline))
+        <|> (char separator *> return (Flow result (Separator separator)))
+        <|> (char '}' *> return (Flow result Edge))
 
 pBlock :: Parser Block
 pBlock = do

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -232,18 +232,20 @@ pStatement =
         expr <- pExpression
         return (Execute expr)
 
-    pBlank = label "a blank line" $ do
+    pBlank = hidden $ do -- label "a blank line"
+        void newline
         return Blank
-
 
 ---------------------------------------------------------------------
 
 pBlock :: Parser Block
 pBlock = do
-    statements <- between
-        (char '{' *> skipSpace *> try newline)
-        (skipSpace <* char '}')
-        (many (skipSpace *> pStatement <* skipSpace <* try newline))
+    void (char '{' <* skipSpace <* optional newline)
+
+    statements <- many
+         (skipSpace *> pStatement <* skipSpace <* optional newline)
+
+    void (skipSpace *> char '}')
 
     return (Block statements)
 

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -213,7 +213,8 @@ pStatement =
     try pAssignment <|>
     try pDeclaration <|>
     try pExecute <|>
-    try pBlank
+    try pBlank <|>
+    try pSeries
   where
     pAssignment = label "an assignment" $ do
         name <- pIdentifier
@@ -235,6 +236,12 @@ pStatement =
     pBlank = hidden $ do -- label "a blank line"
         void newline
         return Blank
+
+    pSeries = do
+        skipSpace
+        void (char ';')
+        skipSpace
+        return Series
 
 ---------------------------------------------------------------------
 

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -238,26 +238,14 @@ pStatement =
 
 ---------------------------------------------------------------------
 
--- trailing
--- { x }            Edge x
--- { ; y }          Separator Blank ; Edge y
--- { z\n }          Newline z
--- {\n    z\n}      Newline Blank, Newline z
-
-pFlow :: Parser a -> Char -> Parser (Flow a)
-pFlow parser separator = do
-    void skipSpace
-    result <- parser
-    void skipSpace
-    (newline *> return (Flow result Newline))
-        <|> (char separator *> return (Flow result (Separator separator)))
-        <|> (char '}' *> return (Flow result Edge))
-
 pBlock :: Parser Block
 pBlock = do
-    void (char '{')
-    flows <- many (pFlow pStatement ';')
-    return (Block flows)
+    statements <- between
+        (char '{' *> skipSpace *> try newline)
+        (skipSpace <* char '}')
+        (many (skipSpace *> pStatement <* skipSpace <* try newline))
+
+    return (Block statements)
 
 pProcedureFunction :: Parser Procedure
 pProcedureFunction = do

--- a/tests/CheckAbstractSyntax.hs
+++ b/tests/CheckAbstractSyntax.hs
@@ -60,3 +60,15 @@ checkAbstractSyntax = do
 ]
 |]
 
+    describe "Rendering of a Block" $ do
+        it "renders a normal block with indentation" $
+          let
+            b = Block
+                [ Execute (Variable (Identifier "x"))
+                ]
+          in do
+            renderTest b `shouldBe` [quote|
+{
+    x
+}
+|]

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -112,7 +112,7 @@ checkSkeletonParser = do
 
     describe "Parses statements containing expressions" $ do
         it "a blank line is a Blank" $ do
-            parseMaybe pStatement "" `shouldBe` Just Blank
+            parseMaybe pStatement "\n" `shouldBe` Just Blank
 
         it "considers a single identifier an Execute" $ do
             parseMaybe pStatement "x"
@@ -127,39 +127,31 @@ checkSkeletonParser = do
             parseMaybe pBlock "{}" `shouldBe` Just (Block [])
 
         it "a block with a newline (only) is []" $ do
-            parseMaybe pBlock "{\n}" `shouldBe` Just (Block [Blank, Blank])
+            parseMaybe pBlock "{\n}" `shouldBe` Just (Block [])
 
         it "a block with single statement surrounded by a newlines" $ do
             parseMaybe pBlock "{\nx\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Execute (Variable (Identifier "x"))
-                    , Blank
+                    [ Execute (Variable (Identifier "x"))
                     ])
             parseMaybe pBlock "{\nanswer = 42\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Assignment (Identifier "answer") (Literal (Number 42))
-                    , Blank
+                    [ Assignment (Identifier "answer") (Literal (Number 42))
                     ])
 
         it "a block with a blank line contains a Blank" $ do
             parseMaybe pBlock "{\nx1\n\nx2\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Execute (Variable (Identifier "x1"))
+                    [ Execute (Variable (Identifier "x1"))
                     , Blank
                     , Execute (Variable (Identifier "x2"))
-                    , Blank
                     ])
 
         it "a block with multiple statements separated by newlines" $ do
             parseMaybe pBlock "{\nx\nanswer = 42\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Execute (Variable (Identifier "x"))
+                    [ Execute (Variable (Identifier "x"))
                     , Assignment (Identifier "answer") (Literal (Number 42))
-                    , Blank
                     ])
 
         it "a block with multiple statements separated by semicolons" $ do
@@ -168,3 +160,4 @@ checkSkeletonParser = do
                     [ Execute (Variable (Identifier "x"))
                     , Assignment (Identifier "answer") (Literal (Number 42))
                     ])
+

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -158,6 +158,7 @@ checkSkeletonParser = do
             parseMaybe pBlock "{x ; answer = 42}"
                 `shouldBe` Just (Block
                     [ Execute (Variable (Identifier "x"))
+                    , Series
                     , Assignment (Identifier "answer") (Literal (Number 42))
                     ])
 

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -124,47 +124,51 @@ checkSkeletonParser = do
 
     describe "Parses blocks of statements" $ do
         it "an empty block is a [] (special case)" $ do
-            parseMaybe pBlock "{}" `shouldBe` Just (Block [])
+            parseMaybe pBlock "{}" `shouldBe` Just (Block [Flow Blank Edge])
 
-        it "a block with a newline (only) is []" $ do
-            parseMaybe pBlock "{\n}" `shouldBe` Just (Block [Blank, Blank])
+        it "a block with a newline (only) is []" $ do -- FIXME
+            parseMaybe pBlock "{\n}"
+                `shouldBe` Just (Block
+                    [ Flow Blank Newline
+                    , Flow Blank Edge
+                    ])
 
         it "a block with single statement surrounded by a newlines" $ do
             parseMaybe pBlock "{\nx\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Execute (Variable (Identifier "x"))
-                    , Blank
+                    [ Flow Blank Newline
+                    , Flow (Execute (Variable (Identifier "x"))) Newline
+                    , Flow Blank Edge
                     ])
             parseMaybe pBlock "{\nanswer = 42\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Assignment (Identifier "answer") (Literal (Number 42))
-                    , Blank
+                    [ Flow Blank Newline
+                    , Flow (Assignment (Identifier "answer") (Literal (Number 42))) Newline
+                    , Flow Blank Edge
                     ])
 
         it "a block with a blank line contains a Blank" $ do
             parseMaybe pBlock "{\nx1\n\nx2\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Execute (Variable (Identifier "x1"))
-                    , Blank
-                    , Execute (Variable (Identifier "x2"))
-                    , Blank
+                    [ Flow Blank Newline
+                    , Flow (Execute (Variable (Identifier "x1"))) Newline
+                    , Flow Blank Newline
+                    , Flow (Execute (Variable (Identifier "x2"))) Newline
+                    , Flow Blank Edge
                     ])
 
         it "a block with multiple statements separated by newlines" $ do
             parseMaybe pBlock "{\nx\nanswer = 42\n}"
                 `shouldBe` Just (Block
-                    [ Blank
-                    , Execute (Variable (Identifier "x"))
-                    , Assignment (Identifier "answer") (Literal (Number 42))
-                    , Blank
+                    [ Flow Blank Newline
+                    , Flow (Execute (Variable (Identifier "x"))) Newline
+                    , Flow (Assignment (Identifier "answer") (Literal (Number 42))) Newline
+                    , Flow Blank Edge
                     ])
 
         it "a block with multiple statements separated by semicolons" $ do
             parseMaybe pBlock "{x ; answer = 42}"
                 `shouldBe` Just (Block
-                    [ Execute (Variable (Identifier "x"))
-                    , Assignment (Identifier "answer") (Literal (Number 42))
+                    [ Flow (Execute (Variable (Identifier "x"))) (Separator ';')
+                    , Flow (Assignment (Identifier "answer") (Literal (Number 42))) Edge
                     ])

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -124,51 +124,47 @@ checkSkeletonParser = do
 
     describe "Parses blocks of statements" $ do
         it "an empty block is a [] (special case)" $ do
-            parseMaybe pBlock "{}" `shouldBe` Just (Block [Flow Blank Edge])
+            parseMaybe pBlock "{}" `shouldBe` Just (Block [])
 
-        it "a block with a newline (only) is []" $ do -- FIXME
-            parseMaybe pBlock "{\n}"
-                `shouldBe` Just (Block
-                    [ Flow Blank Newline
-                    , Flow Blank Edge
-                    ])
+        it "a block with a newline (only) is []" $ do
+            parseMaybe pBlock "{\n}" `shouldBe` Just (Block [Blank, Blank])
 
         it "a block with single statement surrounded by a newlines" $ do
             parseMaybe pBlock "{\nx\n}"
                 `shouldBe` Just (Block
-                    [ Flow Blank Newline
-                    , Flow (Execute (Variable (Identifier "x"))) Newline
-                    , Flow Blank Edge
+                    [ Blank
+                    , Execute (Variable (Identifier "x"))
+                    , Blank
                     ])
             parseMaybe pBlock "{\nanswer = 42\n}"
                 `shouldBe` Just (Block
-                    [ Flow Blank Newline
-                    , Flow (Assignment (Identifier "answer") (Literal (Number 42))) Newline
-                    , Flow Blank Edge
+                    [ Blank
+                    , Assignment (Identifier "answer") (Literal (Number 42))
+                    , Blank
                     ])
 
         it "a block with a blank line contains a Blank" $ do
             parseMaybe pBlock "{\nx1\n\nx2\n}"
                 `shouldBe` Just (Block
-                    [ Flow Blank Newline
-                    , Flow (Execute (Variable (Identifier "x1"))) Newline
-                    , Flow Blank Newline
-                    , Flow (Execute (Variable (Identifier "x2"))) Newline
-                    , Flow Blank Edge
+                    [ Blank
+                    , Execute (Variable (Identifier "x1"))
+                    , Blank
+                    , Execute (Variable (Identifier "x2"))
+                    , Blank
                     ])
 
         it "a block with multiple statements separated by newlines" $ do
             parseMaybe pBlock "{\nx\nanswer = 42\n}"
                 `shouldBe` Just (Block
-                    [ Flow Blank Newline
-                    , Flow (Execute (Variable (Identifier "x"))) Newline
-                    , Flow (Assignment (Identifier "answer") (Literal (Number 42))) Newline
-                    , Flow Blank Edge
+                    [ Blank
+                    , Execute (Variable (Identifier "x"))
+                    , Assignment (Identifier "answer") (Literal (Number 42))
+                    , Blank
                     ])
 
         it "a block with multiple statements separated by semicolons" $ do
             parseMaybe pBlock "{x ; answer = 42}"
                 `shouldBe` Just (Block
-                    [ Flow (Execute (Variable (Identifier "x"))) (Separator ';')
-                    , Flow (Assignment (Identifier "answer") (Literal (Number 42))) Edge
+                    [ Execute (Variable (Identifier "x"))
+                    , Assignment (Identifier "answer") (Literal (Number 42))
                     ])

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -44,8 +44,7 @@ exampleProcedureOven =
         , procedureOutput = Type "()" -- ?
         , procedureLabel = Just (Markdown "Set oven temperature")
         , procedureDescription = Nothing
-        , procedureBlock = Block
-            [ Flow (Execute (Literal (Text "builtinProcedure!"))) Edge ]
+        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
         }
 
 
@@ -62,7 +61,7 @@ builtinProcedureTask =
         , procedureOutput = Type "()" -- ?
         , procedureLabel = Just (Markdown "A task")
         , procedureDescription = Nothing
-        , procedureBlock = Block [ Flow (Execute (Literal (Text "builtinProcedure!"))) Edge ]
+        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
         }
 
 builtinProcedureRecord :: Procedure
@@ -74,7 +73,7 @@ builtinProcedureRecord =
         , procedureOutput = Type "Text" -- ?
         , procedureLabel = Just (Markdown "Record")
         , procedureDescription = Just (Markdown "Record a quantity")
-        , procedureBlock = Block [ Flow (Execute (Literal (Text "builtinProcedure!"))) Edge ]
+        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
         }
 
 
@@ -86,39 +85,38 @@ exampleRoastTurkey =
     celsius = fromJust (lookupKeyValue "°C" units)
     chef = Role "chef"
     block = Block
-                [ Flow (Attribute chef (Block
-                    [ Flow (Assignment
+                [ Attribute chef (Block
+                    [ Assignment
                         (Identifier "preheat")
                         (Application
                             (Identifier "oven")
-                            (Grouping (Literal (Quantity 180 celsius))))) Newline
-                    , Flow (Execute
+                            (Grouping (Literal (Quantity 180 celsius))))
+                    , Execute
                         (Application
                             (Identifier "task")
-                            (Literal (Text "Bacon strips onto bird")))) Newline
-                    , Flow (Execute
-                        (Variable (Identifier "preheat"))) Newline
-                    , Flow (Execute
-                        (Literal Undefined)) Newline
-                    , Flow Blank Newline
-                    , Flow (Execute
+                            (Literal (Text "Bacon strips onto bird")))
+                    , Execute
+                        (Variable (Identifier "preheat"))
+                    , Execute
+                        (Literal Undefined)
+                    , Blank
+                    , Execute
                         (Operation (Operator "&")
                             (Variable (Identifier "w1"))
                             (Grouping (Operation (Operator "|")
                                 (Variable (Identifier "w2"))
-                                (Variable (Identifier "w3")))))) Newline
-                    , Flow Blank Newline
-                    , Flow (Assignment
+                                (Variable (Identifier "w3")))))
+                    , Blank
+                    , Assignment
                         (Identifier "temp")
                         (Application
                             (Identifier "record")
-                            (Literal (Text "Probe bird temperature")))) Newline
-                    , Flow (Execute
+                            (Literal (Text "Probe bird temperature")))
+                    , Execute
                         (Table
                             (Tablet
-                                [ Binding "Final temperature" (Variable (Identifier "temp")) ]))) Newline
-                    , Flow Blank Edge
-                    ])) Newline
+                                [ Binding "Final temperature" (Variable (Identifier "temp")) ]))
+                    ])
                 ]
   in
     Procedure

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -107,6 +107,9 @@ exampleRoastTurkey =
                                 (Variable (Identifier "w2"))
                                 (Variable (Identifier "w3")))))
                     , Blank
+                    , Execute (Variable (Identifier "v1"))
+                    , Series
+                    , Execute (Variable (Identifier "v2"))
                     , Assignment
                         (Identifier "temp")
                         (Application

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -44,7 +44,8 @@ exampleProcedureOven =
         , procedureOutput = Type "()" -- ?
         , procedureLabel = Just (Markdown "Set oven temperature")
         , procedureDescription = Nothing
-        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
+        , procedureBlock = Block
+            [ Flow (Execute (Literal (Text "builtinProcedure!"))) Edge ]
         }
 
 
@@ -61,7 +62,7 @@ builtinProcedureTask =
         , procedureOutput = Type "()" -- ?
         , procedureLabel = Just (Markdown "A task")
         , procedureDescription = Nothing
-        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
+        , procedureBlock = Block [ Flow (Execute (Literal (Text "builtinProcedure!"))) Edge ]
         }
 
 builtinProcedureRecord :: Procedure
@@ -73,7 +74,7 @@ builtinProcedureRecord =
         , procedureOutput = Type "Text" -- ?
         , procedureLabel = Just (Markdown "Record")
         , procedureDescription = Just (Markdown "Record a quantity")
-        , procedureBlock = Block [ Execute (Literal (Text "builtinProcedure!")) ]
+        , procedureBlock = Block [ Flow (Execute (Literal (Text "builtinProcedure!"))) Edge ]
         }
 
 
@@ -85,38 +86,39 @@ exampleRoastTurkey =
     celsius = fromJust (lookupKeyValue "°C" units)
     chef = Role "chef"
     block = Block
-                [ Attribute chef (Block
-                    [ Assignment
+                [ Flow (Attribute chef (Block
+                    [ Flow (Assignment
                         (Identifier "preheat")
                         (Application
                             (Identifier "oven")
-                            (Grouping (Literal (Quantity 180 celsius))))
-                    , Execute
+                            (Grouping (Literal (Quantity 180 celsius))))) Newline
+                    , Flow (Execute
                         (Application
                             (Identifier "task")
-                            (Literal (Text "Bacon strips onto bird")))
-                    , Execute
-                        (Variable (Identifier "preheat"))
-                    , Execute
-                        (Literal Undefined)
-                    , Blank
-                    , Execute
+                            (Literal (Text "Bacon strips onto bird")))) Newline
+                    , Flow (Execute
+                        (Variable (Identifier "preheat"))) Newline
+                    , Flow (Execute
+                        (Literal Undefined)) Newline
+                    , Flow Blank Newline
+                    , Flow (Execute
                         (Operation (Operator "&")
                             (Variable (Identifier "w1"))
                             (Grouping (Operation (Operator "|")
                                 (Variable (Identifier "w2"))
-                                (Variable (Identifier "w3")))))
-                    , Blank
-                    , Assignment
+                                (Variable (Identifier "w3")))))) Newline
+                    , Flow Blank Newline
+                    , Flow (Assignment
                         (Identifier "temp")
                         (Application
                             (Identifier "record")
-                            (Literal (Text "Probe bird temperature")))
-                    , Execute
+                            (Literal (Text "Probe bird temperature")))) Newline
+                    , Flow (Execute
                         (Table
                             (Tablet
-                                [ Binding "Final temperature" (Variable (Identifier "temp")) ]))
-                    ])
+                                [ Binding "Final temperature" (Variable (Identifier "temp")) ]))) Newline
+                    , Flow Blank Edge
+                    ])) Newline
                 ]
   in
     Procedure


### PR DESCRIPTION
Ordinarily statements in a blocks are separated by newlines, but optionally they can be separated by a `;` character. Support this in parser and output formatter.

This patch also deals with the problem of parsing a block which happens to not have newlines after opening brace or before closing brace. While we don't want this as normal practice it is entirely reasonable to parse it as a valid block.