### PR TITLE
Render compilation errors arising from translation phase

### DIFF
--- a/lib/Technique/Diagnostics.hs
+++ b/lib/Technique/Diagnostics.hs
@@ -80,7 +80,6 @@ instance Render Name where
     colourize = colourizeTechnique
     intoDocA (Name name) = annotate VariableToken (pretty name)
 
-
 instance Render Value where
     type Token Value = TechniqueToken
     colourize = colourizeTechnique

--- a/lib/Technique/Diagnostics.hs
+++ b/lib/Technique/Diagnostics.hs
@@ -75,6 +75,10 @@ instance Render Step where
             f (label,substep) =
                 intoDocA label <+> "<-" <+> intoDocA substep
 
+        Located _ substep ->
+            intoDocA substep
+
+
 instance Render Name where
     type Token Name = TechniqueToken
     colourize = colourizeTechnique

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -13,27 +13,47 @@ import Core.System.Base
 import Core.System.Pretty
 import Core.Text.Rope
 import Core.Text.Utilities
+import Data.List.NonEmpty
+import qualified Data.Set as OrdSet
+import qualified Data.Text as T
+import Text.Megaparsec (PosState(..), SourcePos(..))
+import Text.Megaparsec.Error
+    ( ParseError(..)
+    , ErrorFancy(..)
+    , ParseErrorBundle(..)
+    , errorBundlePretty
+    , ShowErrorComponent(..)
+    )
+import Text.Megaparsec.Pos (Pos, mkPos)
 
 import Technique.Language
 import Technique.Formatter
 
+data Source = Source
+    { sourceContents :: T.Text                   -- whatever parser is expecting
+    , sourceFilename :: FilePath
+    , sourceStatement :: Statement
+    , sourceOffset :: Offset
+    }
+    deriving (Eq,Ord,Show)
+
 data CompilerFailure
     = ParsingFailed String              -- FIXME change to ParseErrorSomethingErOther
-    | VariableAlreadyInUse (Offset,Statement) Identifier
-    | ProcedureAlreadyDeclared (Offset,Statement) Identifier
-    | CallToUnknownProcedure (Offset,Statement) Identifier
-    | UseOfUnknownIdentifier (Offset,Statement) Identifier
-    | EncounteredUndefined (Offset,Statement)
-    deriving (Eq,Show)
+    | VariableAlreadyInUse Identifier
+    | ProcedureAlreadyDeclared Identifier
+    | CallToUnknownProcedure Identifier
+    | UseOfUnknownIdentifier Identifier
+    | EncounteredUndefined
+    deriving (Eq,Ord,Show)
 
 instance Enum CompilerFailure where
     fromEnum x = case x of
         ParsingFailed _ -> 1
-        VariableAlreadyInUse _ _ -> 2
-        ProcedureAlreadyDeclared _ _ -> 3
-        CallToUnknownProcedure _ _ -> 4
-        UseOfUnknownIdentifier _ _ -> 5
-        EncounteredUndefined _ -> 6
+        VariableAlreadyInUse _ -> 2
+        ProcedureAlreadyDeclared _ -> 3
+        CallToUnknownProcedure _ -> 4
+        UseOfUnknownIdentifier _ -> 5
+        EncounteredUndefined -> 6
     toEnum = undefined
 
 instance Exception CompilerFailure where
@@ -46,9 +66,45 @@ instance Render CompilerFailure where
     colourize = colourizeTechnique
     intoDocA failure = case failure of
         ParsingFailed err -> pretty err
-        VariableAlreadyInUse _ i -> "Variable by the name of '" <> intoDocA i <> "' already defined."
-        ProcedureAlreadyDeclared _ i -> "Procedure by the name of '" <> intoDocA i <> "' already declared."
-        CallToUnknownProcedure _ i -> "Call to unknown procedure '" <> intoDocA i <> "'."
-        UseOfUnknownIdentifier (offset,statement) i ->
-            pretty offset <> ": " <> intoDocA statement <> line <> "Variable '" <> intoDocA i <> "' not in scope."
+        VariableAlreadyInUse i -> "Variable by the name of '" <> intoDocA i <> "' already defined."
+        ProcedureAlreadyDeclared i -> "Procedure by the name of '" <> intoDocA i <> "' already declared."
+        CallToUnknownProcedure i -> "Call to unknown procedure '" <> intoDocA i <> "'."
+        UseOfUnknownIdentifier i -> "Variable '" <> intoDocA i <> "' not in scope."
         EncounteredUndefined _ -> "Encountered 'undefined' marker."
