### PR TITLE
Index declarations as symbols for LSP symbol search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +133,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +174,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -324,6 +382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +481,7 @@ name = "technique"
 version = "0.4.6"
 dependencies = [
  "clap",
+ "ignore",
  "lsp-server",
  "lsp-types",
  "owo-colors",
@@ -532,6 +600,25 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.1",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.5.16", features = [ "wrap_help" ] }
+ignore = "0.4"
 lsp-server = "0.7.9"
 lsp-types = "0.97"
 owo-colors = "4"

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -22,11 +22,11 @@ pub(crate) fn run_language_server() {
 
     // extract any initialization parameters passed from the editor.
     if let Ok(params) = connection.initialize(capabilities) {
-        let _params = serde_json::from_value::<InitializeParams>(params).unwrap();
+        let params = serde_json::from_value::<InitializeParams>(params).unwrap();
 
         info!("Technique Language Server starting on stdin");
 
-        let server = server::TechniqueLanguageServer::new();
+        let server = server::TechniqueLanguageServer::new(params);
 
         if let Err(e) = server.run(connection) {
             eprintln!("Server error: {}", e);

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -14,6 +14,8 @@ pub(crate) fn run_language_server() {
     let capabilities = serde_json::to_value(ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
         document_formatting_provider: Some(OneOf::Left(true)),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
         ..Default::default()
     })
     .unwrap();

--- a/src/editor/server.rs
+++ b/src/editor/server.rs
@@ -82,12 +82,6 @@ impl TechniqueLanguageServer {
             .method
             .as_str()
         {
-            "initialize" => {
-                let params: InitializeParams = from_value(req.params)?;
-                let result = self.handle_initialize(params)?;
-                let response = Response::new_ok(req.id, result);
-                sender(Message::Response(response))?;
-            }
             "textDocument/formatting" => {
                 let params: DocumentFormattingParams = from_value(req.params)?;
                 match self.handle_document_formatting(params) {
@@ -136,8 +130,8 @@ impl TechniqueLanguageServer {
             .as_str()
         {
             "initialized" => {
-                let _params: InitializedParams = from_value(notification.params)?;
-                self.handle_initialized()?;
+                let params: InitializedParams = from_value(notification.params)?;
+                self.handle_initialized(params)?;
             }
             "textDocument/didOpen" => {
                 let params: DidOpenTextDocumentParams = from_value(notification.params)?;
@@ -162,26 +156,12 @@ impl TechniqueLanguageServer {
         Ok(())
     }
 
-    fn handle_initialize(
-        &self,
-        _params: InitializeParams,
-    ) -> Result<InitializeResult, Box<dyn std::error::Error + Sync + Send>> {
-        info!("Language Server initializing");
-
-        Ok(InitializeResult {
-            server_info: None,
-            capabilities: ServerCapabilities {
-                text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::FULL,
-                )),
-                document_formatting_provider: Some(lsp_types::OneOf::Left(true)),
-                ..Default::default()
-            },
-        })
-    }
-
-    fn handle_initialized(&self) -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
-        info!("Technique Language Server initialized");
+    fn handle_initialized(
+        &mut self,
+        _params: InitializedParams,
+    ) -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
+        // Note: workspace folders are received in the initialize params, which are handled by
+        // connection.initialize() in mod.rs. If we need workspace info, we should pass it from there.
         Ok(())
     }
 


### PR DESCRIPTION
Index procedure declarations as "symbols" in the language server, making them available for document and project-wide symbol searches.

Among other things this involved a bit of cleanup in the initialization code path, and exposing the `textDocument/documentSymbol` and `workspace/symbol` capabilities.

To facilitate project-wide symbol search by a user, we add a cache and populate it with symbols from _all_ Technique files in the local project. The **ignore** crate is used so that files ignored by e.g. _.gitignore_ are omitted when searching.

Procedure declarations are sent as `SymbolKind::CONSTRUCTOR`, matching the context used in syntax highlighting.