### PR TITLE
Replace use of try with lookAhead

### DIFF
--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -215,7 +215,9 @@ toNumbers c = case c of
 pQuantity :: Parser Quantity
 pQuantity =
     (do
+        -- look ahead far enough to commit to this branch
         void (lookAhead (try (skipMany (anySingleBut ' ') *> char ' ')))
+
         n <- pMantissa
         u <- pUncertainty <|> pure (Decimal 0 0)
         m <- pMagnitude <|> pure 0
@@ -243,7 +245,9 @@ pQuantity =
     pUncertainty = do
         void (char '±') <|> void (string "+/-")
         skipSpace
-        decimalLiteral
+        decimal <- decimalLiteral
+        skipSpace
+        return decimal
 
     pMagnitude = do
         void (char '×') <|> void (char 'x') <|> hidden (void (char '*'))

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -216,11 +216,13 @@ toNumbers c = case c of
 pQuantity :: Parser Quantity
 pQuantity =
     (do
-        -- look ahead far enough to commit to this branch, skipping the
-        -- structural characters that indicate the end of a literal.
+        -- look ahead far enough to commit to this branch:  the pieces of a
+        -- decimal, a space, and then one of the characters that starts an
+        -- uncertainty, magnitude, or symbol.
         lookAhead (try (do
-            skipMany (noneOf [' ',')','}',']',';','\n'])
-            void (oneOf [' ', '±', '+', '×', 'x'] <|> unitChar)
+            skipMany (digitChar <|> char '.' <|> char '-')
+            skipSpace1
+            void (char '±' <|> char '+' <|> char '×' <|> char 'x' <|> unitChar)
             ))
 
         n <- pMantissa

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -17,7 +17,6 @@ module Technique.Parser where
 import Control.Monad
 import Control.Monad.Combinators
 import Core.Text.Rope
-import Data.Char (GeneralCategory(..))
 import Data.Foldable (foldl')
 import Data.Int (Int8, Int64)
 import Data.Text (Text)
@@ -155,7 +154,7 @@ stringLiteral = label "a string literal" $ do
     return (T.pack str)
 
 unitChar :: Parser Char
-unitChar = hidden (upperChar <|> lowerChar <|> charCategory CurrencySymbol)
+unitChar = hidden (upperChar <|> lowerChar <|> char '°')
 
 unitLiteral :: Parser Rope
 unitLiteral = label "a units symbol" $ do

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: technique
-version:  0.2.3
+version:  0.2.4
 synopsis: Procedures and Sequences
 description: |
   A domain specific lanaguage for procedures.

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -242,10 +242,12 @@ checkSkeletonParser = do
                 `shouldBe` Just (Block
                     [ Execute (Variable [Identifier "x"])
                     ])
-            parseMaybe pBlock "{ \n (42 )    \n}"
+            parseMaybe pBlock "{ \n (42)    \n}"
                 `shouldBe` Just (Block
                     [ Execute (Grouping (Amount (Number 42)))
                     ])
+            parseMaybe pBlock "{ \n (42 )    \n}"
+                `shouldBe` Nothing
             parseMaybe pBlock "{ answer = 42 ; }"
                 `shouldBe` Just (Block
                     [ (Assignment [Identifier "answer"] (Amount (Number 42)))

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -247,7 +247,9 @@ checkSkeletonParser = do
                     [ Execute (Grouping (Amount (Number 42)))
                     ])
             parseMaybe pBlock "{ \n (42 )    \n}"
-                `shouldBe` Nothing
+                `shouldBe` Just (Block
+                    [ Execute (Grouping (Amount (Number 42)))
+                    ])
             parseMaybe pBlock "{ answer = 42 ; }"
                 `shouldBe` Just (Block
                     [ (Assignment [Identifier "answer"] (Amount (Number 42)))

--- a/tests/ParseSnippet.hs
+++ b/tests/ParseSnippet.hs
@@ -1,14 +1,36 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE BangPatterns #-}
 
 import Core.Program
 import Core.Text
 import Core.System
 import Data.Text (Text)
-import qualified Data.Text.IO as T
 import Text.Megaparsec
 
 import Technique.Parser
 import Technique.Formatter ()
+
+text :: Text
+text = "5.9722 × 10^24 kg"
+
+text1 = [quote|
+{ 
+    (42 )  
+}
+|]
+
+text2 = "{ answer = 42 kg }" -- ;
+
+text3 = "x"
+
+main :: IO ()
+main = execute $ do
+    let !result = parse pBlock "" text1
+    liftIO $ hFlush stdout
+    sleep 0.25
+    case result of
+        Left err    -> write (intoRope (errorBundlePretty err))
+        Right x     -> writeR x
 
 
 blob1 :: Text
@@ -66,13 +88,3 @@ blob4 = [quote|
     ]
 }}
 |]
-
-main :: IO ()
-main = execute $ do
-    blob3 <- liftIO $ T.readFile "tests/Stub.t"
-    let result = parse pTechnique "" blob3
-    sleep 0.25
-    case result of
-        Left err    -> write (intoRope (errorBundlePretty err))
-        Right x     -> writeR x
-        


### PR DESCRIPTION
After much frustration we independently discovered that the `try a <|> b` pattern leads to well intentioned error message being swallowed by backtracking with the result that misparse of a number, say, ends up as an error about a misplaced `{` 15 lines earlier. Egad!

Thanks to @ezyang's blog post titled [Parsec: “try a <|> b” considered harmful](http://blog.ezyang.com/2014/05/parsec-try-a-or-b-considered-harmful/) on this pattern for having clarified that we had indeed hit a fundamental design {limitation, feature, flaw} of parser combinators.

This rips out all the use of `try <|>` and replaces it with scans using **megaparsec**'s `lookAhead` to determine wither to commit to a given alternative branch.