+
+{-
+            let
+                statement = sourceStatement source
+                offset = sourceOffset source
+            in
+                pretty offset <> ": " <> intoDocA statement <> line <>
+-}
+
+instance ShowErrorComponent CompilerFailure where
+    showErrorComponent = fromRope . render 78
+
+{-|
+In order to have consistently formatted "compiler" failure messages, we
+jump through the hoops to use megaparsec's parse error message machinery.
+-}
+makeErrorBundle :: (FilePath,T.Text,Offset,CompilerFailure) -> ParseErrorBundle T.Text CompilerFailure
+makeErrorBundle (filename,source,offset,failure) =
+  let
+    fancy = ErrorCustom failure
+    errors = FancyError offset (OrdSet.singleton fancy) :| []
+    bundle = ParseErrorBundle
+        { bundleErrors = errors
+        , bundlePosState = PosState
+            { pstateInput = source
+            , pstateOffset = 0
+            , pstateSourcePos = SourcePos
+                { sourceName = filename
+                , sourceLine = mkPos 1
+                , sourceColumn = mkPos 1
+                }
+            , pstateTabWidth = mkPos 4
+            , pstateLinePrefix = ""
+            }
+        }
+  in
+    bundle

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -10,26 +10,28 @@ module Technique.Failure where
 
 import Core.System.Base
 import Core.Text.Rope
+import Core.Text.Utilities (render)
 
 import Technique.Language
+import Technique.Formatter ()
 
 data CompilerFailure
     = ParsingFailed String              -- FIXME change to ParseErrorSomethingErOther
-    | VariableAlreadyInUse Identifier
-    | ProcedureAlreadyDeclared Identifier
-    | CallToUnknownProcedure Identifier
-    | UseOfUnknownIdentifier Identifier
-    | EncounteredUndefined
+    | VariableAlreadyInUse (Offset,Statement) Identifier
+    | ProcedureAlreadyDeclared (Offset,Statement) Identifier
+    | CallToUnknownProcedure (Offset,Statement) Identifier
+    | UseOfUnknownIdentifier (Offset,Statement) Identifier
+    | EncounteredUndefined (Offset,Statement)
     deriving (Eq,Show)
 
 instance Enum CompilerFailure where
     fromEnum x = case x of
         ParsingFailed _ -> 1
-        VariableAlreadyInUse _ -> 2
-        ProcedureAlreadyDeclared _ -> 3
-        CallToUnknownProcedure _ -> 4
-        UseOfUnknownIdentifier _ -> 5
-        EncounteredUndefined -> 6
+        VariableAlreadyInUse _ _ -> 2
+        ProcedureAlreadyDeclared _ _ -> 3
+        CallToUnknownProcedure _ _ -> 4
+        UseOfUnknownIdentifier _ _ -> 5
+        EncounteredUndefined _ -> 6
     toEnum = undefined
 
 instance Exception CompilerFailure where
@@ -40,8 +42,9 @@ instance Exception CompilerFailure where
 renderFailure :: CompilerFailure -> Rope
 renderFailure e = case e of
     ParsingFailed err -> intoRope err
