### PR TITLE
Parse of quanties with units

### DIFF
--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -164,7 +164,7 @@ instance Render Quantity where
         Number i ->
             annotate QuantityToken (pretty i)
         Quantity i unit ->
-            annotate QuantityToken (pretty i <+> pretty (unitSymbol unit))
+            annotate QuantityToken (pretty i <+> pretty unit)
         Text text ->
             annotate SymbolToken dquote <>
             annotate StringToken (pretty text) <>

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -132,16 +132,6 @@ pType = label "a valid type" $ do
 
 ---------------------------------------------------------------------
 
--- TODO What is special about L.charLiteral vs just using normal parsers?
-
-stringLiteral0 :: Parser Text
-stringLiteral0 = do
-    void (char '\"')
-    str <- takeWhileP Nothing (/= '"')
-    notFollowedBy eol
-    void (char '\"')
-    return str
-
 stringLiteral :: Parser Text
 stringLiteral = label "a string literal" $ do
     void (char '\"')

--- a/lib/Technique/Quantity.hs
+++ b/lib/Technique/Quantity.hs
@@ -17,7 +17,7 @@ import Core.Data.Structures
 data Quantity
     = None
     | Number Int                -- FIXME not Int
-    | Quantity Int Unit
+    | Quantity Int Symbol
     | Text Rope
     | Undefined
     deriving (Show, Eq)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: technique
-version:  0.2.1
+version:  0.2.2
 synopsis: Procedures and Sequences
 description: |
   A domain specific lanaguage for procedures.

--- a/src/TechniqueMain.hs
+++ b/src/TechniqueMain.hs
@@ -45,3 +45,4 @@ program = do
             _       -> do
                 write "Unknown command?"
                 terminate 3
+    event "Done"

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -14,6 +14,7 @@ import Core.System
 import Technique.Language
 import Technique.Formatter ()
 import Technique.Parser
+import System.IO (hIsTerminalDevice)
 
 import Text.Megaparsec
 
@@ -84,6 +85,10 @@ commandFormatTechnique = do
     result <- loadProcedure procfile
     case result of
         Right procedure -> do
-            write (renderNoAnsi 80 procedure)
+            terminal <- liftIO $ hIsTerminalDevice stdout
+            case terminal of
+                True    -> writeR procedure
+                False   -> write (renderNoAnsi 80 procedure)
+
         Left err -> do
             write err

--- a/tests/CheckAbstractSyntax.hs
+++ b/tests/CheckAbstractSyntax.hs
@@ -6,10 +6,8 @@ module CheckAbstractSyntax
     )
 where
 
-import Core.Data.Structures
 import Core.Text.Rope ()
 import Core.Text.Utilities
-import Data.Maybe (fromJust)
 import Data.Text.Prettyprint.Doc (line)
 import Test.Hspec
 
@@ -47,10 +45,9 @@ checkAbstractSyntax = do
 
         it "renders a tablet as expected" $
           let
-            hours = fromJust (lookupKeyValue "hr" units)
             tablet = Tablet
                         [ Binding "Final temperature" (Variable (Identifier "temp"))
-                        , Binding "Cooking time" (Grouping (Literal (Quantity 3 hours)))
+                        , Binding "Cooking time" (Grouping (Literal (Quantity 3 "hr")))
                         ]
           in do
             renderTest tablet `shouldBe` [quote|

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -93,15 +93,15 @@ checkSkeletonParser = do
 
 
     describe "Parses quantities" $ do
-        it "quoted string is a Text" $ do
+        it "a quoted string is a Text" $ do
             parseMaybe pQuantity "\"Hello world\"" `shouldBe` Just (Text "Hello world")
             parseMaybe pQuantity "\"\"" `shouldBe` Just (Text "")
 
-        it "number is a Number" $ do
+        it "a number is a Number" $ do
             parseMaybe pQuantity "42" `shouldBe` Just (Number 42)
             parseMaybe pQuantity "-42" `shouldBe` Just (Number (-42))
 
-        it "quantity with units is a Quantity" $ do
+        it "a quantity with units is a Quantity" $ do
             parseMaybe pQuantity "149 kg" `shouldBe` Just (Quantity 149 "kg")
 
     describe "Parses expressions" $ do
@@ -116,7 +116,7 @@ checkSkeletonParser = do
 
         it "an identifier, space, and then expression is an Application" $ do
             parseMaybe pExpression "a x"
-                `shouldBe` Just (Application (Identifier "x") (Variable (Identifier "x")))
+                `shouldBe` Just (Application (Identifier "a") (Variable (Identifier "x")))
 
         it "a quoted string is a Literal Text" $ do
             parseMaybe pExpression "\"Hello world\"" `shouldBe` Just (Literal (Text "Hello world"))

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -91,6 +91,19 @@ checkSkeletonParser = do
             parseMaybe numberLiteral "0" `shouldBe` Just 0
             parseMaybe numberLiteral "1a" `shouldBe` Nothing
 
+
+    describe "Parses quantities" $ do
+        it "quoted string is a Text" $ do
+            parseMaybe pQuantity "\"Hello world\"" `shouldBe` Just (Text "Hello world")
+            parseMaybe pQuantity "\"\"" `shouldBe` Just (Text "")
+
+        it "number is a Number" $ do
+            parseMaybe pQuantity "42" `shouldBe` Just (Number 42)
+            parseMaybe pQuantity "-42" `shouldBe` Just (Number (-42))
+
+        it "quantity with units is a Quantity" $ do
+            parseMaybe pQuantity "149 kg" `shouldBe` Just (Quantity 149 "kg")
+
     describe "Parses expressions" $ do
         it "an empty input an error" $ do
             parseMaybe pExpression "" `shouldBe` Nothing
@@ -100,6 +113,10 @@ checkSkeletonParser = do
 
         it "a bare identifier is a Variable" $ do
             parseMaybe pExpression "x" `shouldBe` Just (Variable (Identifier "x"))
+
+        it "an identifier, space, and then expression is an Application" $ do
+            parseMaybe pExpression "a x"
+                `shouldBe` Just (Application (Identifier "x") (Variable (Identifier "x")))
 
         it "a quoted string is a Literal Text" $ do
             parseMaybe pExpression "\"Hello world\"" `shouldBe` Just (Literal (Text "Hello world"))

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -3,12 +3,10 @@
 
 module ExampleProcedure where
 
-import Core.Data.Structures
 import Core.Text.Rope ()
 import Core.Text.Utilities ()
 import Core.Program.Execute hiding (None)
 import Core.Program.Logging
-import Data.Maybe (fromJust)
 
 import Technique.Language
 import Technique.Quantity
@@ -82,7 +80,7 @@ exampleRoastTurkey =
   let
     i = Type "Ingredients"
     o = Type "Turkey"
-    celsius = fromJust (lookupKeyValue "°C" units)
+    celsius = "°C"
     chef = Role "chef"
     block = Block
                 [ Attribute chef (Block


### PR DESCRIPTION
We can now handle

    180 °C

as a Quantity!

Fixes several whitespace bugs that crept in, including one where function application was no longer working.

Completes the round trip of the format command: if redirected to a file plain text is emitted, but if the output is to terminal then syntax highlighting will be rendered. Beautiful.