### PR TITLE
Implement front-end for parser and round-trip output formatter

### DIFF
--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -6,7 +6,7 @@
 
 module Technique.Formatter where
 
-import Core.Text.Rope ()
+import Core.Text.Rope
 import Core.Text.Utilities
 import Data.Foldable (foldl')
 import Data.Text.Prettyprint.Doc

--- a/package.yaml
+++ b/package.yaml
@@ -49,7 +49,8 @@ executables:
     ghc-options: -threaded -dynamic
     source-dirs: src
     main: TechniqueMain.hs
-    other-modules: []
+    other-modules:
+     - TechniqueUser
 
 tests:
   check:

--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,7 @@ github: oprdyn/technique
 dependencies:
  - base >= 4.11 && < 5
  - ivar-simple
- - core-data >= 0.2.0
+ - core-data >= 0.2.1
  - core-text >= 0.2.2
  - core-program >= 0.2.2
  - free
@@ -34,7 +34,6 @@ library:
    - text
   source-dirs: lib
   exposed-modules:
-   - Technique.Procedure
    - Technique.Language
    - Technique.Quantity
    - Technique.Formatter

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ library:
 executables:
   technique:
     dependencies:
+     - megaparsec
      - technique
     ghc-options: -threaded -dynamic
     source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -18,8 +18,8 @@ dependencies:
  - base >= 4.11 && < 5
  - ivar-simple
  - core-data >= 0.2.0
- - core-text >= 0.2.0
- - core-program >= 0.2.1
+ - core-text >= 0.2.2
+ - core-program >= 0.2.2
  - free
 
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/src/TechniqueMain.hs
+++ b/src/TechniqueMain.hs
@@ -25,7 +25,7 @@ main = do
               |]
             ]
         , Command "format" "Format the given procedure"