-    VariableAlreadyInUse i -> "Variable by the name of '" <> unIdentifier i <> "' already defined."
-    ProcedureAlreadyDeclared i -> "Procedure by the name of '" <> unIdentifier i <> "' already declared."
-    CallToUnknownProcedure i -> "Call to unknown procedure '" <> unIdentifier i <> "'."
-    UseOfUnknownIdentifier i -> "Variable '" <> unIdentifier i <> "' not in scope."
-    EncounteredUndefined -> "Encountered 'undefined' marker."
+    VariableAlreadyInUse _ i -> "Variable by the name of '" <> unIdentifier i <> "' already defined."
+    ProcedureAlreadyDeclared _ i -> "Procedure by the name of '" <> unIdentifier i <> "' already declared."
+    CallToUnknownProcedure _ i -> "Call to unknown procedure '" <> unIdentifier i <> "'."
+    UseOfUnknownIdentifier (offset,statement) i ->
+        intoRope (show offset) <> ": " <> render 78 statement <> "\nVariable '" <> unIdentifier i <> "' not in scope."
+    EncounteredUndefined _ -> "Encountered 'undefined' marker."

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -137,7 +137,7 @@ instance Render Attribute where
     intoDocA role =  case role of
         Role name -> annotate RoleToken ("@" <> pretty name)
         Place name -> annotate RoleToken ("#" <> pretty name)
-        Inherited -> annotate ErrorToken "Inherited"
+        Inherit -> annotate ErrorToken "Inherit"
 
 instance Render Expression where
     type Token Expression = TechniqueToken

--- a/lib/Technique/Formatter.hs
+++ b/lib/Technique/Formatter.hs
@@ -96,18 +96,18 @@ instance Render Markdown where
 instance Render Block where
     type Token Block = TechniqueToken
     colourize = colourizeTechnique
-    intoDocA (Block statements) =
+    intoDocA (Block pairs) =
         nest 4 (
             annotate SymbolToken lbrace <>
-            go statements
+            go pairs
         ) <>
         line <>
         annotate SymbolToken rbrace
       where
-        go :: [Statement] -> Doc TechniqueToken
+        go :: [(Offset,Statement)] -> Doc TechniqueToken
         go [] = emptyDoc
-        go (Series:x1:xs) = intoDocA Series <> intoDocA x1 <> go xs
-        go (x:xs) = line <> intoDocA x <> go xs
+        go ((_,Series):(_,x1):xs) = intoDocA Series <> intoDocA x1 <> go xs
+        go ((_,x):xs) = line <> intoDocA x <> go xs
 
 instance Render Statement where
     type Token Statement = TechniqueToken

--- a/lib/Technique/Internal.hs
+++ b/lib/Technique/Internal.hs
@@ -14,7 +14,6 @@ import Data.DList
 
 import Technique.Language
 import Technique.Quantity
-import Technique.Failure
 
 -- FIXME ??? upgrade to named IVar
 newtype Promise = Promise Value

--- a/lib/Technique/Internal.hs
+++ b/lib/Technique/Internal.hs
@@ -112,6 +112,7 @@ data Step
     | Asynchronous [Name] Step              -- assignment (ie lambda, "implication introduction"
     | Invocation Attribute Function Step    -- function application ("implication elimination") on a [sub] Procedure
     | Nested (DList Step)
+    | Located (Offset,Statement) Step
                                             -- assumption axiom?
                                             -- weakening?
     deriving (Eq,Show)

--- a/lib/Technique/Internal.hs
+++ b/lib/Technique/Internal.hs
@@ -14,6 +14,7 @@ import Data.DList
 
 import Technique.Language
 import Technique.Quantity
+import Technique.Failure
 
 -- FIXME ??? upgrade to named IVar
 newtype Promise = Promise Value

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -90,11 +90,10 @@ emptyProcedure = Procedure
     , procedureBlock = Block []
     }
 
-data Block = Block [Statement]
+data Block = Block [(Offset,Statement)]
     deriving (Show, Eq)
 
