### PR TITLE
Add Workflow to upload artifact to Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release
+on:
+    release:
+        types: [published]
+
+jobs:
+    build:
+        name: Build and Upload
+        runs-on: ubuntu-latest
+        steps:
+            - name: Clone project
+              uses: actions/checkout@v3
+
+            - name: Validate toolchain
+              run: |
+                  echo "RUST_VERSION=$(rustc --version | cut -d ' ' -f 2)" >> ${GITHUB_ENV}
+
+            - uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                      target/release
+                  key: cargo-${{ runner.os }}-${{ runner.arch}}-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+                  restore-keys: |
+                      cargo-${{ runner.os }}-${{ runner.arch}}-${{ env.RUST_VERSION }}-
+
+            - name: Build binary
+              run: |
+                  cargo build --release
+
+            - name: Upload binary to Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ github.ref_name }}
+                  files: target/release/technique


### PR DESCRIPTION
Add a new GitHub Actions Workflow to build the release binary and upload the resultant artifact to a Release.