### PR TITLE
Fix syntax highlighting in formatting and rendering

### DIFF
--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -363,14 +363,7 @@ impl<'i> Formatter<'i> {
         sub.append_application(invocation);
         sub.flush_current();
 
-        // Combine all fragments into a single atomic fragment to prevent wrapping
-        let mut combined = String::new();
-        for (_syntax, content) in &sub.fragments {
-            combined.push_str(&content);
-        }
-
-        // Return as a single fragment
-        vec![(Syntax::Invocation, Cow::Owned(combined))]
+        sub.fragments
     }
 
     fn render_binding(
@@ -403,13 +396,7 @@ impl<'i> Formatter<'i> {
         sub.append_variables(variables);
         sub.flush_current();
 
-        // Combine all fragments into a single atomic fragment to prevent wrapping
-        let mut combined = String::new();
-        for (_syntax, content) in &sub.fragments {
-            combined.push_str(&content);
-        }
-
-        vec![(Syntax::Structure, Cow::Owned(combined))]
+        sub.fragments
     }
 
     pub fn append_char(&mut self, c: char) {

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -342,13 +342,7 @@ impl<'i> Formatter<'i> {
                 sub.add_fragment_reference(Syntax::Neutral, " ");
                 sub.add_fragment_reference(Syntax::Structure, "}");
                 sub.flush_current();
-
-                let mut combined = String::new();
-                for (_syntax, content) in &sub.fragments {
-                    combined.push_str(&content);
-                }
-
-                vec![(Syntax::Structure, Cow::Owned(combined))]
+                sub.fragments
             }
         }
     }


### PR DESCRIPTION
Fix a regression in formatting and rendering of code blocks and bindings introduced when we improved error messages in #81.