-blockStatements :: Block -> [Statement]
-blockStatements (Block statements) = statements
+type Offset = Int
 
 data Statement
     = Assignment [Identifier] Expression

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -41,13 +41,13 @@ instance Key Identifier
 -- TODO construction needs to validate internal rules for labels. No
 -- newlines, perhaps.
 newtype Label = Label Rope
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 data Attribute
     = Role Identifier
     | Place Identifier
     | Inherit
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 {-
     | Anyone
@@ -56,14 +56,14 @@ data Attribute
 
 data Markdown
     = Markdown Rope
-    deriving (Eq)
+    deriving (Eq, Ord)
 
 instance Show Markdown where
     show (Markdown text) = "[quote|\n" ++ fromRope text ++ "|]"
 
 data Type
     = Type Rope
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 unitType :: Type
 unitType = Type "()"
@@ -77,7 +77,7 @@ data Procedure = Procedure
     , procedureDescription :: Maybe Markdown
     , procedureBlock :: Block
     }
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 emptyProcedure :: Procedure
 emptyProcedure = Procedure
@@ -91,7 +91,7 @@ emptyProcedure = Procedure
     }
 
 data Block = Block [(Offset,Statement)]
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 type Offset = Int
 
@@ -102,7 +102,7 @@ data Statement
     | Declaration Procedure
     | Blank
     | Series
-    deriving (Show, Eq)
+    deriving (Show, Ord, Eq)
 
 data Expression
     = Application Identifier Expression     -- this had better turn out to be a procedure
@@ -115,20 +115,20 @@ data Expression
     | Operation Operator Expression Expression
     | Grouping Expression
     | Restriction Attribute Block
-    deriving (Show, Eq)
+    deriving (Show, Ord, Eq)
 
 data Tablet
     = Tablet [Binding]
-    deriving (Show, Eq)
+    deriving (Show, Ord, Eq)
 
 -- only valid Expressions are Literal and Variable. Should we enforce that
 -- somewhere?
 data Binding
     = Binding Label Expression
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 data Operator
     = WaitEither
     | WaitBoth
     | Combine
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -46,7 +46,7 @@ newtype Label = Label Rope
 data Attribute
     = Role Identifier
     | Place Identifier
-    | Inherited
+    | Inherit
     deriving (Show, Eq)
 
 {-

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -389,7 +389,7 @@ pExpression = do
         lookAhead (try (do
             skipMany identifierChar
             skipSpace1
-            void (identifierChar <|> digitChar <|> char '(')))
+            void (identifierChar <|> digitChar <|> char '(' <|> char '\"')))
 
         name <- pIdentifier
         -- ie at least one space

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -68,10 +68,11 @@ import Text.Read
     ( readMaybe
     )
 
+import Technique.Failure
 import Technique.Language
 import Technique.Quantity
 
