### PR TITLE
Fix naked bindings in Descriptives

### DIFF
--- a/src/language/types.rs
+++ b/src/language/types.rs
@@ -82,7 +82,7 @@ pub enum Descriptive<'i> {
     Text(&'i str),
     CodeBlock(Expression<'i>),
     Application(Invocation<'i>),
-    Binding(Invocation<'i>, Identifier<'i>),
+    Binding(Box<Descriptive<'i>>, Identifier<'i>),
 }
 
 // types for Steps within procedures


### PR DESCRIPTION
Fix handling of naked bindings in the text passages that are used for procedure descriptions or step descriptions.