-            [ Argument "file" [quote|
+            [ Argument "filename" [quote|
                 The file containing the code for the procedure you want to format.
               |]
             ]

--- a/src/TechniqueMain.hs
+++ b/src/TechniqueMain.hs
@@ -16,12 +16,17 @@ version = $(fromPackage)
 main :: IO ()
 main = do
     context <- configure version None (complex
-        [ Command "check" "Syntax- and type-check the given procedure."
+        [ Command "check" "Syntax- and type-check the given procedure"
             [ Option "watch" Nothing Empty [quote|
                 Watch the given procedure file and recompile if changes are detected.
               |]
-            , Argument "procfile" [quote|
+            , Argument "file" [quote|
                 The file containing the code for the procedure you want to type-check.
+              |]
+            ]
+        , Command "format" "Format the given procedure"
+            [ Argument "file" [quote|
+                The file containing the code for the procedure you want to format.
               |]
             ]
         ])

--- a/src/TechniqueMain.hs
+++ b/src/TechniqueMain.hs
@@ -4,11 +4,12 @@
 
 import Core.Program
 import Core.Text
-import Technique.Procedure ()
+
+import TechniqueUser (commandCheckTechnique)
 
 program :: Program None ()
 program = do
-    write "Start"
+    commandCheckTechnique
 
 version :: Version
 version = $(fromPackage)
@@ -20,7 +21,7 @@ main = do
             [ Option "watch" Nothing Empty [quote|
                 Watch the given procedure file and recompile if changes are detected.
               |]
-            , Argument "file" [quote|
+            , Argument "filename" [quote|
                 The file containing the code for the procedure you want to type-check.
               |]
             ]

--- a/src/TechniqueMain.hs
+++ b/src/TechniqueMain.hs
@@ -5,11 +5,10 @@
 import Core.Program
 import Core.Text
 
-import TechniqueUser (commandCheckTechnique)
-
-program :: Program None ()
-program = do
-    commandCheckTechnique
+import TechniqueUser
+    ( commandCheckTechnique
+    , commandFormatTechnique
+    )
 
 version :: Version
 version = $(fromPackage)
@@ -32,3 +31,17 @@ main = do
             ]
         ])
     executeWith context program
+
+program :: Program None ()
+program = do
+    params <- getCommandLine
+    case commandNameFrom params of
+        Nothing -> do
+            write "Illegal state?"
+            terminate 2
+        Just command -> case command of
+            "check"     -> commandCheckTechnique
+            "format"    -> commandFormatTechnique
+            _       -> do
+                write "Unknown command?"
+                terminate 3

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-|
+Programs implementing front-end commands for users: check, format
+-}
+
+module TechniqueUser where
+
+import Core.Program
+import Core.Text
+import Technique.Procedure ()
+
+commandCheckTechnique :: Program None ()
+commandCheckTechnique = do
+    params <- getCommandLine
+    
+    let procfile = case lookupArgument "filename" params of
+            Nothing -> error "invalid"
+            Just file -> file
+
+    writeS procfile

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -20,3 +20,8 @@ commandCheckTechnique = do
             Just file -> file
 
     writeS procfile
+
+commandFormatTechnique :: Program None ()
+commandFormatTechnique = do
+    write "Not yet implemented, sorry"
+    terminate 42

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -9,7 +9,11 @@ module TechniqueUser where
 
 import Core.Program
 import Core.Text
+import Core.System
 import Technique.Procedure ()
+import Technique.Parser
+
+import Text.Megaparsec
 
 commandCheckTechnique :: Program None ()
 commandCheckTechnique = do
@@ -19,7 +23,25 @@ commandCheckTechnique = do
             Nothing -> error "invalid"
             Just file -> file
 
-    writeS procfile
+    event "Read procedure file"
+    contents <- liftIO $ withFile procfile ReadMode hInput
+
+    event "Parse procedure file into Procedure"
+
+    -- This is somewhat horrible; reading into Bytes, then going through
+    -- Rope to get to Text is a bit silly... except that interop was kinda
+    -- the whole point of the unbeliever library. So, good? We can make
+    -- this better if/when we come up with an effecient Stream Rope
+    -- instance so megaparsec can use Rope directly.
+
+    let result = parse pProcedure procfile (fromRope (intoRope contents))
+    case result of
+        Right _ -> do
+            write "Ok"
+        Left err -> do
+            write (intoRope (errorBundlePretty err))
+            terminate 42
+
 
 commandFormatTechnique :: Program None ()
 commandFormatTechnique = do

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -7,6 +7,7 @@ Programs implementing front-end commands for users: check, format
 
 module TechniqueUser where
 
+import Control.Monad (forever, void)
 import Core.Program
 import Core.Text
 import Core.System
@@ -15,14 +16,31 @@ import Technique.Parser
 
 import Text.Megaparsec
 
+data Mode = Cycle | Once
+
 commandCheckTechnique :: Program None ()
 commandCheckTechnique = do
     params <- getCommandLine
     
     let procfile = case lookupArgument "filename" params of
-            Nothing -> error "invalid"
-            Just file -> file
+            Just file   -> file
+            _           -> error "Invalid State"
 
+    let mode = case lookupOptionFlag "watch" params of
+            Just True   -> Cycle
+            Nothing     -> Once
+            _           -> error "Invalid State"
+
+    case mode of
+        Once -> do
+            -- normal operation, single pass
+            void (syntaxCheck procfile)
+        Cycle -> do
+            -- use inotify to rebuild on changes
+            forever (syntaxCheck procfile >> waitForChange [procfile])
+
+syntaxCheck :: FilePath -> Program None ()
+syntaxCheck procfile = do
     event "Read procedure file"
     contents <- liftIO $ withFile procfile ReadMode hInput
 
@@ -40,7 +58,6 @@ commandCheckTechnique = do
             write "Ok"
         Left err -> do
             write (intoRope (errorBundlePretty err))
-            terminate 42
 
 
 commandFormatTechnique :: Program None ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,9 @@
-resolver: lts-14.8
+resolver: lts-14.11
 
 extra-deps:
  - ivar-simple-0.3.2
- - git: http://github.com/oprdyn/unbeliever
-   commit: 735fd5892f087a6ede2cd37dda7d4a22af441f41
+ - git: /home/andrew/src/oprdyn/unbeliever
+   commit: f150b65c204806a06ef3b9a4fd9d74bdc11299e6
    subdirs:
     - core-program
     - core-text

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,9 +2,10 @@ resolver: lts-14.11
 
 extra-deps:
  - ivar-simple-0.3.2
- - git: /home/andrew/src/oprdyn/unbeliever
-   commit: f150b65c204806a06ef3b9a4fd9d74bdc11299e6
+ - git: http://github.com/oprdyn/unbeliever
+   commit: 43688701ba367ca9d74eacb5393fa62fb060d14d
    subdirs:
-    - core-program
     - core-text
+    - core-program
+    - core-data
 

--- a/symlinks
+++ b/symlinks
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+ROOTDIR=`stack path --local-install-root`
+DISTDIR=`stack path --dist-dir`
+
+link () {
+	NAME="$2"
+	ORIGIN="$1"
+
+	if [ -L ./${NAME} ] ; then
+		rm -f ./${NAME}
+	fi
+	if [ -f ./${NAME} ] ; then
+		exit 1
+	fi
+	ln -s ${ORIGIN} ${NAME}
+}
+
+# symlink a "executable" binary
+e () {
+	NAME="$1"
+	link "${ROOTDIR}/bin/${NAME}" "${NAME}"
+}
+
+# symlink a "test-suite" binary
+t () {
+	NAME="$1"
+	link "${DISTDIR}/build/${NAME}/${NAME}" "${NAME}"
+}
+
+
+# main
+e technique
+t check


### PR DESCRIPTION
Implement `check` and `format` commands to the _technique_ program, driving the Technique.Parser and Technique.Formatter modules respectively.