-type Parser = Parsec Void Text
+type Parser = Parsec FailureReason Text
 
 __VERSION__ :: Int
 __VERSION__ = 0

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -58,7 +58,7 @@ import Data.Void
 import qualified Data.Text as T (pack)
 import Text.Megaparsec
     ( Parsec, try, takeWhileP, takeWhile1P, hidden, (<?>), label
-    , notFollowedBy, oneOf, lookAhead, skipMany
+    , notFollowedBy, oneOf, lookAhead, skipMany, getOffset
     )
 import Text.Megaparsec.Char
     ( char, spaceChar, string, newline, lowerChar, upperChar, digitChar
@@ -451,13 +451,15 @@ pExpression = do
 
         return (Variable names)
 
-pStatement :: Parser Statement
-pStatement =
-    pAssignment <|>
-    pDeclaration <|>
-    pExecute <|>
-    pBlank <|>
-    pSeries
+pStatement :: Parser (Offset,Statement)
+pStatement = do
+    offset <- getOffset
+    statement <- pAssignment <|>
+        pDeclaration <|>
+        pExecute <|>
+        pBlank <|>
+        pSeries
+    return (offset,statement)
   where
     pAssignment = label "an assignment" $ do
         lookAhead (try (do

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -68,11 +68,10 @@ import Text.Read
     ( readMaybe
     )
 
-import Technique.Failure
 import Technique.Language
 import Technique.Quantity
 
-type Parser = Parsec FailureReason Text
+type Parser = Parsec Void Text
 
 __VERSION__ :: Int
 __VERSION__ = 0

--- a/lib/Technique/Quantity.hs
+++ b/lib/Technique/Quantity.hs
@@ -25,7 +25,7 @@ import Data.Int (Int8, Int64)
 data Quantity
     = Number Int64
     | Quantity Decimal Decimal Magnitude Symbol
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 type Symbol = Rope
 
@@ -45,7 +45,7 @@ representable is 9223372036854775807 and the smallest is
 precision but meh.
 -}
 data Decimal = Decimal Int64 Int8
-    deriving Eq
+    deriving (Eq, Ord)
 
 instance Show Decimal where
     show = show . decimalToRope

--- a/lib/Technique/Translate.hs
+++ b/lib/Technique/Translate.hs
@@ -232,7 +232,7 @@ failBecause :: FailureReason -> Translate a
 failBecause reason = do
     env <- get
     let source = environmentCurrent env
-    let failure = CompilationError (makeErrorBundle source reason)
+    let failure = CompilationError source reason
     throwError failure
 
 

--- a/lib/Technique/Translate.hs
+++ b/lib/Technique/Translate.hs
@@ -108,8 +108,8 @@ translateBlock (Block statements) = do
     let step = environmentAccumulated env'
     return step
 
-translateStatement :: Statement -> Translate ()
-translateStatement statement = case statement of
+translateStatement :: (Offset,Statement) -> Translate ()
+translateStatement (_,statement) = case statement of
     Assignment vars expr -> do
         names <- traverse insertVariable vars
         step <- translateExpression expr

--- a/lib/Technique/Translate.hs
+++ b/lib/Technique/Translate.hs
@@ -16,7 +16,6 @@ import Core.Data
 import Core.Text
 import Data.DList (toList, fromList)
 import Data.Foldable (traverse_)
-import qualified Data.Text as T
 
 import Technique.Builtins
 import Technique.Failure
@@ -130,7 +129,6 @@ translateStatement (offset,statement) = do
             step <- translateExpression expr
             appendStep (offset,statement) step
 
-
         Declaration proc -> do
             _ <- translateProcedure proc
             return ()
@@ -231,12 +229,11 @@ registerProcedure func = do
 -- exceptions mechansism is unfortunate. We're not throwing an exception,
 -- end it's definitely not pure `error`. Wrap it for clarity.
 failBecause :: FailureReason -> Translate a
-failBecause e = do
+failBecause reason = do
     env <- get
     let source = environmentCurrent env
-    let failure = CompilationError source e
+    let failure = CompilationError (makeErrorBundle source reason)
     throwError failure
--- TODO HERE wrap CompilationError into a CompilerFailure, which annotates source location
 
 
 lookupVariable :: Identifier -> Translate Name

--- a/lib/Technique/Translate.hs
+++ b/lib/Technique/Translate.hs
@@ -43,7 +43,7 @@ emptyEnvironment :: Environment
 emptyEnvironment = Environment
     { environmentVariables = emptyMap
     , environmentFunctions = emptyMap
-    , environmentRole = Inherited
+    , environmentRole = Inherit
     , environmentCurrent = (-1,Blank)
     , environmentAccumulated = NoOp
     }

--- a/package.yaml
+++ b/package.yaml
@@ -72,7 +72,7 @@ tests:
       - tests
     main: TestSuite.hs
     other-modules:
-      - CheckAbstractSyntax
+      - CheckConcreteSyntax
       - CheckSkeletonParser
       - CheckQuantityBehaviour
       - CheckTranslationStage

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ dependencies:
   - ivar-simple
   - containers
   - core-data >= 0.2.1
-  - core-text >= 0.2.2.6
+  - core-text >= 0.2.3.1
   - core-program >= 0.2.3
   - dlist
   - free

--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,7 @@ github: oprdyn/technique
 dependencies:
   - base >= 4.11 && < 5
   - ivar-simple
+  - containers
   - core-data >= 0.2.1
   - core-text >= 0.2.2.6
   - core-program >= 0.2.3
@@ -28,7 +29,7 @@ dependencies:
   - prettyprinter
   - prettyprinter-ansi-terminal
 
-ghc-options: -Wall -Wwarn -fwarn-tabs -dynamic
+ghc-options: -Wall -Wwarn -fwarn-tabs
 
 library:
   dependencies:

--- a/src/TechniqueMain.hs
+++ b/src/TechniqueMain.hs
@@ -25,7 +25,11 @@ main = do
               |]
             ]
         , Command "format" "Format the given procedure"
