### PR TITLE
Support parsing operators

### DIFF
--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -201,5 +201,8 @@ instance Render Binding where
 instance Render Operator where
     type Token Operator = TechniqueToken
     colourize = colourizeTechnique
-    intoDocA (Operator symbol) =
-        annotate OperatorToken (pretty symbol)
+    intoDocA operator =
+        annotate OperatorToken $ case operator of
+            WaitBoth ->     pretty '&'
+            WaitEither ->   pretty '|'
+            Combine ->      pretty '+'

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -79,5 +79,7 @@ data Binding
     deriving (Show, Eq)
 
 data Operator
-    = Operator Rope
+    = WaitEither
+    | WaitBoth
+    | Combine
     deriving (Show, Eq)

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -191,7 +191,6 @@ pExpression = do
         Just (oper,expr2)   -> return (Operation oper expr1 expr2)
         Nothing             -> return expr1
   where
-    pTerm :: Parser Expression
     pTerm =
         try pNone <|>
         try pUndefined <|>
@@ -206,13 +205,13 @@ pExpression = do
     pUndefined = do
         void (char '?')
         return (Literal Undefined)
-    pOperation2 = do
+    pOperation2 = do                    -- 2 as in 2nd half
         operator <- pOperator
         skipSpace
         subexpr2 <- pExpression
         return (operator,subexpr2)
     pGrouping = do
-        between (char '(' <* skipSpace) (skipSpace *> char ')') $ do
+        between (char '(' <* skipSpace) (char ')') $ do
             subexpr <- pExpression
             return (Grouping subexpr)
     pApplication = do
@@ -259,7 +258,6 @@ pStatement =
         return Blank
 
     pSeries = do
-        skipSpace
         void (char ';')
         skipSpace
         return Series
@@ -268,12 +266,12 @@ pStatement =
 
 pBlock :: Parser Block
 pBlock = do
-    void (char '{' <* skipSpace <* optional newline)
+    void (char '{' <* skipSpace <* optional newline <* skipSpace)
 
     statements <- many
-         (skipSpace *> pStatement <* skipSpace <* optional newline)
+         (pStatement <* skipSpace <* optional newline <* skipSpace)
 
-    void (skipSpace *> char '}')
+    void (char '}')
 
     return (Block statements)
 

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -177,9 +177,9 @@ pQuantity = do
 
 pOperator :: Parser Operator
 pOperator =
-    try (char '&' *> return WaitBoth) <|>
-    try (char '|' *> return WaitEither) <|>
-    try (char '+' *> return Combine)
+    (char '&' *> return WaitBoth) <|>
+    (char '|' *> return WaitEither) <|>
+    (char '+' *> return Combine)
 
 pExpression :: Parser Expression
 pExpression =

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -110,6 +110,13 @@ checkSkeletonParser = do
         it "a nested expression is parsed as Grouped" $ do
             parseMaybe pExpression "(42)" `shouldBe` Just (Grouping (Literal (Number 42)))
 
+        it "an operator between two expressions is an Operation" $ do
+            parseMaybe pExpression "x & y"
+                `shouldBe` Just (Operation
+                    WaitBoth
+                    (Variable (Identifier "x"))
+                    (Variable (Identifier "y")))
+
     describe "Parses statements containing expressions" $ do
         it "a blank line is a Blank" $ do
             parseMaybe pStatement "\n" `shouldBe` Just Blank

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -169,3 +169,19 @@ checkSkeletonParser = do
                     , Assignment (Identifier "answer") (Literal (Number 42))
                     ])
 
+        it "consumes whitespace in inconvenient places" $ do
+            parseMaybe pBlock "{ \n }"
+                `shouldBe` Just (Block [])
+            parseMaybe pBlock "{ \n x \n }"
+                `shouldBe` Just (Block
+                    [ Execute (Variable (Identifier "x"))
+                    ])
+            parseMaybe pBlock "{ \n (42 )    \n}"
+                `shouldBe` Just (Block
+                    [ Execute (Grouping (Literal (Number 42)))
+                    ])
+            parseMaybe pBlock "{ answer = 42 ; }"
+                `shouldBe` Just (Block
+                    [ (Assignment (Identifier "answer") (Literal (Number 42)))
+                    , Series
+                    ])

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -101,9 +101,9 @@ exampleRoastTurkey =
                         (Literal Undefined)
                     , Blank
                     , Execute
-                        (Operation (Operator "&")
+                        (Operation WaitBoth
                             (Variable (Identifier "w1"))
-                            (Grouping (Operation (Operator "|")
+                            (Grouping (Operation WaitEither
                                 (Variable (Identifier "w2"))
                                 (Variable (Identifier "w3")))))
                     , Blank


### PR DESCRIPTION
Enhance parser to support parsing of operators. The language only has a few fixed operators: `|` and `&` for waiting, and `+` for combining tablets.