### PR TITLE
Colour tokens in compiler error messages

### DIFF
--- a/lib/Technique/Builtins.hs
+++ b/lib/Technique/Builtins.hs
@@ -26,68 +26,58 @@ builtinProcedures = intoMap (fmap (\p -> (functionName p, p))
 
 builtinProcedureTask :: Function
 builtinProcedureTask = Primitive
-    Procedure
+    emptyProcedure
         { procedureName = Identifier "task"
-        , procedureParams = []
         , procedureInput = [Type "Text"]
         , procedureOutput = [Type "()"] -- ?
         , procedureTitle = Just (Markdown "Task")
         , procedureDescription = Just (Markdown "A task to be executed by the person carrying out this role.")
-        , procedureBlock = Block []
         }
     undefined
 
 builtinProcedureRecord :: Function
 builtinProcedureRecord = Primitive
-    Procedure
+    emptyProcedure
         { procedureName = Identifier "record"
-        , procedureParams = []
         , procedureInput = [Type "Text"]
         , procedureOutput = [Type "Text"] -- ?
         , procedureTitle = Just (Markdown "Record")
         , procedureDescription = Just (Markdown "Input from the user to be parsed as a quantity.")
-        , procedureBlock = Block []
         }
     undefined
 
 -- the '|' operation
 builtinProcedureWaitEither :: Function
 builtinProcedureWaitEither = Primitive
-    Procedure
+    emptyProcedure
         { procedureName = Identifier "wait_either"
-        , procedureParams = []
         , procedureInput = [Type "*", Type "*"]
         , procedureOutput = [Type "()"]
         , procedureTitle = Just (Markdown "Wait Either")
         , procedureDescription = Just (Markdown "Wait for either of two values to be ready.")
-        , procedureBlock = Block []
         }
     undefined
 
 -- the '&' operation
 builtinProcedureWaitBoth :: Function
 builtinProcedureWaitBoth = Primitive
-    Procedure
+    emptyProcedure
         { procedureName = Identifier "wait_both"
-        , procedureParams = []
         , procedureInput = [Type "*", Type "*"]
         , procedureOutput = [Type "()"]
         , procedureTitle = Just (Markdown "Wait Both")
         , procedureDescription = Just (Markdown "Wait for two values to both be ready.")
-        , procedureBlock = Block []
         }
     undefined
 
 -- the '+' operation
 builtinProcedureCombineValues :: Function
 builtinProcedureCombineValues = Primitive
-    Procedure
+    emptyProcedure
         { procedureName = Identifier "combine_values"
-        , procedureParams = []
         , procedureInput = [Type "*", Type "*"]
         , procedureOutput = [Type "*"]
         , procedureTitle = Just (Markdown "Combine Two Values")
         , procedureDescription = Just (Markdown "Combine two values. This will involve coersion if the concrete types differ.")
-        , procedureBlock = Block []
         }
     undefined

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -101,11 +101,11 @@ instance Render FailureReason where
           in
             un <> ex
 
-        VariableAlreadyInUse i -> "Variable by the name of '" <> intoDocA i <> "' already defined."
-        ProcedureAlreadyDeclared i -> "Procedure by the name of '" <> intoDocA i <> "' already declared."
-        CallToUnknownProcedure i -> "Call to unknown procedure '" <> intoDocA i <> "'."
-        UseOfUnknownIdentifier i -> "Variable '" <> intoDocA i <> "' not in scope."
-        EncounteredUndefined -> "Encountered 'undefined' marker."
+        VariableAlreadyInUse i -> "Variable by the name of '" <> annotate VariableToken (intoDocA i) <> "' already defined."
+        ProcedureAlreadyDeclared i -> "Procedure by the name of '" <> annotate ProcedureToken (intoDocA i) <> "' already declared."
+        CallToUnknownProcedure i -> "Call to unknown procedure '" <> annotate ApplicationToken (intoDocA i) <> "'."
+        UseOfUnknownIdentifier i -> "Variable '" <> annotate VariableToken (intoDocA i) <> "' not in scope."
+        EncounteredUndefined -> "Encountered an " <> annotate ErrorToken "undefined" <> " marker."
 
 {-|
 ErrorItem is a bit overbearing, but we handle its /four/ cases by saying

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -166,12 +166,12 @@ instance Render CompilationError where
       let
         filename = pretty (sourceFilename source)
         contents = intoRope (sourceContents source)
-        offset = sourceOffset source
+        o = sourceOffset source
 
 -- Given an offset point where the error occured, split the input at that
 -- point.
 
-        (before,_) = splitRope offset contents
+        (before,_) = splitRope o contents
         (l,c) = calculatePositionEnd before
 
 -- Isolate the line on which the error occured. l and c are 1-origin here,
@@ -216,7 +216,7 @@ extractErrorBundle source bundle =
   let
     errors = bundleErrors bundle
     first = NonEmpty.head errors
-    (offset,unexpected,expected) = extractParseError first
+    (o,unexpected,expected) = extractParseError first
     pstate = bundlePosState bundle
     srcpos = pstateSourcePos pstate
 
@@ -233,19 +233,19 @@ extractErrorBundle source bundle =
     reason = ParsingFailed unexpected expected
 
     source' = source
-        { sourceOffset = offset + l + c
+        { sourceOffset = o + l + c
         }
   in
     CompilationError source' reason
 
 extractParseError :: ParseError T.Text Void -> (Int,[ErrorItem Char],[ErrorItem Char])
 extractParseError e = case e of
-    TrivialError offset unexpected0 expected0 ->
+    TrivialError o unexpected0 expected0 ->
       let
         unexpected = case unexpected0 of
             Just item -> item : []
             Nothing -> []
         expected = OrdSet.toList expected0
       in
-        (offset,unexpected,expected)
+        (o,unexpected,expected)
     FancyError _ _ -> error "Unexpected parser error"

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -37,7 +37,7 @@ instance Render Status where
     colourize = colourizeTechnique
     intoDocA status = case status of
         Ok -> annotate LabelToken "ok"
-        Failed e -> annotate ErrorToken "failed" <+> intoDocA e
+        Failed e -> intoDocA e
 
 data Source = Source
     { sourceContents :: Rope

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -30,7 +30,7 @@ import Text.Megaparsec.Pos (unPos)
 import Technique.Language hiding (Label)
 import Technique.Formatter
 
-data Status = Ok | Failed CompilationError
+data Status = Ok | Failed CompilationError | Reload
 
 instance Render Status where
     type Token Status = TechniqueToken
@@ -38,6 +38,7 @@ instance Render Status where
     intoDocA status = case status of
         Ok -> annotate LabelToken "ok"
         Failed e -> intoDocA e
+        Reload -> annotate MagicToken "Δ"
 
 data Source = Source
     { sourceContents :: Rope

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -30,6 +30,15 @@ import Text.Megaparsec.Pos (unPos)
 import Technique.Language hiding (Label)
 import Technique.Formatter
 
+data Status = Ok | Failed CompilationError
+
+instance Render Status where
+    type Token Status = TechniqueToken
+    colourize = colourizeTechnique
+    intoDocA status = case status of
+        Ok -> annotate LabelToken "ok"
+        Failed e -> annotate ErrorToken "failed" <+> intoDocA e
+
 data Source = Source
     { sourceContents :: Rope
     , sourceFilename :: FilePath
@@ -187,7 +196,7 @@ instance Render CompilationError where
         padding = replicateChar (c - 1) ' '
         caroted = replicateChar (numberOfCarots reason) '^'
       in
-        filename <> ":" <> linenum <> ":" <> colunum <> hardline <>
+        annotate StepToken filename <> ":" <> linenum <> ":" <> colunum <> hardline <>
         hardline <>
         pretty trimmed <> hardline <>
         pretty padding <> annotate ErrorToken (pretty caroted) <> hardline <>

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -107,7 +107,7 @@ instance Render FailureReason where
 
             ex = case expected of
                 [] -> emptyDoc
-                items -> "expected " <> hsep (punctuate comma (fmap (formatErrorItem SymbolToken) items)) <> "."
+                items -> "expecting " <> hcat (fancyPunctuate (fmap (formatErrorItem SymbolToken) items)) <> "."
           in
             un <> ex
 
@@ -117,6 +117,12 @@ instance Render FailureReason where
         UseOfUnknownIdentifier i -> "Variable '" <> annotate VariableToken (intoDocA i) <> "' not in scope."
         EncounteredUndefined -> "Encountered an " <> annotate ErrorToken "undefined" <> " marker."
 
+fancyPunctuate :: [Doc ann] -> [Doc ann]
+fancyPunctuate list = case list of
+    [] -> []
+    [x] -> [x]
+    (x1:x2:[]) -> x1 : ", or " : x2 : []
+    (x1:xs) -> x1 : ", " : fancyPunctuate xs
 {-|
 ErrorItem is a bit overbearing, but we handle its /four/ cases by saying
 single quotes around characters, double quotes around strings, /no/ quotes

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -70,7 +70,7 @@ data FailureReason
     | CallToUnknownProcedure Identifier
     | UseOfUnknownIdentifier Identifier
     | EncounteredUndefined
-    deriving Show
+    deriving (Show,Eq)
 
 instance Enum FailureReason where
     fromEnum x = case x of

--- a/lib/Technique/Failure.hs
+++ b/lib/Technique/Failure.hs
@@ -195,9 +195,14 @@ instance Render CompilationError where
             else offending
 
         padding = replicateChar (c - 1) ' '
-        caroted = replicateChar (numberOfCarots reason) '^'
+        num = numberOfCarots reason
+        caroted = replicateChar num '^'
+
+        columns = if num > 1
+            then colunum <> "-" <> pretty (c + num - 1)
+            else colunum
       in
-        annotate StepToken filename <> ":" <> linenum <> ":" <> colunum <> hardline <>
+        annotate StepToken filename <> ":" <> linenum <> ":" <> columns <> hardline <>
         hardline <>
         pretty trimmed <> hardline <>
         pretty padding <> annotate ErrorToken (pretty caroted) <> hardline <>

--- a/lib/Technique/Internal.hs
+++ b/lib/Technique/Internal.hs
@@ -118,14 +118,14 @@ data Step
 
 instance Located Step where
     locationOf step = case step of
-        Known offset _ -> offset
-        Bench offset _ -> offset
-        Depends offset _ -> offset
+        Known o _ -> o
+        Bench o _ -> o
+        Depends o _ -> o
         NoOp -> -2
-        Tuple offset _ -> offset
-        Asynchronous offset _ _ -> offset
-        Invocation offset _ _ _ -> offset
-        Nested offset _ -> offset
+        Tuple o _ -> o
+        Asynchronous o _ _ -> o
+        Invocation o _ _ _ -> o
+        Nested o _ -> o
 
 instance Semigroup Step where
     (<>) = mappend
@@ -134,7 +134,7 @@ instance Monoid Step where
     mempty = NoOp
     mappend NoOp s2 = s2
     mappend s1 NoOp = s1
-    mappend (Nested offset1 list1) (Nested _ list2) = Nested offset1 (append list1 list2)
-    mappend (Nested offset1 list1) s2 = Nested offset1 (snoc list1 s2)
+    mappend (Nested o1 list1) (Nested _ list2) = Nested o1 (append list1 list2)
+    mappend (Nested o1 list1) s2 = Nested o1 (snoc list1 s2)
     mappend s1 (Nested _ list2) = Nested (locationOf s1) (cons s1 list2)
     mappend s1 s2 = Nested (locationOf s1) (cons s1 (singleton s2))

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -114,12 +114,12 @@ data Statement
 
 instance Located Statement where
     locationOf statement = case statement of
-        Assignment offset _ _ -> offset
-        Execute offset _ -> offset
-        Comment offset _ -> offset
-        Declaration offset _ -> offset
-        Blank offset -> offset
-        Series offset -> offset
+        Assignment o _ _ -> o
+        Execute o _ -> o
+        Comment o _ -> o
+        Declaration o _ -> o
+        Blank o -> o
+        Series o -> o
 
 data Expression
     = Application Offset Identifier Expression     -- this had better turn out to be a procedure
@@ -136,16 +136,16 @@ data Expression
 
 instance Located Expression where
     locationOf expr = case expr of
-        Application offset _ _ -> offset
-        None offset -> offset
-        Text offset _ -> offset
-        Amount offset _ -> offset
-        Undefined offset -> offset
-        Object offset _ -> offset
-        Variable offset _ -> offset
-        Operation offset _ _ _ -> offset
-        Grouping offset _ -> offset
-        Restriction offset _ _ -> offset
+        Application o _ _ -> o
+        None o -> o
+        Text o _ -> o
+        Amount o _ -> o
+        Undefined o -> o
+        Object o _ -> o
+        Variable o _ -> o
+        Operation o _ _ _ -> o
+        Grouping o _ -> o
+        Restriction o _ _ -> o
 
 data Tablet
     = Tablet [Binding]

--- a/lib/Technique/Language.hs
+++ b/lib/Technique/Language.hs
@@ -69,7 +69,8 @@ unitType :: Type
 unitType = Type "()"
 
 data Procedure = Procedure
-    { procedureName :: Identifier
+    { procedureOffset :: Offset
+    , procedureName :: Identifier
     , procedureParams :: [Identifier]
     , procedureInput :: [Type]
     , procedureOutput :: [Type]
@@ -81,7 +82,8 @@ data Procedure = Procedure
 
 emptyProcedure :: Procedure
 emptyProcedure = Procedure
-    { procedureName = Identifier "none"
+    { procedureOffset = -1
+    , procedureName = Identifier "none"
     , procedureParams = []
     , procedureInput = [unitType]
     , procedureOutput = [unitType]
@@ -97,6 +99,9 @@ type Offset = Int
 
 class Located a where
     locationOf :: a -> Offset
+
+instance Located Procedure where
+    locationOf = procedureOffset
 
 data Statement
     = Assignment Offset [Identifier] Expression

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -544,12 +544,14 @@ pMarkdown = do
 
 pProcedureCode :: Parser Procedure
 pProcedureCode = do
+    offset <- getOffset
     (name,params,ins,out) <- pProcedureDeclaration <* skipSpace <* optional newline <* skipSpace
 
     block <- pBlock <* skipSpace <* optional newline
 
     return (Procedure
-        { procedureName = name
+        { procedureOffset = offset
+        , procedureName = name
         , procedureParams = params
         , procedureInput = ins
         , procedureOutput = out

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -90,6 +90,9 @@ Skip at least /one/ actual space character.
 skipSpace1 :: Parser ()
 skipSpace1 = void (hidden (some (char ' ' <|> char '\t')))
 
+digitChar0 :: Parser Char
+digitChar0 = label "a digit" $ digitChar
+
 pMagicLine :: Parser Int
 pMagicLine = do
     void (char '%') <?> "first line to begin with % character"
@@ -144,7 +147,7 @@ pProcedureDeclaration = do
     return (name,params,ins,out)
 
 identifierChar :: Parser Char
-identifierChar = hidden (lowerChar <|> digitChar <|> char '_' <|> char '\'')
+identifierChar = hidden (lowerChar <|> digitChar0 <|> char '_' <|> char '\'')
 
 
 -- these do NOT consume trailing space. That's for pExpression to do.
@@ -161,7 +164,7 @@ pIdentifiers1 :: Parser [Identifier]
 pIdentifiers1 = sepBy1 (pIdentifier <* skipSpace) (char ',' <* skipSpace)
 
 typeChar :: Parser Char
-typeChar = hidden (upperChar <|> lowerChar <|> digitChar)
+typeChar = hidden (upperChar <|> lowerChar <|> digitChar0)
 
 pType :: Parser Type
 pType = label "a valid type" $ try
@@ -204,7 +207,7 @@ unitLiteral = label "a units symbol" $ do
 
 numberLiteral :: Parser Int64
 numberLiteral = label "a number literal" $ do
-    digits <- some digitChar
+    digits <- some digitChar0
     let result = readMaybe digits
     case result of
         Just number -> return number
@@ -212,10 +215,10 @@ numberLiteral = label "a number literal" $ do
 
 decimalLiteral :: Parser Decimal
 decimalLiteral = label "a decimal literal" $ do
-    digits1 <- some digitChar
+    digits1 <- some digitChar0
     fraction <- optional (do
         void (char '.')
-        some digitChar)
+        some digitChar0)
 
     return (case fraction of
         Nothing ->
@@ -260,7 +263,7 @@ pQuantity =
         -- decimal, a space, and then one of the characters that starts an
         -- uncertainty, magnitude, or symbol.
         lookAhead (try (do
-            skipMany (digitChar <|> char '.' <|> char '-' <|> char ' ')
+            skipMany (digitChar0 <|> char '.' <|> char '-' <|> char ' ')
             void (char '±' <|> char '+' <|> char '×' <|> char 'x' <|> unitChar)
             ))
 
@@ -431,7 +434,7 @@ pExpression = do
         lookAhead (try (do
             skipMany identifierChar
             skipSpace1
-            void (identifierChar <|> digitChar <|> char '(' <|> char '\"')))
+            void (identifierChar <|> digitChar0 <|> char '(' <|> char '\"')))
 
         name <- pIdentifier
         -- ie at least one space

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -372,33 +372,33 @@ pAttribute =
 
 pExpression :: Parser Expression
 pExpression = do
-    offset <- getOffset
-    expr1 <- pTerm offset
+    o <- getOffset
+    expr1 <- pTerm o
     skipSpace
     rest <- (optional (try pOperation2))
     skipSpace
     case rest of
-        Just (oper,expr2)   -> return (Operation offset oper expr1 expr2)
+        Just (oper,expr2)   -> return (Operation o oper expr1 expr2)
         Nothing             -> return expr1
   where
-    pTerm offset =
-        pNone offset <|>
-        pUndefined offset <|>
-        pRestriction offset <|>
-        pGrouping offset <|>
-        pObject offset <|>
-        pApplication offset <|>
-        pLiteral offset <|>
-        pVariable offset
+    pTerm o =
+        pNone o <|>
+        pUndefined o <|>
+        pRestriction o <|>
+        pGrouping o <|>
+        pObject o <|>
+        pApplication o <|>
+        pLiteral o <|>
+        pVariable o
 
     pNone :: Offset -> Parser Expression
-    pNone offset = do
+    pNone o = do
         void (string "()")
-        return (None offset)
+        return (None o)
 
-    pUndefined offset = do
+    pUndefined o = do
         void (char '?')
-        return (Undefined offset)
+        return (Undefined o)
 
     pOperation2 = do                    -- 2 as in 2nd half
         operator <- pOperator
@@ -406,13 +406,13 @@ pExpression = do
         subexpr2 <- pExpression
         return (operator,subexpr2)
 
-    pRestriction offset = do
+    pRestriction o = do
         attr <- pAttribute
         hidden space
         block <- pBlock
-        return (Restriction offset attr block)
+        return (Restriction o attr block)
 
-    pGrouping offset = do
+    pGrouping o = do
         void (char '(')
         skipSpace
 
@@ -421,13 +421,13 @@ pExpression = do
         void (char ')')
         skipSpace
 
-        return (Grouping offset subexpr)
+        return (Grouping o subexpr)
 
-    pObject offset = do
+    pObject o = do
         tablet <- pTablet
-        return (Object offset tablet)
+        return (Object o tablet)
 
-    pApplication offset = do
+    pApplication o = do
         lookAhead (try (do
             skipMany identifierChar
             skipSpace1
@@ -438,32 +438,32 @@ pExpression = do
         skipSpace1
         -- FIXME better do this manually, not all valid
         subexpr <- pExpression
-        return (Application offset name subexpr)
+        return (Application o name subexpr)
 
-    pLiteral offset =
+    pLiteral o =
         (do
             str <- stringLiteral
-            return (Text offset (intoRope str))) <|>
+            return (Text o (intoRope str))) <|>
         (do
             qty <- pQuantity
-            return (Amount offset qty))
+            return (Amount o qty))
 
-    pVariable offset = do
+    pVariable o = do
         names <- pIdentifiers1
 
-        return (Variable offset names)
+        return (Variable o names)
 
 pStatement :: Parser Statement
 pStatement = do
-    offset <- getOffset
-    statement <- pAssignment offset <|>
-        pDeclaration offset <|>
-        pExecute offset <|>
-        pBlank offset <|>
-        pSeries offset
+    o <- getOffset
+    statement <- pAssignment o <|>
+        pDeclaration o <|>
+        pExecute o <|>
+        pBlank o <|>
+        pSeries o
     return statement
   where
-    pAssignment offset = label "an assignment" $ do
+    pAssignment o = label "an assignment" $ do
         lookAhead (try (do
             skipMany (identifierChar <|> char ',' <|> char ' ')
             void (char '=')))
@@ -472,27 +472,27 @@ pStatement = do
         void (char '=')
         hidden space
         expr <- pExpression
-        return (Assignment offset names expr)
+        return (Assignment o names expr)
 
-    pDeclaration offset = label "a declaration" $ do
+    pDeclaration o = label "a declaration" $ do
         lookAhead (try (do
             skipMany (identifierChar <|> char ',' <|> char ' ')
             void (char ':')))
 
         proc <- pProcedureCode
-        return (Declaration offset proc)
+        return (Declaration o proc)
 
-    pExecute offset = label "a value to execute" $ do
+    pExecute o = label "a value to execute" $ do
         expr <- pExpression
-        return (Execute offset expr)
+        return (Execute o expr)
 
-    pBlank offset = hidden $ do -- label "a blank line"
+    pBlank o = hidden $ do -- label "a blank line"
         void newline
-        return (Blank offset)
+        return (Blank o)
 
-    pSeries offset = do
+    pSeries o = do
         void (char ';')
-        return (Series offset)
+        return (Series o)
 
 ---------------------------------------------------------------------
 
@@ -544,13 +544,13 @@ pMarkdown = do
 
 pProcedureCode :: Parser Procedure
 pProcedureCode = do
-    offset <- getOffset
+    o <- getOffset
     (name,params,ins,out) <- pProcedureDeclaration <* skipSpace <* optional newline <* skipSpace
 
     block <- pBlock <* skipSpace <* optional newline
 
     return (Procedure
-        { procedureOffset = offset
+        { procedureOffset = o
         , procedureName = name
         , procedureParams = params
         , procedureInput = ins

--- a/lib/Technique/Parser.hs
+++ b/lib/Technique/Parser.hs
@@ -96,7 +96,7 @@ pMagicLine = do
     void spaceChar <?> "a space character"
     void (string "technique")
     void spaceChar <?> "a space character"
-    void (char 'v') <?> "the character v and then a number"
+    void (char 'v') <?> "the character 'v' and then a number"
     v <- numberLiteral <?> "the language version"
     void newline
     return (fromIntegral v)

--- a/lib/Technique/Translate.hs
+++ b/lib/Technique/Translate.hs
@@ -98,7 +98,7 @@ translateProcedure procedure =
         Left e -> throwError e
         Right (step,_) -> do
             let func = Subroutine procedure step
-            registerProcedure (locationOf step) func
+            registerProcedure (locationOf procedure) func
             return func
 
 {-|

--- a/lib/Technique/Translate.hs
+++ b/lib/Technique/Translate.hs
@@ -185,17 +185,17 @@ translateExpression expr = do
                 name <- lookupVariable o i
                 return (Depends o name)
 
-        Operation offset op subexpr1 subexpr2 ->
+        Operation o oper subexpr1 subexpr2 ->
           let
-            prim = case op of
+            prim = case oper of
                     WaitEither  -> builtinProcedureWaitEither
                     WaitBoth    -> builtinProcedureWaitBoth
                     Combine     -> builtinProcedureCombineValues
           in do
             step1 <- translateExpression subexpr1
             step2 <- translateExpression subexpr2
-            let tuple = Tuple offset [step1,step2]
-            return (Invocation offset attr prim tuple)
+            let tuple = Tuple o [step1,step2]
+            return (Invocation o attr prim tuple)
 
         Grouping _ subexpr ->
             translateExpression subexpr
@@ -210,7 +210,7 @@ or to a primative builtin. We have Invocation as the Step constructors for
 these cases.
 -}
 registerProcedure :: Offset -> Function -> Translate ()
-registerProcedure offset func = do
+registerProcedure o func = do
     env <- get
 
     let i = functionName func
@@ -218,7 +218,7 @@ registerProcedure offset func = do
     let defined = containsKey i known
 
     when defined $ do
-        failBecause offset (ProcedureAlreadyDeclared i)
+        failBecause o (ProcedureAlreadyDeclared i)
 
     let known' = insertKeyValue i func known
     let env' = env { environmentFunctions = known' }
@@ -239,13 +239,13 @@ failBecause o reason = do
 
 
 lookupVariable :: Offset -> Identifier -> Translate Name
-lookupVariable offset i = do
+lookupVariable o i = do
     env <- get
     let known = lookupKeyValue i (environmentVariables env)
 
     case known of
         Just name -> return name
-        Nothing -> failBecause offset (UseOfUnknownIdentifier i)
+        Nothing -> failBecause o (UseOfUnknownIdentifier i)
 
 {-|
 Identifiers are valid names but Names are unique, so that we can put
@@ -254,12 +254,12 @@ already declared name (TODO) and given the local use of the identifier a
 scope-local (or globally?) unique name.
 -}
 insertVariable :: Offset -> Identifier -> Translate Name
-insertVariable offset i = do
+insertVariable o i = do
     env <- get
     let known = environmentVariables env
 
     when (containsKey i known) $ do
-        failBecause offset (VariableAlreadyInUse i)
+        failBecause o (VariableAlreadyInUse i)
 
     let n = Name (singletonRope '!' <> unIdentifier i) -- TODO
 
@@ -309,28 +309,28 @@ a function call is made, look up to see if we actually know what it is.
 -}
 resolveFunctions :: Step -> Translate Step
 resolveFunctions step = case step of
-    Invocation offset attr func substep -> do
-        func' <- lookupFunction offset func
+    Invocation o attr func substep -> do
+        func' <- lookupFunction o func
         substep' <- resolveFunctions substep
-        return (Invocation offset attr func' substep')
+        return (Invocation o attr func' substep')
 
-    Tuple offset substeps -> do
+    Tuple o substeps -> do
         substeps' <- traverse resolveFunctions substeps
-        return (Tuple offset substeps')
+        return (Tuple o substeps')
 
-    Asynchronous offset names substep -> do
+    Asynchronous o names substep -> do
         substep' <- resolveFunctions substep
-        return (Asynchronous offset names substep')
+        return (Asynchronous o names substep')
 
-    Nested offset sublist -> do
+    Nested o sublist -> do
         let actual = toList sublist
         actual' <- traverse resolveFunctions actual
         let sublist' = fromList actual'
-        return (Nested offset sublist')
+        return (Nested o sublist')
 
-    Bench offset pairs -> do
+    Bench o pairs -> do
         pairs' <- traverse f pairs
-        return (Bench offset pairs')
+        return (Bench o pairs')
       where
         f :: (Label,Step) -> Translate (Label,Step)
         f (label,substep) = do
@@ -342,7 +342,7 @@ resolveFunctions step = case step of
     NoOp -> return step
 
 lookupFunction :: Offset -> Function -> Translate Function
-lookupFunction offset func = do
+lookupFunction o func = do
     env <- get
 
     let i = functionName func
@@ -350,7 +350,7 @@ lookupFunction offset func = do
         result = lookupKeyValue i known
 
     case result of
-        Nothing -> failBecause offset (CallToUnknownProcedure i)
+        Nothing -> failBecause o (CallToUnknownProcedure i)
         Just actual -> return actual
 
 {-|
@@ -362,8 +362,8 @@ setLocationFrom :: (Render a, Located a) => a -> Translate ()
 setLocationFrom thing = do
     env <- get
     let source = environmentSource env
-    let offset = locationOf thing
-    let source' = source { sourceOffset = offset }
+    let o = locationOf thing
+    let source' = source { sourceOffset = o }
     let env' = env { environmentSource = source' }
     put env'
 

--- a/package.yaml
+++ b/package.yaml
@@ -56,7 +56,7 @@ executables:
   technique:
     dependencies:
       - technique
-    ghc-options: -threaded -dynamic
+    ghc-options: -threaded
     source-dirs: src
     main: TechniqueMain.hs
     other-modules:
@@ -67,7 +67,7 @@ tests:
     dependencies:
       - hspec
       - technique
-    ghc-options: -threaded -dynamic
+    ghc-options: -threaded
     source-dirs:
       - tests
     main: TestSuite.hs

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -61,10 +61,10 @@ syntaxCheck procfile =
             abstract <- translationPhase source concrete
             debugR "abstract" abstract
             -- TODO extractionPhase
-            write "ok"
+            writeR Ok
             return 0)
         (\(e :: CompilationError) -> do
-            write ("failed: " <> render 78 e)
+            writeR (Failed e)
             return (exitCodeFor e))
 
 {-|

--- a/src/TechniqueUser.hs
+++ b/src/TechniqueUser.hs
@@ -46,7 +46,7 @@ commandCheckTechnique = do
             terminate code
         Cycle -> do
             -- use inotify to rebuild on changes
-            forever (syntaxCheck procfile >> waitForChange [procfile])
+            forever (syntaxCheck procfile >> waitForChange [procfile] >> writeR Reload)
 
 syntaxCheck :: FilePath -> Program None Int
 syntaxCheck procfile =

--- a/tests/CheckSkeletonParser.hs
+++ b/tests/CheckSkeletonParser.hs
@@ -289,7 +289,8 @@ checkSkeletonParser = do
         it "parses a declaration and block" $ do
             parseMaybe pProcedureCode "f : X -> Y\n{ x }\n"
                 `shouldBe` Just (emptyProcedure
-                    { procedureName = Identifier "f"
+                    { procedureOffset = 0
+                    , procedureName = Identifier "f"
                     , procedureInput = [Type "X"]
                     , procedureOutput = [Type "Y"]
                     , procedureBlock = Block [Execute 13 (Variable 13 [Identifier "x"])]

--- a/tests/CheckTranslationStage.hs
+++ b/tests/CheckTranslationStage.hs
@@ -39,9 +39,8 @@ checkTranslationStage = do
             result = runTranslate testEnv (translateExpression expr)
           in do
             case result of
-                Left (CompilationError _ failure) ->
+                Left (CompilationError _ failure) -> do
                     failure `shouldBe` EncounteredUndefined
-                Left _ -> fail "Incorrect CompilerFailure encountered"
                 Right _ -> fail "Should have emitted CompilerFailure"
 
         it "encountering unknown variable" $
@@ -52,7 +51,6 @@ checkTranslationStage = do
             case result of
                 Left (CompilationError _ failure) ->
                     failure `shouldBe` UseOfUnknownIdentifier (Identifier "y")
-                Left _ -> fail "Incorrect CompilerFailure encountered"
                 Right _ -> fail "Should have emitted CompilerFailure"
 
         it "encountering unknown procedure" $

--- a/tests/ExampleProcedure.hs
+++ b/tests/ExampleProcedure.hs
@@ -35,13 +35,10 @@ import Technique.Formatter () -- Render instances for main function
 
 exampleProcedureOven :: Procedure
 exampleProcedureOven =
-    Procedure
+    emptyProcedure
         { procedureName = Identifier "oven"
-        , procedureParams = []
         , procedureInput = [Type "Temperature"]
         , procedureOutput = [Type "()"] -- ?
-        , procedureTitle = Nothing
-        , procedureDescription = Nothing
         , procedureBlock = Block [ Execute 0 (Application 0 (Identifier "task") (Text 0 "Set oven temperature!")) ]
         }
 
@@ -91,7 +88,8 @@ exampleRoastTurkey =
                 ]
   in
     Procedure
-        { procedureName = Identifier "roast_turkey"
+        { procedureOffset = 0
+        , procedureName = Identifier "roast_turkey"
         , procedureParams = [Identifier "i", Identifier "j", Identifier "k"]
         , procedureInput = [i]
         , procedureOutput = [o]


### PR DESCRIPTION
Colour the unexpected (if any), expected tokens [for parsing phase] and emphasize identifiers as variables, applied functions, or procedure declcarations in the compiler error messages.