-            [ Argument "filename" [quote|
+            [ Option "raw-control-chars" (Just 'R') Empty [quote|
+                Emit ANSI escape codes for syntax highlighting even if output
+                is redirected to a pipe or file.
+              |]
+            , Argument "filename" [quote|
                 The file containing the code for the procedure you want to format.
               |]
             ]

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -13,7 +13,7 @@ import Core.Program
 import Core.Text
 import Core.System
 import System.IO (hIsTerminalDevice)
-import Text.Megaparsec (parse, errorBundlePretty, ParseErrorBundle, bundleErrors, bundlePosState)
+import Text.Megaparsec (parse)
 
 import Technique.Builtins
 import Technique.Diagnostics ()
@@ -88,7 +88,7 @@ parsingPhase filename bytes = do
     let result = parse pTechnique filename (fromRope (intoRope bytes))
     case result of
         Right technique -> return technique
-        Left bundle -> throw (CompilationError bundle)
+        Left bundle -> throw (extractErrorBundle bundle)
 
 {-|
 Take a static Procedure definition and spin it up into a sequence of

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -58,9 +58,9 @@ syntaxCheck procfile =
             debugR "abstract" abstract
             write "ok"
             return 0)
-        (\(e :: CompilerFailure) -> do
+        (\(e :: CompilationError) -> do
             write ("failed: " <> render 78 e)
-            return (fromEnum e))
+            return (exitCodeFor e))
 
 {-|
 Load a technique file hopefully containing a procedure.
@@ -88,7 +88,7 @@ parsingPhase filename bytes = do
     let result = parse pTechnique filename (fromRope (intoRope bytes))
     case result of
         Right technique -> return technique
-        Left err -> throw (ParsingFailed (errorBundlePretty err))
+        Left err -> throw (CompilationError emptySource (ParsingFailed (errorBundlePretty err)))
 
 {-|
 Take a static Procedure definition and spin it up into a sequence of
@@ -134,6 +134,6 @@ commandFormatTechnique = do
             case (terminal || raw) of
                 True    -> writeR technique
                 False   -> write (renderNoAnsi 80 technique))
-        (\(e :: CompilerFailure) -> do
+        (\(e :: CompilationError) -> do
             write ("failed: " <> render 78 e)
-            terminate (fromEnum e))
+            terminate (exitCodeFor e))

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -13,7 +13,7 @@ import Core.Program
 import Core.Text
 import Core.System
 import System.IO (hIsTerminalDevice)
-import Text.Megaparsec (parse, errorBundlePretty)
+import Text.Megaparsec (parse, errorBundlePretty, ParseErrorBundle, bundleErrors, bundlePosState)
 
 import Technique.Builtins
 import Technique.Diagnostics ()
@@ -88,7 +88,7 @@ parsingPhase filename bytes = do
     let result = parse pTechnique filename (fromRope (intoRope bytes))
     case result of
         Right technique -> return technique
-        Left err -> throw (CompilationError emptySource (ParsingFailed (errorBundlePretty err)))
+        Left bundle -> throw (CompilationError bundle)
 
 {-|
 Take a static Procedure definition and spin it up into a sequence of

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 {-|
@@ -57,8 +58,8 @@ syntaxCheck procfile =
             debugR "abstract" abstract
             write "ok"
             return 0)
-        (\e -> do
-            write ("failed: " <> renderFailure e)
+        (\(e :: CompilerFailure) -> do
+            write ("failed: " <> render 78 e)
             return (fromEnum e))
 
 {-|
@@ -133,6 +134,6 @@ commandFormatTechnique = do
             case (terminal || raw) of
                 True    -> writeR technique
                 False   -> write (renderNoAnsi 80 technique))
-        (\e -> do
-            write ("failed: " <> renderFailure e)
+        (\(e :: CompilerFailure) -> do
+            write ("failed: " <> render 78 e)
             terminate (fromEnum e))

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -78,6 +78,11 @@ commandFormatTechnique :: Program None ()
 commandFormatTechnique = do
     params <- getCommandLine
 
+    let raw = case lookupOptionFlag "raw-control-chars" params of
+            Nothing     -> False
+            Just True   -> True
+            _           -> error "Invalid State"
+
     let procfile = case lookupArgument "filename" params of
             Just file   -> file
             _           -> error "Invalid State"
@@ -86,7 +91,7 @@ commandFormatTechnique = do
     case result of
         Right technique -> do
             terminal <- liftIO $ hIsTerminalDevice stdout
-            case terminal of
+            case (terminal || raw) of
                 True    -> writeR technique
                 False   -> write (renderNoAnsi 80 technique)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
-resolver: lts-14.16
+resolver: lts-14.19
 
 packages:
- - /home/andrew/src/oprdyn/unbeliever/core-text
- - /home/andrew/src/oprdyn/unbeliever/core-program
- - /home/andrew/src/oprdyn/unbeliever/core-data
  - .
 
 extra-deps:
+ - core-text-0.2.2.6
+ - core-program-0.2.3.0
+ - core-data-0.2.1.4
  - ivar-simple-0.3.2
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.19
+resolver: lts-14.20
 
 packages:
  - .

--- a/tests/CheckAbstractSyntax.hs
+++ b/tests/CheckAbstractSyntax.hs
@@ -66,7 +66,7 @@ checkAbstractSyntax = do
         it "renders a normal block with indentation" $
           let
             b = Block
-                [ Execute (Variable [Identifier "x"])
+                [ (0, Execute (Variable [Identifier "x"]))
                 ]
           in do
             renderTest b `shouldBe` [quote|
@@ -82,7 +82,7 @@ checkAbstractSyntax = do
                     { procedureName = Identifier "f"
                     , procedureInput = [Type "X"]
                     , procedureOutput = [Type "Y"]
-                    , procedureBlock = Block [Execute (Variable [Identifier "z"])]
+                    , procedureBlock = Block [(0, Execute (Variable [Identifier "z"]))]
                     }
           in do
             renderTest p `shouldBe` [quote|

--- a/tests/CheckTranslationStage.hs
+++ b/tests/CheckTranslationStage.hs
@@ -25,12 +25,9 @@ main = do
     finally (hspec checkTranslationStage) (putStrLn ".")
 
 testEnv :: Environment
-testEnv = Environment
+testEnv = emptyEnvironment
     { environmentVariables = singletonMap (Identifier "x") (Name "!x")
     , environmentFunctions = insertKeyValue (Identifier "oven") (Subroutine exampleProcedureOven NoOp) builtinProcedures
-    , environmentRole = Inherit
-    , environmentCurrent = (0,Blank)
-    , environmentAccumulated = NoOp
     }
 
 checkTranslationStage :: Spec

--- a/tests/CheckTranslationStage.hs
+++ b/tests/CheckTranslationStage.hs
@@ -53,7 +53,7 @@ checkTranslationStage = do
           let
             expr1 = Variable [Identifier "x"]
             expr2 = Application (Identifier "f") expr1
-            stmt = Execute expr2
+            stmt = (0, Execute expr2)
             block = Block [stmt]
             technique = emptyTechnique { techniqueBody = [ emptyProcedure { procedureBlock = block } ] }
           in do
@@ -67,7 +67,7 @@ checkTranslationStage = do
         it "encountering builtin procedure" $
           let
             expr = Application (Identifier "task") (Text "Say Hello")
-            stmt = Execute expr
+            stmt = (0, Execute expr)
             block = Block [stmt]
             proc = emptyProcedure { procedureName = Identifier "hypothetical", procedureBlock = block }
             tech = emptyTechnique { techniqueBody = [ proc ]}
@@ -82,7 +82,7 @@ checkTranslationStage = do
         it "encounters a declaration for an already existing procedure name" $
           let
             proc = exampleProcedureOven -- already in testEnv
-            stmt = Declaration proc
+            stmt = (0, Declaration proc)
             block = Block [stmt]
           in do
             -- verify precondition that there is one already there

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -42,7 +42,7 @@ exampleProcedureOven =
         , procedureOutput = [Type "()"] -- ?
         , procedureTitle = Nothing
         , procedureDescription = Nothing
-        , procedureBlock = Block [ Execute (Application (Identifier "task") (Text "Set oven temperature!")) ]
+        , procedureBlock = Block [ (0, Execute (Application (Identifier "task") (Text "Set oven temperature!")) )]
         }
 
 exampleRoastTurkey :: Procedure
@@ -53,41 +53,41 @@ exampleRoastTurkey =
     celsius = "°C"
     chef = Role (Identifier "chef")
     block = Block
-                [ Execute (Restriction chef (Block
-                    [ Assignment
+                [ (0, Execute (Restriction chef (Block
+                    [ (0, Assignment
                         [Identifier "preheat"]
                         (Application
                             (Identifier "oven")
-                            (Grouping (Amount (Quantity (Decimal 180 0) (Decimal 0 0) 0 celsius))))
-                    , Execute
+                            (Grouping (Amount (Quantity (Decimal 180 0) (Decimal 0 0) 0 celsius)))))
+                    , (0, Execute
                         (Application
                             (Identifier "task")
-                            (Text "Bacon strips onto bird"))
-                    , Execute
-                        (Variable [Identifier "preheat"])
-                    , Execute
-                        (Undefined)
-                    , Blank
-                    , Execute
+                            (Text "Bacon strips onto bird")))
+                    , (0, Execute
+                        (Variable [Identifier "preheat"]))
+                    , (0, Execute
+                        (Undefined))
+                    , (0, Blank)
+                    , (0, Execute
                         (Operation WaitBoth
                             (Variable [Identifier "w1"])
                             (Grouping (Operation WaitEither
                                 (Variable [Identifier "w2"])
-                                (Variable [Identifier "w3"]))))
-                    , Blank
-                    , Execute (Variable [Identifier "v1"])
-                    , Series
-                    , Execute (Variable [Identifier "v2"])
-                    , Assignment
+                                (Variable [Identifier "w3"])))))
+                    , (0, Blank)
+                    , (0, Execute (Variable [Identifier "v1"]))
+                    , (0, Series)
+                    , (0, Execute (Variable [Identifier "v2"]))
+                    , (0, Assignment
                         [Identifier "temp"]
                         (Application
                             (Identifier "record")
-                            (Text "Probe bird temperature"))
-                    , Execute
+                            (Text "Probe bird temperature")))
+                    , (0, Execute
                         (Object
                             (Tablet
-                                [ Binding (Label "Final temperature") (Variable [Identifier "temp"]) ]))
-                    ])
+                                [ Binding (Label "Final temperature") (Variable [Identifier "temp"]) ])))
+                    ]))
                 )]
   in
     Procedure

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -5,7 +5,7 @@ import Test.Hspec (Spec, hspec)
 import Core.System
 
 import CheckAbstractSyntax
-import CheckSkeletonParser
+import CheckSkeletonParser hiding (main)
 import CheckQuantityBehaviour hiding (main)
 import CheckTranslationStage hiding (main)
 

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -4,7 +4,7 @@ import Test.Hspec (Spec, hspec)
 
 import Core.System
 
-import CheckAbstractSyntax
+import CheckConcreteSyntax hiding (main)
 import CheckSkeletonParser hiding (main)
 import CheckQuantityBehaviour hiding (main)
 import CheckTranslationStage hiding (main)
@@ -16,6 +16,6 @@ main = do
 suite :: Spec
 suite = do
     checkQuantityBehaviour
-    checkAbstractSyntax
+    checkConcreteSyntax
     checkSkeletonParser
     checkTranslationStage


### PR DESCRIPTION
Reverse the attempt to have **megaparsec** render all the compilation errors, and instead gather details of a failure encountered during parsing phase as just one of the ways that compilation can fail. Rebuild a renderer of parse error messages and use the same machinery to render the various translation phase problems.