### PR TITLE
Refine console output

### DIFF
--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -133,6 +133,15 @@ pub fn render_descriptive<'i>(descriptive: &'i Descriptive, renderer: &dyn Rende
     render_fragments(&sub.fragments, renderer)
 }
 
+/// Render a procedure or section title with its leading `#` marker.
+pub fn render_title(title: &str, renderer: &dyn Render) -> String {
+    let mut sub = Formatter::new(78);
+    sub.add_fragment_reference(Syntax::Header, "# ");
+    sub.add_fragment_reference(Syntax::Title, title);
+    sub.flush_current();
+    render_fragments(&sub.fragments, renderer)
+}
+
 pub fn render_function<'i>(function: &'i Function, renderer: &dyn Render) -> String {
     let mut sub = Formatter::new(78);
     sub.append_function(function);
@@ -169,14 +178,16 @@ pub fn render_scope<'i>(scope: &'i Scope, renderer: &dyn Render) -> String {
     let mut sub = Formatter::new(78);
     match scope {
         Scope::AttributeBlock { attributes, .. } => {
-            // Render attributes without indentation for error messages
             sub.append_attributes(attributes);
         }
-        _ => {
-            panic!("Do not use for anything other than rendering Attribute line examples");
+        Scope::DependentBlock { .. } | Scope::ParallelBlock { .. } => {
+            sub.append_step(scope);
         }
+        _ => unreachable!(),
     }
     render_fragments(&sub.fragments, renderer)
+        .trim_end()
+        .to_string()
 }
 
 /// Helper function to convert fragments to a styled string using a renderer

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -155,19 +155,28 @@ pub fn render_expression<'i>(expression: &'i Expression, renderer: &dyn Render) 
 }
 
 pub fn render_procedure_declaration<'i>(procedure: &'i Procedure, renderer: &dyn Render) -> String {
+    render_declaration(
+        procedure.name.value,
+        procedure.parameters.as_ref().map(|v| v.as_slice()),
+        procedure.signature.as_ref(),
+        renderer,
+    )
+}
+
+pub fn render_declaration<'i>(
+    name: &'i str,
+    parameters: Option<&'i [Identifier<'i>]>,
+    signature: Option<&'i Signature<'i>>,
+    renderer: &dyn Render,
+) -> String {
     let mut sub = Formatter::new(78);
-    sub.append(
-        Syntax::Declaration,
-        procedure
-            .name
-            .value,
-    );
-    if let Some(parameters) = &procedure.parameters {
+    sub.append(Syntax::Declaration, name);
+    if let Some(parameters) = parameters {
         sub.append_parameters(parameters);
     }
     sub.add_fragment_reference(Syntax::Neutral, " ");
     sub.add_fragment_reference(Syntax::Structure, ":");
-    if let Some(signature) = &procedure.signature {
+    if let Some(signature) = signature {
         sub.add_fragment_reference(Syntax::Neutral, " ");
         sub.append_signature(signature);
     }
@@ -645,7 +654,7 @@ impl<'i> Formatter<'i> {
     }
 
     // Output names surrounded by parenthesis
-    pub fn append_parameters(&mut self, variables: &'i Vec<Identifier>) {
+    pub fn append_parameters(&mut self, variables: &'i [Identifier]) {
         self.add_fragment_reference(Syntax::Structure, "(");
         for (i, variable) in variables
             .iter()

--- a/src/program/types.rs
+++ b/src/program/types.rs
@@ -109,6 +109,7 @@ pub enum Operation<'i> {
         ordinal: Ordinal<'i>,
         attributes: Vec<&'i [language::Attribute<'i>]>,
         description: Vec<Operation<'i>>,
+        source: &'i language::Scope<'i>,
         body: Box<Operation<'i>>,
         responses: Vec<&'i language::Response<'i>>,
     },
@@ -128,7 +129,7 @@ pub enum Operation<'i> {
 /// captured by the parser (`"1"`, `"a"`, `"iii"`, ...); `Parallel` has no
 /// captured form, its position deriving from its index in the surrounding
 /// `Sequence`.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Ordinal<'i> {
     Dependent(&'i str),
     Parallel,

--- a/src/runner/checks/driver.rs
+++ b/src/runner/checks/driver.rs
@@ -211,7 +211,7 @@ fn menu_shows_greyed_edit_when_unavailable() {
     let mut it = Interaction::begin(&[], Value::Unitus);
     it.handle(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, "I/1", &it).expect("draw");
+    draw(&mut out, "I/1", "→", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(written.contains("Edit"));
     assert!(written.contains("Skip"));
@@ -349,7 +349,7 @@ fn render_frozen_shows_only_triangle() {
     let dump = Value::Literali("1: lo\n2: eth0\n3: wlan0".to_string());
     let it = Interaction::begin(&[], dump);
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, "I/1", &it).expect("draw");
+    draw(&mut out, "I/1", "→", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(!written.contains('\n'));
     assert!(!written.contains("eth0"));
@@ -372,7 +372,7 @@ fn render_edit_shows_candidate_text() {
     it.handle(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
     it.handle(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, "I/1", &it).expect("draw");
+    draw(&mut out, "I/1", "→", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(written.contains("hello"));
 }
@@ -388,7 +388,7 @@ fn render_reason_replaces_menu() {
     it.handle(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
     it.handle(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, "I/1", &it).expect("draw");
+    draw(&mut out, "I/1", "→", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(!written.contains('\n'));
     assert!(written.contains('▶'));
@@ -400,7 +400,7 @@ fn render_reason_replaces_menu() {
 fn render_choices_lists_options() {
     let it = Interaction::begin(&["Yes", "No"], Value::Unitus);
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, "I/1", &it).expect("draw");
+    draw(&mut out, "I/1", "→", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(written.contains('▶'));
     assert!(written.contains("Yes"));

--- a/src/runner/checks/driver.rs
+++ b/src/runner/checks/driver.rs
@@ -82,7 +82,7 @@ fn console_step_writes_fqn_and_description() {
     p.step("local_network:I/1", "Check the cable.");
     let written = String::from_utf8(output).expect("utf8");
     assert!(written.contains("→ local_network:I/1"));
-    assert!(written.contains("  Check the cable."));
+    assert!(written.contains("    Check the cable."));
 }
 
 #[test]
@@ -92,7 +92,8 @@ fn console_enter_writes_fqn_and_title() {
     p.enter("I", "Setup");
     let written = String::from_utf8(output).expect("utf8");
     assert!(written.contains("↘ I"));
-    assert!(written.contains("  Setup"));
+    assert!(written.contains("Setup"));
+    assert!(!written.contains("    Setup"));
 }
 
 #[test]

--- a/src/runner/checks/driver.rs
+++ b/src/runner/checks/driver.rs
@@ -54,14 +54,13 @@ fn mock_records_offered_choices() {
 #[test]
 fn mock_records_enter_and_announce() {
     let mut p = Mock::new();
-    p.enter("I", "Setup");
+    p.enter("I");
     p.announce("Calling helper");
     assert_eq!(
         p.events(),
         &[
             Event::Enter {
                 qualified: "I".to_string(),
-                title: "Setup".to_string(),
             },
             Event::Announce("Calling helper".to_string()),
         ]
@@ -86,14 +85,12 @@ fn console_step_writes_fqn_and_description() {
 }
 
 #[test]
-fn console_enter_writes_fqn_and_title() {
+fn console_enter_writes_fqn() {
     let mut output: Vec<u8> = Vec::new();
     let mut p = Console::with_output(&mut output);
-    p.enter("I", "Setup");
+    p.enter("I");
     let written = String::from_utf8(output).expect("utf8");
     assert!(written.contains("↘ I"));
-    assert!(written.contains("Setup"));
-    assert!(!written.contains("    Setup"));
 }
 
 #[test]

--- a/src/runner/checks/driver.rs
+++ b/src/runner/checks/driver.rs
@@ -10,24 +10,30 @@ fn mock_returns_canned_answers_in_order() {
         UserInput::Skip,
         UserInput::Quit,
     ]);
-    assert_eq!(p.ask(&[], Value::Unitus), UserInput::Done(Value::Unitus));
-    assert_eq!(p.ask(&[], Value::Unitus), UserInput::Skip);
-    assert_eq!(p.ask(&[], Value::Unitus), UserInput::Quit);
+    assert_eq!(
+        p.ask("/I/1", &[], Value::Unitus),
+        UserInput::Done(Value::Unitus)
+    );
+    assert_eq!(p.ask("/I/1", &[], Value::Unitus), UserInput::Skip);
+    assert_eq!(p.ask("/I/1", &[], Value::Unitus), UserInput::Quit);
 }
 
 #[test]
 fn mock_records_step_and_ask_events() {
     let mut p = Mock::with_answers([UserInput::Done(Value::Unitus)]);
-    p.step("local_network:I/1", "Check the cable.");
-    let _ = p.ask(&[], Value::Unitus);
+    p.step("/local_network:I/1", "Check the cable.");
+    let _ = p.ask("/local_network:I/1", &[], Value::Unitus);
     assert_eq!(
         p.events(),
         &[
             Event::Step {
-                qualified: "local_network:I/1".to_string(),
+                qualified: "/local_network:I/1".to_string(),
                 description: "Check the cable.".to_string(),
             },
-            Event::Ask { choices: vec![] },
+            Event::Ask {
+                qualified: "/local_network:I/1".to_string(),
+                choices: vec![],
+            },
         ]
     );
 }
@@ -35,10 +41,11 @@ fn mock_records_step_and_ask_events() {
 #[test]
 fn mock_records_offered_choices() {
     let mut p = Mock::with_answers([UserInput::Done(Value::Literali("Yes".to_string()))]);
-    let _ = p.ask(&["Yes", "No"], Value::Unitus);
+    let _ = p.ask("I/1", &["Yes", "No"], Value::Unitus);
     assert_eq!(
         p.events(),
         &[Event::Ask {
+            qualified: "I/1".to_string(),
             choices: vec!["Yes".to_string(), "No".to_string()],
         }]
     );
@@ -69,7 +76,7 @@ fn mock_records_enter_leave_and_announce() {
 #[should_panic(expected = "Mock::ask called with no canned answers remaining")]
 fn mock_ask_without_answers_panics() {
     let mut p = Mock::new();
-    let _ = p.ask(&[], Value::Unitus);
+    let _ = p.ask("I/1", &[], Value::Unitus);
 }
 
 #[test]
@@ -207,7 +214,7 @@ fn menu_shows_greyed_edit_when_unavailable() {
     let mut it = Interaction::begin(&[], Value::Unitus);
     it.handle(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, &it).expect("draw");
+    draw(&mut out, "I/1", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(written.contains("Edit"));
     assert!(written.contains("Skip"));
@@ -345,7 +352,7 @@ fn render_frozen_shows_only_triangle() {
     let dump = Value::Literali("1: lo\n2: eth0\n3: wlan0".to_string());
     let it = Interaction::begin(&[], dump);
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, &it).expect("draw");
+    draw(&mut out, "I/1", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(!written.contains('\n'));
     assert!(!written.contains("eth0"));
@@ -368,7 +375,7 @@ fn render_edit_shows_candidate_text() {
     it.handle(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
     it.handle(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, &it).expect("draw");
+    draw(&mut out, "I/1", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(written.contains("hello"));
 }
@@ -384,7 +391,7 @@ fn render_reason_replaces_menu() {
     it.handle(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
     it.handle(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, &it).expect("draw");
+    draw(&mut out, "I/1", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(!written.contains('\n'));
     assert!(written.contains('▶'));
@@ -396,7 +403,7 @@ fn render_reason_replaces_menu() {
 fn render_choices_lists_options() {
     let it = Interaction::begin(&["Yes", "No"], Value::Unitus);
     let mut out: Vec<u8> = Vec::new();
-    draw(&mut out, &it).expect("draw");
+    draw(&mut out, "I/1", &it).expect("draw");
     let written = String::from_utf8(out).expect("utf8");
     assert!(written.contains('▶'));
     assert!(written.contains("Yes"));

--- a/src/runner/checks/driver.rs
+++ b/src/runner/checks/driver.rs
@@ -52,11 +52,10 @@ fn mock_records_offered_choices() {
 }
 
 #[test]
-fn mock_records_enter_leave_and_announce() {
+fn mock_records_enter_and_announce() {
     let mut p = Mock::new();
     p.enter("I", "Setup");
     p.announce("Calling helper");
-    p.leave("I");
     assert_eq!(
         p.events(),
         &[
@@ -65,9 +64,6 @@ fn mock_records_enter_leave_and_announce() {
                 title: "Setup".to_string(),
             },
             Event::Announce("Calling helper".to_string()),
-            Event::Leave {
-                qualified: "I".to_string(),
-            },
         ]
     );
 }

--- a/src/runner/checks/path.rs
+++ b/src/runner/checks/path.rs
@@ -104,19 +104,19 @@ fn procedure_segment() {
     stack.push(PathSegment::Procedure("local_network"));
     assert_eq!(stack.render(), "/local_network:");
 
-    // Procedure with a step: `/name:N`.
+    // Procedure with a step: `/name:/N`.
     let mut stack = QualifiedPath::new();
     stack.push(PathSegment::Procedure("make_coffee"));
     stack.push(PathSegment::DependentStep("2"));
-    assert_eq!(stack.render(), "/make_coffee:2");
+    assert_eq!(stack.render(), "/make_coffee:/2");
 
-    // Nested procedure: the inner frame replaces the outer prefix entirely.
+    // Nested procedure: each level is its own component.
     let mut stack = QualifiedPath::new();
     stack.push(PathSegment::Procedure("outer"));
     stack.push(PathSegment::DependentStep("1"));
     stack.push(PathSegment::Procedure("inner"));
     stack.push(PathSegment::DependentStep("2"));
-    assert_eq!(stack.render(), "/inner:2");
+    assert_eq!(stack.render(), "/outer:/1/inner:/2");
 }
 
 #[test]

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -746,6 +746,62 @@ test :
         .collect();
     assert_eq!(announcements, vec!["journal()"]);
 }
+    
+#[test]
+fn exec_step_solicits_command_then_judges() {
+    let source = r#"
+% technique v1
+
+test :
+
+1.  Run it { exec("ip addr") }
+        "#
+    .trim_ascii();
+    let document = parsing::parse(Path::new("Test.tq"), source).expect("parsed");
+    let mut program = translate(&document).expect("translated");
+    crate::linking::link(&mut program, &Library::stub()).expect("linked");
+
+    let mut fixture = StoreFixture::new("exec-command");
+    let prompt = Mock::with_answers([UserInput::Done(Value::Unitus)]);
+    let mut runner = Runner::new(
+        &program,
+        fixture.take_appender(),
+        HashSet::new(),
+        prompt,
+        Library::stub(),
+    );
+    runner
+        .run(Environment::new())
+        .expect("run");
+
+    let prompt = runner.into_driver();
+    // The exec is gated. A Command beat shows the script at the step's path,
+    // and only once commanded does the step's own verdict prompt judge it.
+    let commands: Vec<(&str, &str)> = prompt
+        .events()
+        .iter()
+        .filter_map(|e| {
+            if let Event::Command { qualified, script } = e {
+                Some((qualified.as_str(), script.as_str()))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let asks: Vec<&str> = prompt
+        .events()
+        .iter()
+        .filter_map(|e| {
+            if let Event::Ask { qualified, .. } = e {
+                Some(qualified.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(commands, vec![("/test:/1", "ip addr")]);
+    assert_eq!(asks, vec!["/test:/1"]);
+}
 
 #[test]
 fn loop_inside_step_produces_one_result() {

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use crate::language;
 use crate::language::{Identifier, Numeric as LangNumeric};
 use crate::parsing;
 use crate::program::{
@@ -72,11 +73,37 @@ impl Drop for StoreFixture {
     }
 }
 
+fn scope_for(ordinal: Ordinal<'static>) -> &'static language::Scope<'static> {
+    scope_with(ordinal, Vec::new())
+}
+
+fn scope_with(
+    ordinal: Ordinal<'static>,
+    description: Vec<language::Paragraph<'static>>,
+) -> &'static language::Scope<'static> {
+    let scope = match ordinal {
+        Ordinal::Dependent(s) => language::Scope::DependentBlock {
+            ordinal: s,
+            description,
+            subscopes: Vec::new(),
+            span: language::Span::default(),
+        },
+        Ordinal::Parallel => language::Scope::ParallelBlock {
+            bullet: '-',
+            description,
+            subscopes: Vec::new(),
+            span: language::Span::default(),
+        },
+    };
+    Box::leak(Box::new(scope))
+}
+
 fn step(ordinal: Ordinal<'static>, body: Operation<'static>) -> Operation<'static> {
     Operation::Step {
         ordinal,
         attributes: Vec::new(),
         description: Vec::new(),
+        source: scope_for(ordinal),
         body: Box::new(body),
         responses: Vec::new(),
     }
@@ -526,9 +553,12 @@ test :
             }
         })
         .collect();
-    // Step 1 only binds, so its description renders to empty. Step 2
-    // sees the binding established by step 1 and interpolates it.
-    assert_eq!(descriptions, vec!["", "Result: 42"]);
+    // Both steps render from their source paragraphs: the binding syntax
+    // and the interpolation reference are shown as-written, with ordinals.
+    assert_eq!(
+        descriptions,
+        vec!["1.  { 42 ~ answer }", "2.  Result: { answer }"]
+    );
 }
 
 #[test]
@@ -627,9 +657,8 @@ greet(name) :
             _ => None,
         })
         .collect();
-    // The argument "World" is bound to greet's `name` parameter and
-    // interpolated into the step description.
-    assert_eq!(steps, vec![("/main:/greet:/1", "Hello World")]);
+    // The step renders from its source paragraph, showing the template.
+    assert_eq!(steps, vec![("/main:/greet:/1", "1.  Hello { name }")]);
 }
 
 #[test]
@@ -746,7 +775,7 @@ test :
         .collect();
     assert_eq!(announcements, vec!["journal()"]);
 }
-    
+
 #[test]
 fn exec_step_solicits_command_then_judges() {
     let source = r#"
@@ -820,6 +849,7 @@ fn loop_inside_step_produces_one_result() {
         ordinal: Ordinal::Dependent("1"),
         attributes: Vec::new(),
         description: Vec::new(),
+        source: scope_for(Ordinal::Dependent("1")),
         body: Box::new(loop_op),
         responses: Vec::new(),
     };
@@ -867,6 +897,7 @@ fn repeat_loops_until_quit() {
         ordinal: Ordinal::Dependent("1"),
         attributes: Vec::new(),
         description: Vec::new(),
+        source: scope_for(Ordinal::Dependent("1")),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
     };
@@ -916,10 +947,17 @@ fn foreach_walks_body_once_per_list_element() {
     let description = Operation::String(vec![Fragment::Interpolation(Operation::Variable(
         Identifier::new("item"),
     ))]);
+    let source_paragraphs = vec![language::Paragraph::new(vec![
+        language::Descriptive::CodeInline(language::Expression::Variable(
+            Identifier::new("item"),
+            language::Span::default(),
+        )),
+    ])];
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         description: vec![description],
+        source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
     };
@@ -977,7 +1015,10 @@ fn foreach_walks_body_once_per_list_element() {
             _ => None,
         })
         .collect();
-    assert_eq!(steps, vec![("/[1]/a", "first"), ("/[2]/a", "second")]);
+    assert_eq!(
+        steps,
+        vec![("/[1]/a", "a.  { item }"), ("/[2]/a", "a.  { item }")]
+    );
 }
 
 #[test]
@@ -994,10 +1035,17 @@ fn foreach_over_seq_builtin_runs() {
     let description = Operation::String(vec![Fragment::Interpolation(Operation::Variable(
         Identifier::new("n"),
     ))]);
+    let source_paragraphs = vec![language::Paragraph::new(vec![
+        language::Descriptive::CodeInline(language::Expression::Variable(
+            Identifier::new("n"),
+            language::Span::default(),
+        )),
+    ])];
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         description: vec![description],
+        source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
     };
@@ -1055,7 +1103,11 @@ fn foreach_over_seq_builtin_runs() {
     // bound to each in turn.
     assert_eq!(
         steps,
-        vec![("/[1]/a", "1"), ("/[2]/a", "2"), ("/[3]/a", "3")]
+        vec![
+            ("/[1]/a", "a.  { n }"),
+            ("/[2]/a", "a.  { n }"),
+            ("/[3]/a", "a.  { n }"),
+        ]
     );
 }
 
@@ -1070,10 +1122,22 @@ fn foreach_destructures_tuple_elements() {
         Fragment::Text("/"),
         Fragment::Interpolation(Operation::Variable(Identifier::new("second"))),
     ]);
+    let source_paragraphs = vec![language::Paragraph::new(vec![
+        language::Descriptive::CodeInline(language::Expression::Variable(
+            Identifier::new("first"),
+            language::Span::default(),
+        )),
+        language::Descriptive::Text("/"),
+        language::Descriptive::CodeInline(language::Expression::Variable(
+            Identifier::new("second"),
+            language::Span::default(),
+        )),
+    ])];
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         description: vec![description],
+        source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
     };
@@ -1131,7 +1195,7 @@ fn foreach_destructures_tuple_elements() {
             _ => None,
         })
         .collect();
-    assert_eq!(steps, vec!["a/b", "c/d"]);
+    assert_eq!(steps, vec!["a.  { first } / { second }", "a.  { first } / { second }"]);
 }
 
 #[test]
@@ -1143,10 +1207,17 @@ fn foreach_widens_primitive_to_singleton() {
     let description = Operation::String(vec![Fragment::Interpolation(Operation::Variable(
         Identifier::new("item"),
     ))]);
+    let source_paragraphs = vec![language::Paragraph::new(vec![
+        language::Descriptive::CodeInline(language::Expression::Variable(
+            Identifier::new("item"),
+            language::Span::default(),
+        )),
+    ])];
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         description: vec![description],
+        source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
     };
@@ -1191,7 +1262,7 @@ fn foreach_widens_primitive_to_singleton() {
             _ => None,
         })
         .collect();
-    assert_eq!(steps, vec![("/[1]/a", "lonely")]);
+    assert_eq!(steps, vec![("/[1]/a", "a.  { item }")]);
 }
 
 #[test]
@@ -1386,7 +1457,7 @@ greet(name) :
             }
         })
         .collect();
-    assert_eq!(descriptions, vec!["Hello world"]);
+    assert_eq!(descriptions, vec!["1.  Hello { name }"]);
 }
 
 #[test]

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -370,10 +370,22 @@ fn section_walking() {
         .expect("run");
     let prompt = runner.into_driver();
     let events = prompt.events();
+    // A section descends with a `Section` heading (its numeral) and signs off
+    // at its close with a `Seal` carrying the section's qualified path.
+    let section_numerals: Vec<&str> = events
+        .iter()
+        .filter_map(|e| {
+            if let Event::Section { numeral, .. } = e {
+                Some(numeral.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
     let section_fqns: Vec<&str> = events
         .iter()
         .filter_map(|e| {
-            if let Event::Enter { qualified, .. } = e {
+            if let Event::Seal { qualified } = e {
                 Some(qualified.as_str())
             } else {
                 None
@@ -390,6 +402,7 @@ fn section_walking() {
             }
         })
         .collect();
+    assert_eq!(section_numerals, vec!["I"]);
     assert_eq!(section_fqns, vec!["/I"]);
     assert_eq!(step_fqns, vec!["/I/1"]);
 
@@ -420,7 +433,7 @@ fn section_walking() {
         .events()
         .iter()
         .find_map(|e| {
-            if let Event::Enter { title, .. } = e {
+            if let Event::Section { title, .. } = e {
                 Some(title.as_str())
             } else {
                 None

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1354,7 +1354,7 @@ test :
         .events()
         .iter()
         .filter_map(|e| {
-            if let Event::Ask { choices } = e {
+            if let Event::Ask { choices, .. } = e {
                 Some(choices)
             } else {
                 None

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -576,10 +576,10 @@ helper :
             }
         })
         .collect();
-    // The Step inside `helper` was reached and prompted, with the
-    // helper procedure as the FQN prefix (the outer `main` frame is
-    // overridden by the inner Procedure segment).
-    assert_eq!(step_fqns, vec!["/helper:1"]);
+    // The Step inside `helper` was reached and prompted, with the full
+    // enclosing hierarchy in the FQN: the entry `main` frame, the
+    // invoked `helper` frame, then the step.
+    assert_eq!(step_fqns, vec!["/main:/helper:/1"]);
 }
 
 #[test]
@@ -629,7 +629,7 @@ greet(name) :
         .collect();
     // The argument "World" is bound to greet's `name` parameter and
     // interpolated into the step description.
-    assert_eq!(steps, vec![("/greet:1", "Hello World")]);
+    assert_eq!(steps, vec![("/main:/greet:/1", "Hello World")]);
 }
 
 #[test]

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -51,11 +51,6 @@ pub trait Driver {
     /// subroutine — with its Qualified Name and title text (the `↘` marker).
     fn enter(&mut self, qualified: &str, title: &str);
 
-    /// Announce ascent back out of a named scope, with the Qualified Name of
-    /// the scope being left (the `↙` marker). Paired with `enter`; loop
-    /// iterations do not emit it.
-    fn leave(&mut self, qualified: &str);
-
     /// Surface an informational line — Loop body announcements,
     /// Execute / Unresolved Invoke announce-only, resume diagnostics.
     fn announce(&mut self, message: &str);
@@ -121,10 +116,6 @@ impl<W: Write> Driver for Console<W> {
         write_indented(&mut self.output, title);
     }
 
-    fn leave(&mut self, qualified: &str) {
-        let _ = writeln!(self.output, "{}", format!("↙ {}", qualified).green());
-    }
-
     fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
         // Grey descent bracket (the address), then the prose heading.
         let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).dark_grey());
@@ -146,9 +137,10 @@ impl<W: Write> Driver for Console<W> {
 
 /// Run one interactive prompt and settle it. The live `▶` line is drawn and
 /// re-drawn as keys arrive; on settle it is replaced by a `settle` verdict line
-/// (`→` for a step, `↙` for a scope close) in the outcome colour, which scrolls
-/// up into the record — except Quit, which leaves the scope unfinished (resume
-/// re-runs it) and just clears the row.
+/// (`→` for a step, `↙` for a scope close) in dark grey with a trailing verdict
+/// glyph (`✓` done, `⊘` skip, `✗` fail), which scrolls up into the record —
+/// except Quit, which leaves the scope unfinished (resume re-runs it) and just
+/// clears the row.
 fn prompt<W: Write>(
     out: &mut W,
     qualified: &str,
@@ -186,15 +178,18 @@ fn prompt<W: Write>(
         cursor::MoveToColumn(0),
         Clear(ClearType::CurrentLine)
     );
+    // The settle line stays dark grey like the descent introducer: colour is
+    // reserved for the formatter's syntax highlighting, so the verdict speaks
+    // through a trailing glyph (a shape channel) rather than line colour.
     match &result {
         UserInput::Done(_) => {
-            let _ = writeln!(out, "{}", format!("{} {}", settle, qualified).green());
+            let _ = writeln!(out, "{}", format!("{} {} ✓", settle, qualified).dark_grey());
         }
         UserInput::Skip => {
-            let _ = writeln!(out, "{}", format!("{} {}", settle, qualified).yellow());
+            let _ = writeln!(out, "{}", format!("{} {} ⊘", settle, qualified).dark_grey());
         }
         UserInput::Fail(_) => {
-            let _ = writeln!(out, "{}", format!("{} {}", settle, qualified).red());
+            let _ = writeln!(out, "{}", format!("{} {} ✗", settle, qualified).dark_grey());
         }
         UserInput::Quit => {}
     }
@@ -224,11 +219,6 @@ fn render_step<W: Write>(out: &mut W, fqn: &str, description: &str) {
 fn render_enter<W: Write>(out: &mut W, qualified: &str, title: &str) {
     let _ = writeln!(out, "↘ {}", qualified);
     write_indented(out, title);
-}
-
-/// Render a named scope's `↙` ascent line.
-fn render_leave<W: Write>(out: &mut W, qualified: &str) {
-    let _ = writeln!(out, "↙ {}", qualified);
 }
 
 /// Render a Section heading: its numeral and title, e.g.
@@ -780,10 +770,6 @@ impl<W: Write> Driver for Automatic<W> {
         render_enter(&mut self.output, qualified, title);
     }
 
-    fn leave(&mut self, qualified: &str) {
-        render_leave(&mut self.output, qualified);
-    }
-
     fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
         let _ = writeln!(self.output, "↘ {}", qualified);
         render_section(&mut self.output, numeral, title);
@@ -824,9 +810,6 @@ pub enum Event {
     Enter {
         qualified: String,
         title: String,
-    },
-    Leave {
-        qualified: String,
     },
     Section {
         qualified: String,
@@ -884,13 +867,6 @@ impl Driver for Mock {
             .push(Event::Enter {
                 qualified: fqn.to_string(),
                 title: title.to_string(),
-            });
-    }
-
-    fn leave(&mut self, fqn: &str) {
-        self.events
-            .push(Event::Leave {
-                qualified: fqn.to_string(),
             });
     }
 

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -17,6 +17,8 @@ use crossterm::style::{Attribute, SetAttribute, Stylize};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType};
 use crossterm::{cursor, queue};
 
+use crate::formatting::{Identity, Render};
+use crate::highlighting::Terminal;
 use crate::value::Value;
 
 /// Which driver walks a run: `Interactive` prompts the user, `Automatic` runs
@@ -81,6 +83,11 @@ pub trait Driver {
     /// `ask` but with no response choices, settling to the `↙` close marker;
     /// `produced` is the scope's value, offered for acceptance.
     fn seal(&mut self, qualified: &str, produced: Value) -> UserInput;
+
+    /// The syntax renderer for highlighting source fragments shown to the
+    /// user. `Console` returns the ANSI `Terminal` renderer; non-interactive
+    /// drivers return `Identity` (no markup).
+    fn renderer(&self) -> &'static dyn Render;
 }
 
 /// Interactive console prompt in a terminal. `step` / `section` / `announce`
@@ -112,20 +119,26 @@ impl<W: Write> Console<W> {
 impl<W: Write> Driver for Console<W> {
     fn step(&mut self, fqn: &str, description: &str) {
         let _ = writeln!(self.output, "{}", format!("→ {}", fqn).dark_grey());
+        let _ = writeln!(self.output);
         write_indented(&mut self.output, description);
+        let _ = writeln!(self.output);
     }
 
     fn enter(&mut self, qualified: &str, title: &str) {
-        // Grey: a descent opener is recessive scaffolding, not a status. Only
-        // the live prompt is ever blue.
         let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).dark_grey());
-        write_indented(&mut self.output, title);
+        if !title.is_empty() {
+            let _ = writeln!(self.output);
+            let _ = writeln!(self.output, "{}", title);
+        }
+        let _ = writeln!(self.output);
     }
 
     fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
-        // Grey descent bracket (the address), then the prose heading.
+        let renderer = self.renderer();
         let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).dark_grey());
-        render_section(&mut self.output, numeral, title);
+        let _ = writeln!(self.output);
+        render_section(&mut self.output, numeral, title, renderer);
+        let _ = writeln!(self.output);
     }
 
     fn announce(&mut self, message: &str) {
@@ -142,6 +155,10 @@ impl<W: Write> Driver for Console<W> {
 
     fn seal(&mut self, qualified: &str, produced: Value) -> UserInput {
         prompt(&mut self.output, qualified, "↙", &[], produced)
+    }
+
+    fn renderer(&self) -> &'static dyn Render {
+        &Terminal
     }
 }
 
@@ -178,19 +195,17 @@ fn prompt<W: Write>(
     result
 }
 
-/// Solicit the user's command to run a shell `exec`. The script is shown above
-/// the prompt as context so pressing `<Enter>` to run it is an informed act; it
-/// is also seeded as the candidate value so `<Esc>`→Edit can tweak an inline
-/// command before running, and Skip / Fail / Quit stay available. On run
-/// (`Done`) no settle line is printed — the command's output follows
-/// immediately, and the step's own verdict prompt judges the result; Skip and
-/// Fail decline the run and settle the step here with a grey verdict line.
+/// Solicit the user's approval to run a shell command. The script appears
+/// pre-filled on the `▶` prompt line as if already typed — Enter runs it,
+/// typing edits it in place, Esc opens the menu (Skip / Fail / Quit). On
+/// `Done` no settle line is printed — the command's output follows immediately
+/// and the step's own verdict prompt judges the result.
 fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserInput {
-    write_indented(out, script);
+    let field = edit(script.to_string(), Value::Literali(script.to_string()));
     let result = interact(
         out,
         qualified,
-        Interaction::begin(&[], Value::Literali(script.to_string())),
+        Interaction { field, menu: None, reason: None },
     );
     match &result {
         UserInput::Done(_) | UserInput::Quit => {}
@@ -242,38 +257,39 @@ fn interact<W: Write>(out: &mut W, qualified: &str, mut interaction: Interaction
     result
 }
 
-/// Write prompt text into the two character gutter, one line at a time.
-/// Console output sits in two bands: a one-glyph gutter (column 0) carrying
-/// the directional markers — `↘` descend, `→` step, `▶` prompt — and the body
-/// (column 2) carrying the qualified name, description, and prompt content.
-/// Raw subprocess output (`exec`) is streamed verbetum and thus flush-left at
-/// column 0.
+/// Write text indented by four spaces, replicating the canonical source
+/// layout the code formatter emits.
 fn write_indented<W: Write>(out: &mut W, text: &str) {
     for line in text.lines() {
-        let _ = writeln!(out, "  {}", line);
+        let _ = writeln!(out, "    {}", line);
     }
 }
 
-/// Render a step's `→` line and indented description.
+/// Render a step's `→` line and description.
 fn render_step<W: Write>(out: &mut W, fqn: &str, description: &str) {
     let _ = writeln!(out, "→ {}", fqn);
+    let _ = writeln!(out);
     write_indented(out, description);
+    let _ = writeln!(out);
 }
 
-/// Render a named scope's `↘` descent line and indented title.
+/// Render a named scope's `↘` descent line and title.
 fn render_enter<W: Write>(out: &mut W, qualified: &str, title: &str) {
     let _ = writeln!(out, "↘ {}", qualified);
-    write_indented(out, title);
+    if !title.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "{}", title);
+    }
+    let _ = writeln!(out);
 }
 
-/// Render a Section heading: its numeral and title, e.g.
-/// `II. Check internet connectivity`. Default colour — a heading is prose, not
-/// a status marker — so `Console` and `Automatic` share it.
-fn render_section<W: Write>(out: &mut W, numeral: &str, title: &str) {
+/// Render a Section heading: its numeral and title.
+fn render_section<W: Write>(out: &mut W, numeral: &str, title: &str, renderer: &dyn Render) {
+    let styled_numeral = renderer.style(crate::formatting::Syntax::StepItem, numeral);
     if title.is_empty() {
-        let _ = writeln!(out, "{}.", numeral);
+        let _ = writeln!(out, "{}.", styled_numeral);
     } else {
-        let _ = writeln!(out, "{}. {}", numeral, title);
+        let _ = writeln!(out, "{}. {}", styled_numeral, title);
     }
 }
 
@@ -816,8 +832,11 @@ impl<W: Write> Driver for Automatic<W> {
     }
 
     fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
+        let renderer = self.renderer();
         let _ = writeln!(self.output, "↘ {}", qualified);
-        render_section(&mut self.output, numeral, title);
+        let _ = writeln!(self.output);
+        render_section(&mut self.output, numeral, title, renderer);
+        let _ = writeln!(self.output);
     }
 
     fn announce(&mut self, message: &str) {
@@ -835,6 +854,10 @@ impl<W: Write> Driver for Automatic<W> {
 
     fn seal(&mut self, _qualified: &str, produced: Value) -> UserInput {
         UserInput::Done(produced)
+    }
+
+    fn renderer(&self) -> &'static dyn Render {
+        &Identity
     }
 }
 
@@ -975,6 +998,10 @@ impl Driver for Mock {
                 qualified: qualified.to_string(),
             });
         UserInput::Done(Value::Unitus)
+    }
+
+    fn renderer(&self) -> &'static dyn Render {
+        &Identity
     }
 }
 

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -176,25 +176,34 @@ fn prompt<W: Write>(
     produced: Value,
 ) -> UserInput {
     let result = interact(out, qualified, settle, Interaction::begin(choices, produced));
-    let glyph = match &result {
-        UserInput::Done(_) => Some("✓"),
-        UserInput::Skip => Some("⊘"),
-        UserInput::Fail(_) => Some("✗"),
-        UserInput::Quit => None,
-    };
-    if let Some(g) = glyph {
-        let col = settle
+    let col = settle
+        .chars()
+        .count() as u16
+        + 1
+        + qualified
             .chars()
             .count() as u16
-            + 1
-            + qualified
-                .chars()
-                .count() as u16
-            + 1;
-        let _ = queue!(out, cursor::MoveToColumn(col));
-        let _ = write!(out, "{}", g);
-        let _ = queue!(out, Clear(ClearType::UntilNewLine));
-        let _ = writeln!(out);
+        + 1;
+    match &result {
+        UserInput::Done(_) => {
+            let _ = queue!(out, cursor::MoveToColumn(col));
+            let _ = write!(out, "{}", "✓".green());
+            let _ = queue!(out, Clear(ClearType::UntilNewLine));
+            let _ = writeln!(out);
+        }
+        UserInput::Skip => {
+            let _ = queue!(out, cursor::MoveToColumn(col));
+            let _ = write!(out, "{}", "⊘".yellow());
+            let _ = queue!(out, Clear(ClearType::UntilNewLine));
+            let _ = writeln!(out);
+        }
+        UserInput::Fail(_) => {
+            let _ = queue!(out, cursor::MoveToColumn(col));
+            let _ = write!(out, "{}", "✗".red());
+            let _ = queue!(out, Clear(ClearType::UntilNewLine));
+            let _ = writeln!(out);
+        }
+        UserInput::Quit => {}
     }
     let _ = out.flush();
     result
@@ -213,24 +222,28 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
         "→",
         Interaction { field, menu: None, reason: None },
     );
-    let glyph = match &result {
-        UserInput::Done(_) | UserInput::Quit => None,
-        UserInput::Skip => Some("⊘"),
-        UserInput::Fail(_) => Some("✗"),
-    };
-    if let Some(g) = glyph {
-        let col = "→"
+    let col = "→"
+        .chars()
+        .count() as u16
+        + 1
+        + qualified
             .chars()
             .count() as u16
-            + 1
-            + qualified
-                .chars()
-                .count() as u16
-            + 1;
-        let _ = queue!(out, cursor::MoveToColumn(col));
-        let _ = write!(out, "{}", g);
-        let _ = queue!(out, Clear(ClearType::UntilNewLine));
-        let _ = writeln!(out);
+        + 1;
+    match &result {
+        UserInput::Done(_) | UserInput::Quit => {}
+        UserInput::Skip => {
+            let _ = queue!(out, cursor::MoveToColumn(col));
+            let _ = write!(out, "{}", "⊘".yellow());
+            let _ = queue!(out, Clear(ClearType::UntilNewLine));
+            let _ = writeln!(out);
+        }
+        UserInput::Fail(_) => {
+            let _ = queue!(out, cursor::MoveToColumn(col));
+            let _ = write!(out, "{}", "✗".red());
+            let _ = queue!(out, Clear(ClearType::UntilNewLine));
+            let _ = writeln!(out);
+        }
     }
     let _ = out.flush();
     result
@@ -635,7 +648,7 @@ fn draw<W: Write>(out: &mut W, qualified: &str, settle: &str, interaction: &Inte
         out,
         "{} {} ",
         format!("{} {}", settle, qualified).dark_grey(),
-        PROMPT_SYMBOL,
+        PROMPT_SYMBOL.blue(),
     )?;
 
     // Where the cursor lands; a value of `None` hides it.

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -13,7 +13,7 @@
 use std::io::{self, Write};
 
 use crossterm::event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use crossterm::style::{Attribute, SetAttribute};
+use crossterm::style::{Attribute, SetAttribute, Stylize};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType};
 use crossterm::{cursor, queue};
 
@@ -66,8 +66,9 @@ pub trait Driver {
     /// `choices` is non-empty the operator instead selects one of those
     /// response values, yielding `Done(Literali(choice))`. Skip, fail, and
     /// quit are available either way. `produced` is consumed: the driver
-    /// either moves it into the returned `Done` or discards it.
-    fn ask(&mut self, choices: &[&str], produced: Value) -> UserInput;
+    /// either moves it into the returned `Done` or discards it. `qualified` is
+    /// the step's Qualified Name, repeated on the live prompt line.
+    fn ask(&mut self, qualified: &str, choices: &[&str], produced: Value) -> UserInput;
 }
 
 /// Interactive console prompt in a terminal. `step` / `section` / `announce`
@@ -98,22 +99,24 @@ impl<W: Write> Console<W> {
 
 impl<W: Write> Driver for Console<W> {
     fn step(&mut self, fqn: &str, description: &str) {
-        render_step(&mut self.output, fqn, description);
+        let _ = writeln!(self.output, "{}", format!("→ {}", fqn).dark_grey());
+        write_indented(&mut self.output, description);
     }
 
     fn enter(&mut self, qualified: &str, title: &str) {
-        render_enter(&mut self.output, qualified, title);
+        let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).blue());
+        write_indented(&mut self.output, title);
     }
 
     fn leave(&mut self, qualified: &str) {
-        render_leave(&mut self.output, qualified);
+        let _ = writeln!(self.output, "{}", format!("↙ {}", qualified).green());
     }
 
     fn announce(&mut self, message: &str) {
         write_indented(&mut self.output, message);
     }
 
-    fn ask(&mut self, choices: &[&str], produced: Value) -> UserInput {
+    fn ask(&mut self, qualified: &str, choices: &[&str], produced: Value) -> UserInput {
         let mut interaction = Interaction::begin(choices, produced);
         // The interactive path is guarded on stdout being a terminal before
         // the walk begins, so a raw-mode failure here is an unexpected
@@ -123,7 +126,7 @@ impl<W: Write> Driver for Console<W> {
             return UserInput::Quit;
         }
         let result = loop {
-            if draw(&mut self.output, &interaction).is_err() {
+            if draw(&mut self.output, qualified, &interaction).is_err() {
                 break UserInput::Quit;
             }
             match event::read() {
@@ -137,15 +140,28 @@ impl<W: Write> Driver for Console<W> {
             }
         };
         let _ = disable_raw_mode();
-        // The prompt is a live affordance, not a record: clear it on settle so
-        // the next state line reuses the row rather than leaving spent ▶ lines.
-        // Restore the caret, hidden while a menu was shown.
+        // On settle the live `▶` prompt is replaced by a `→` verdict line in the
+        // outcome colour, which scrolls up into the permanent record — except
+        // Quit, which leaves the step unfinished (resume re-runs it) and so just
+        // clears the row. Restore the cursor, hidden while a menu was shown.
         let _ = queue!(
             self.output,
             cursor::Show,
             cursor::MoveToColumn(0),
             Clear(ClearType::CurrentLine)
         );
+        match &result {
+            UserInput::Done(_) => {
+                let _ = writeln!(self.output, "{}", format!("→ {}", qualified).green());
+            }
+            UserInput::Skip => {
+                let _ = writeln!(self.output, "{}", format!("→ {}", qualified).yellow());
+            }
+            UserInput::Fail(_) => {
+                let _ = writeln!(self.output, "{}", format!("→ {}", qualified).red());
+            }
+            UserInput::Quit => {}
+        }
         let _ = self
             .output
             .flush();
@@ -213,11 +229,20 @@ const MENU: [MenuItem; 4] = [
     MenuItem::Quit,
 ];
 
-/// Prompt prefix shown before an editable / read-only candidate, and its
-/// width in terminal columns (for placing the edit cursor). Later we will
-/// toggle between ▶ and ■
-const PROMPT_TEXT: &str = "▶ ";
-const PROMPT_WIDTH: u16 = 2;
+/// Glyph leading the live prompt line; the qualified path and a separator
+/// follow it before the interactive content. Later we will toggle between ▶
+/// and ■.
+const PROMPT_SYMBOL: &str = "▶";
+
+/// Number of columns spanned by the prompt prefix (the trianle ▶ and the
+/// qualified path of the current scope).
+fn prompt_prefix_width(qualified: &str) -> u16 {
+    // glyph + space + path + two-space separator
+    2 + qualified
+        .chars()
+        .count() as u16
+        + 2
+}
 
 /// Shown on the prompt line (after the `▶` prefix) when soliciting a reason for
 /// e.g. failure, replacing the menu; the typed buffer follows it.
@@ -490,56 +515,49 @@ impl Interaction {
 /// Draw the current interaction state onto the repeatedly-cleared prompt line.
 /// One line throughout: the confirm triangle, the Edit / response candidate, the
 /// menu, or — once Fail is chosen — the `Reason?` entry, which replaces the menu
-/// on the same line (keeping the `▶` prefix). The caret shows only where input
+/// on the same line (keeping the `▶` prefix). The cursor shows only where input
 /// is awaited at a point (confirm prompt, Edit buffer, reason field) and is
 /// hidden where a reverse-video highlight is the indicator (menu, choices).
-fn draw<W: Write>(out: &mut W, interaction: &Interaction) -> io::Result<()> {
+fn draw<W: Write>(out: &mut W, qualified: &str, interaction: &Interaction) -> io::Result<()> {
     queue!(out, cursor::MoveToColumn(0), Clear(ClearType::CurrentLine))?;
 
-    // Where the caret lands; `None` hides it.
+    // The prompt repeats the step's address in blue while the user works on
+    // the step.
+    let prefix = prompt_prefix_width(qualified);
+    write!(out, "{} {}  ", PROMPT_SYMBOL, qualified.blue())?;
+
+    // Where the cursor lands; a value of `None` hides it.
     let mut cursor_col: Option<u16> = None;
     match interaction.menu {
-        Some(active) => {
-            // The step is still running (timer ticking), so keep the same
-            // triangle; only the line's content changes.
-            write!(out, "{}", PROMPT_TEXT)?;
-            match &interaction.reason {
-                Some(reason) => {
-                    write!(out, "{}{}", REASON_PREFIX, reason.buffer)?;
-                    cursor_col = Some(
-                        PROMPT_WIDTH
-                            + REASON_PREFIX
-                                .chars()
-                                .count() as u16
-                            + reason.buffer[..reason.cursor]
-                                .chars()
-                                .count() as u16,
-                    );
-                }
-                None => render_menu(out, interaction, active)?,
+        Some(active) => match &interaction.reason {
+            Some(reason) => {
+                write!(out, "{}{}", REASON_PREFIX, reason.buffer)?;
+                cursor_col = Some(
+                    prefix
+                        + REASON_PREFIX
+                            .chars()
+                            .count() as u16
+                        + reason.buffer[..reason.cursor]
+                            .chars()
+                            .count() as u16,
+                );
             }
-        }
+            None => render_menu(out, interaction, active)?,
+        },
         None => match &interaction.field {
             Field::Edit { buffer, cursor, .. } => {
-                write!(out, "{}{}", PROMPT_TEXT, buffer)?;
+                write!(out, "{}", buffer)?;
                 cursor_col = Some(
-                    PROMPT_WIDTH
+                    prefix
                         + buffer[..*cursor]
                             .chars()
                             .count() as u16,
                 );
             }
             Field::Frozen { .. } => {
-                // The value (if any) was already shown above; the normal prompt
-                // is just the "play" triangle. The caret rests just past it: the
-                // step is awaiting input (an <Enter> to confirm, or typed text
-                // once editing). The exit/edit options are not advertised here —
-                // they appear only once <Esc> opens the menu.
-                write!(out, "{}", PROMPT_TEXT)?;
-                cursor_col = Some(PROMPT_WIDTH);
+                cursor_col = Some(prefix);
             }
             Field::Choose { choices, active } => {
-                write!(out, "{}", PROMPT_TEXT)?;
                 let refs: Vec<&str> = choices
                     .iter()
                     .map(String::as_str)
@@ -726,7 +744,7 @@ impl<W: Write> Driver for Automatic<W> {
         write_indented(&mut self.output, message);
     }
 
-    fn ask(&mut self, _choices: &[&str], produced: Value) -> UserInput {
+    fn ask(&mut self, _qualified: &str, _choices: &[&str], produced: Value) -> UserInput {
         UserInput::Done(produced)
     }
 }
@@ -759,6 +777,7 @@ pub enum Event {
     },
     Announce(String),
     Ask {
+        qualified: String,
         choices: Vec<String>,
     },
 }
@@ -819,9 +838,10 @@ impl Driver for Mock {
             .push(Event::Announce(message.to_string()));
     }
 
-    fn ask(&mut self, choices: &[&str], _produced: Value) -> UserInput {
+    fn ask(&mut self, qualified: &str, choices: &[&str], _produced: Value) -> UserInput {
         self.events
             .push(Event::Ask {
+                qualified: qualified.to_string(),
                 choices: choices
                     .iter()
                     .map(|c| c.to_string())

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -203,7 +203,9 @@ fn prompt<W: Write>(
             let _ = queue!(out, Clear(ClearType::UntilNewLine));
             let _ = writeln!(out);
         }
-        UserInput::Quit => {}
+        UserInput::Quit => {
+            let _ = writeln!(out);
+        }
     }
     let _ = out.flush();
     result
@@ -231,7 +233,10 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
             .count() as u16
         + 1;
     match &result {
-        UserInput::Done(_) | UserInput::Quit => {}
+        UserInput::Done(_) => {}
+        UserInput::Quit => {
+            let _ = writeln!(out);
+        }
         UserInput::Skip => {
             let _ = queue!(out, cursor::MoveToColumn(col));
             let _ = write!(out, "{}", "⊘".yellow());

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -233,8 +233,7 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
             .count() as u16
         + 1;
     match &result {
-        UserInput::Done(_) => {}
-        UserInput::Quit => {
+        UserInput::Done(_) | UserInput::Quit => {
             let _ = writeln!(out);
         }
         UserInput::Skip => {

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -50,8 +50,11 @@ pub trait Driver {
     fn step(&mut self, qualified: &str, description: &str);
 
     /// Announce descent into a named scope — a Section or an invoked
-    /// subroutine — with its Qualified Name and title text (the `↘` marker).
-    fn enter(&mut self, qualified: &str, title: &str);
+    /// subroutine — with its Qualified Name (the `↘` marker).
+    fn enter(&mut self, qualified: &str);
+
+    /// Display a line of formatted content at the left margin.
+    fn display(&mut self, content: &str);
 
     /// Surface an informational line — Loop body announcements,
     /// Execute / Unresolved Invoke announce-only, resume diagnostics.
@@ -124,12 +127,13 @@ impl<W: Write> Driver for Console<W> {
         let _ = writeln!(self.output);
     }
 
-    fn enter(&mut self, qualified: &str, title: &str) {
+    fn enter(&mut self, qualified: &str) {
         let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).dark_grey());
-        if !title.is_empty() {
-            let _ = writeln!(self.output);
-            let _ = writeln!(self.output, "{}", title);
-        }
+        let _ = writeln!(self.output);
+    }
+
+    fn display(&mut self, content: &str) {
+        let _ = writeln!(self.output, "{}", content);
         let _ = writeln!(self.output);
     }
 
@@ -300,14 +304,9 @@ fn render_step<W: Write>(out: &mut W, fqn: &str, description: &str) {
     let _ = writeln!(out);
 }
 
-/// Render a named scope's `↘` descent line and title.
-fn render_enter<W: Write>(out: &mut W, qualified: &str, title: &str) {
+/// Render a named scope's `↘` descent line.
+fn render_enter<W: Write>(out: &mut W, qualified: &str) {
     let _ = writeln!(out, "↘ {}", qualified);
-    if !title.is_empty() {
-        let _ = writeln!(out);
-        let _ = writeln!(out, "{}", title);
-    }
-    let _ = writeln!(out);
 }
 
 /// Render a Section heading: its numeral and title.
@@ -861,8 +860,14 @@ impl<W: Write> Driver for Automatic<W> {
         render_step(&mut self.output, fqn, description);
     }
 
-    fn enter(&mut self, qualified: &str, title: &str) {
-        render_enter(&mut self.output, qualified, title);
+    fn enter(&mut self, qualified: &str) {
+        render_enter(&mut self.output, qualified);
+        let _ = writeln!(self.output);
+    }
+
+    fn display(&mut self, content: &str) {
+        let _ = writeln!(self.output, "{}", content);
+        let _ = writeln!(self.output);
     }
 
     fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
@@ -916,7 +921,6 @@ pub enum Event {
     },
     Enter {
         qualified: String,
-        title: String,
     },
     Section {
         qualified: String,
@@ -973,13 +977,14 @@ impl Driver for Mock {
             });
     }
 
-    fn enter(&mut self, fqn: &str, title: &str) {
+    fn enter(&mut self, fqn: &str) {
         self.events
             .push(Event::Enter {
                 qualified: fqn.to_string(),
-                title: title.to_string(),
             });
     }
+
+    fn display(&mut self, _content: &str) {}
 
     fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
         self.events

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -175,21 +175,26 @@ fn prompt<W: Write>(
     choices: &[&str],
     produced: Value,
 ) -> UserInput {
-    let result = interact(out, qualified, Interaction::begin(choices, produced));
-    // The settle line stays dark grey like the descent introducer: colour is
-    // reserved for the formatter's syntax highlighting, so the verdict speaks
-    // through a trailing glyph (a shape channel) rather than line colour.
-    match &result {
-        UserInput::Done(_) => {
-            let _ = writeln!(out, "{}", format!("{} {} ✓", settle, qualified).dark_grey());
-        }
-        UserInput::Skip => {
-            let _ = writeln!(out, "{}", format!("{} {} ⊘", settle, qualified).dark_grey());
-        }
-        UserInput::Fail(_) => {
-            let _ = writeln!(out, "{}", format!("{} {} ✗", settle, qualified).dark_grey());
-        }
-        UserInput::Quit => {}
+    let result = interact(out, qualified, settle, Interaction::begin(choices, produced));
+    let glyph = match &result {
+        UserInput::Done(_) => Some("✓"),
+        UserInput::Skip => Some("⊘"),
+        UserInput::Fail(_) => Some("✗"),
+        UserInput::Quit => None,
+    };
+    if let Some(g) = glyph {
+        let col = settle
+            .chars()
+            .count() as u16
+            + 1
+            + qualified
+                .chars()
+                .count() as u16
+            + 1;
+        let _ = queue!(out, cursor::MoveToColumn(col));
+        let _ = write!(out, "{}", g);
+        let _ = queue!(out, Clear(ClearType::UntilNewLine));
+        let _ = writeln!(out);
     }
     let _ = out.flush();
     result
@@ -205,16 +210,27 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
     let result = interact(
         out,
         qualified,
+        "→",
         Interaction { field, menu: None, reason: None },
     );
-    match &result {
-        UserInput::Done(_) | UserInput::Quit => {}
-        UserInput::Skip => {
-            let _ = writeln!(out, "{}", format!("→ {} ⊘", qualified).dark_grey());
-        }
-        UserInput::Fail(_) => {
-            let _ = writeln!(out, "{}", format!("→ {} ✗", qualified).dark_grey());
-        }
+    let glyph = match &result {
+        UserInput::Done(_) | UserInput::Quit => None,
+        UserInput::Skip => Some("⊘"),
+        UserInput::Fail(_) => Some("✗"),
+    };
+    if let Some(g) = glyph {
+        let col = "→"
+            .chars()
+            .count() as u16
+            + 1
+            + qualified
+                .chars()
+                .count() as u16
+            + 1;
+        let _ = queue!(out, cursor::MoveToColumn(col));
+        let _ = write!(out, "{}", g);
+        let _ = queue!(out, Clear(ClearType::UntilNewLine));
+        let _ = writeln!(out);
     }
     let _ = out.flush();
     result
@@ -223,7 +239,7 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
 /// Drive one raw-mode interaction to a settled `UserInput`, leaving the prompt
 /// row cleared. Shared by the step/scope prompt and the exec command gate; the
 /// caller writes whatever record line it wants afterward.
-fn interact<W: Write>(out: &mut W, qualified: &str, mut interaction: Interaction) -> UserInput {
+fn interact<W: Write>(out: &mut W, qualified: &str, settle: &str, mut interaction: Interaction) -> UserInput {
     // The interactive path is guarded on stdout being a terminal before the
     // walk begins, so a raw-mode failure here is an unexpected terminal fault
     // rather than a redirect; bail by quitting.
@@ -232,7 +248,7 @@ fn interact<W: Write>(out: &mut W, qualified: &str, mut interaction: Interaction
         return UserInput::Quit;
     }
     let result = loop {
-        if draw(out, qualified, &interaction).is_err() {
+        if draw(out, qualified, settle, &interaction).is_err() {
             break UserInput::Quit;
         }
         match event::read() {
@@ -246,13 +262,7 @@ fn interact<W: Write>(out: &mut W, qualified: &str, mut interaction: Interaction
         }
     };
     let _ = disable_raw_mode();
-    // Restore the cursor, hidden while a menu was shown.
-    let _ = queue!(
-        out,
-        cursor::Show,
-        cursor::MoveToColumn(0),
-        Clear(ClearType::CurrentLine)
-    );
+    let _ = queue!(out, cursor::Show);
     let _ = out.flush();
     result
 }
@@ -324,19 +334,25 @@ const MENU: [MenuItem; 4] = [
     MenuItem::Quit,
 ];
 
-/// Glyph leading the live prompt line; the qualified path and a separator
-/// follow it before the interactive content. Later we will toggle between ▶
-/// and ■.
+/// Shell-prompt glyph placed after the path, before the cursor — the
+/// equivalent of `$` or `>` in a shell.
 const PROMPT_SYMBOL: &str = "▶";
 
-/// Number of columns spanned by the prompt prefix (the trianle ▶ and the
-/// qualified path of the current scope).
-fn prompt_prefix_width(qualified: &str) -> u16 {
-    // glyph + space + path + two-space separator
-    2 + qualified
+/// Number of columns spanned by the prompt prefix:
+/// `{settle} {path} {PROMPT_SYMBOL} `
+fn prompt_prefix_width(qualified: &str, settle: &str) -> u16 {
+    settle
         .chars()
         .count() as u16
-        + 2
+        + 1 // space after settle
+        + qualified
+            .chars()
+            .count() as u16
+        + 1 // space before prompt symbol
+        + PROMPT_SYMBOL
+            .chars()
+            .count() as u16
+        + 1 // space after prompt symbol
 }
 
 /// Shown on the prompt line (after the `▶` prefix) when soliciting a reason for
@@ -608,18 +624,19 @@ impl Interaction {
 }
 
 /// Draw the current interaction state onto the repeatedly-cleared prompt line.
-/// One line throughout: the confirm triangle, the Edit / response candidate, the
-/// menu, or — once Fail is chosen — the `Reason?` entry, which replaces the menu
-/// on the same line (keeping the `▶` prefix). The cursor shows only where input
-/// is awaited at a point (confirm prompt, Edit buffer, reason field) and is
-/// hidden where a reverse-video highlight is the indicator (menu, choices).
-fn draw<W: Write>(out: &mut W, qualified: &str, interaction: &Interaction) -> io::Result<()> {
+/// Layout: `{settle} {path} ▶ {content}` — the settle arrow and path are dark
+/// grey (matching the trace lines above), and ▶ is the shell-prompt character
+/// before the cursor/content area.
+fn draw<W: Write>(out: &mut W, qualified: &str, settle: &str, interaction: &Interaction) -> io::Result<()> {
     queue!(out, cursor::MoveToColumn(0), Clear(ClearType::CurrentLine))?;
 
-    // The prompt repeats the step's address in blue while the user works on
-    // the step.
-    let prefix = prompt_prefix_width(qualified);
-    write!(out, "{} {}  ", PROMPT_SYMBOL, qualified.blue())?;
+    let prefix = prompt_prefix_width(qualified, settle);
+    write!(
+        out,
+        "{} {} ",
+        format!("{} {}", settle, qualified).dark_grey(),
+        PROMPT_SYMBOL,
+    )?;
 
     // Where the cursor lands; a value of `None` hides it.
     let mut cursor_col: Option<u16> = None;

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -884,7 +884,7 @@ impl<W: Write> Driver for Automatic<W> {
 
     fn command(&mut self, _qualified: &str, script: &str) -> UserInput {
         write_indented(&mut self.output, script);
-        UserInput::Done(Value::Unitus)
+        UserInput::Done(Value::Literali(script.to_string()))
     }
 
     fn seal(&mut self, _qualified: &str, produced: Value) -> UserInput {

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -65,6 +65,12 @@ pub trait Driver {
     /// the step's Qualified Name, repeated on the live prompt line.
     fn ask(&mut self, qualified: &str, choices: &[&str], produced: Value) -> UserInput;
 
+    /// Gate a shell `exec` on the user's command: show the `script` to be run
+    /// and settle on the user's verdict. `Done` means run it now; Skip / Fail
+    /// decline the run and settle the step; Quit stops. `Automatic` runs
+    /// unconditionally, returning `Done` without prompting.
+    fn command(&mut self, qualified: &str, script: &str) -> UserInput;
+
     /// Open a Section: the grey `↘ /fqp` descent bracket (matching the `↙`
     /// the section's sign-off closes with) followed by its prose heading —
     /// numeral and title, e.g. `II. Check internet connectivity`.
@@ -130,6 +136,10 @@ impl<W: Write> Driver for Console<W> {
         prompt(&mut self.output, qualified, "→", choices, produced)
     }
 
+    fn command(&mut self, qualified: &str, script: &str) -> UserInput {
+        prompt_command(&mut self.output, qualified, script)
+    }
+
     fn seal(&mut self, qualified: &str, produced: Value) -> UserInput {
         prompt(&mut self.output, qualified, "↙", &[], produced)
     }
@@ -148,7 +158,57 @@ fn prompt<W: Write>(
     choices: &[&str],
     produced: Value,
 ) -> UserInput {
-    let mut interaction = Interaction::begin(choices, produced);
+    let result = interact(out, qualified, Interaction::begin(choices, produced));
+    // The settle line stays dark grey like the descent introducer: colour is
+    // reserved for the formatter's syntax highlighting, so the verdict speaks
+    // through a trailing glyph (a shape channel) rather than line colour.
+    match &result {
+        UserInput::Done(_) => {
+            let _ = writeln!(out, "{}", format!("{} {} ✓", settle, qualified).dark_grey());
+        }
+        UserInput::Skip => {
+            let _ = writeln!(out, "{}", format!("{} {} ⊘", settle, qualified).dark_grey());
+        }
+        UserInput::Fail(_) => {
+            let _ = writeln!(out, "{}", format!("{} {} ✗", settle, qualified).dark_grey());
+        }
+        UserInput::Quit => {}
+    }
+    let _ = out.flush();
+    result
+}
+
+/// Solicit the user's command to run a shell `exec`. The script is shown above
+/// the prompt as context so pressing `<Enter>` to run it is an informed act; it
+/// is also seeded as the candidate value so `<Esc>`→Edit can tweak an inline
+/// command before running, and Skip / Fail / Quit stay available. On run
+/// (`Done`) no settle line is printed — the command's output follows
+/// immediately, and the step's own verdict prompt judges the result; Skip and
+/// Fail decline the run and settle the step here with a grey verdict line.
+fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserInput {
+    write_indented(out, script);
+    let result = interact(
+        out,
+        qualified,
+        Interaction::begin(&[], Value::Literali(script.to_string())),
+    );
+    match &result {
+        UserInput::Done(_) | UserInput::Quit => {}
+        UserInput::Skip => {
+            let _ = writeln!(out, "{}", format!("→ {} ⊘", qualified).dark_grey());
+        }
+        UserInput::Fail(_) => {
+            let _ = writeln!(out, "{}", format!("→ {} ✗", qualified).dark_grey());
+        }
+    }
+    let _ = out.flush();
+    result
+}
+
+/// Drive one raw-mode interaction to a settled `UserInput`, leaving the prompt
+/// row cleared. Shared by the step/scope prompt and the exec command gate; the
+/// caller writes whatever record line it wants afterward.
+fn interact<W: Write>(out: &mut W, qualified: &str, mut interaction: Interaction) -> UserInput {
     // The interactive path is guarded on stdout being a terminal before the
     // walk begins, so a raw-mode failure here is an unexpected terminal fault
     // rather than a redirect; bail by quitting.
@@ -178,21 +238,6 @@ fn prompt<W: Write>(
         cursor::MoveToColumn(0),
         Clear(ClearType::CurrentLine)
     );
-    // The settle line stays dark grey like the descent introducer: colour is
-    // reserved for the formatter's syntax highlighting, so the verdict speaks
-    // through a trailing glyph (a shape channel) rather than line colour.
-    match &result {
-        UserInput::Done(_) => {
-            let _ = writeln!(out, "{}", format!("{} {} ✓", settle, qualified).dark_grey());
-        }
-        UserInput::Skip => {
-            let _ = writeln!(out, "{}", format!("{} {} ⊘", settle, qualified).dark_grey());
-        }
-        UserInput::Fail(_) => {
-            let _ = writeln!(out, "{}", format!("{} {} ✗", settle, qualified).dark_grey());
-        }
-        UserInput::Quit => {}
-    }
     let _ = out.flush();
     result
 }
@@ -783,6 +828,11 @@ impl<W: Write> Driver for Automatic<W> {
         UserInput::Done(produced)
     }
 
+    fn command(&mut self, _qualified: &str, script: &str) -> UserInput {
+        write_indented(&mut self.output, script);
+        UserInput::Done(Value::Unitus)
+    }
+
     fn seal(&mut self, _qualified: &str, produced: Value) -> UserInput {
         UserInput::Done(produced)
     }
@@ -817,6 +867,10 @@ pub enum Event {
         title: String,
     },
     Announce(String),
+    Command {
+        qualified: String,
+        script: String,
+    },
     Ask {
         qualified: String,
         choices: Vec<String>,
@@ -896,6 +950,19 @@ impl Driver for Mock {
         self.answers
             .pop_front()
             .expect("Mock::ask called with no canned answers remaining")
+    }
+
+    /// Records the command beat and auto-commands the run (`Done`) without
+    /// draining the answer queue — the exec gate is orthogonal to the step
+    /// verdicts a test drives. A test asserting gate behaviour inspects the
+    /// recorded `Command` event.
+    fn command(&mut self, qualified: &str, script: &str) -> UserInput {
+        self.events
+            .push(Event::Command {
+                qualified: qualified.to_string(),
+                script: script.to_string(),
+            });
+        UserInput::Done(Value::Unitus)
     }
 
     /// A scope sign-off auto-accepts (records `Done`) and records the event,

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -69,6 +69,17 @@ pub trait Driver {
     /// either moves it into the returned `Done` or discards it. `qualified` is
     /// the step's Qualified Name, repeated on the live prompt line.
     fn ask(&mut self, qualified: &str, choices: &[&str], produced: Value) -> UserInput;
+
+    /// Open a Section: the grey `↘ /fqp` descent bracket (matching the `↙`
+    /// the section's sign-off closes with) followed by its prose heading —
+    /// numeral and title, e.g. `II. Check internet connectivity`.
+    fn section(&mut self, qualified: &str, numeral: &str, title: &str);
+
+    /// Prompt the operator to sign off a completed structural scope — a Section
+    /// at its close, or the whole run at the entry procedure's close. Like
+    /// `ask` but with no response choices, settling to the `↙` close marker;
+    /// `produced` is the scope's value, offered for acceptance.
+    fn seal(&mut self, qualified: &str, produced: Value) -> UserInput;
 }
 
 /// Interactive console prompt in a terminal. `step` / `section` / `announce`
@@ -104,7 +115,9 @@ impl<W: Write> Driver for Console<W> {
     }
 
     fn enter(&mut self, qualified: &str, title: &str) {
-        let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).blue());
+        // Grey: a descent opener is recessive scaffolding, not a status. Only
+        // the live prompt is ever blue.
+        let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).dark_grey());
         write_indented(&mut self.output, title);
     }
 
@@ -112,61 +125,81 @@ impl<W: Write> Driver for Console<W> {
         let _ = writeln!(self.output, "{}", format!("↙ {}", qualified).green());
     }
 
+    fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
+        // Grey descent bracket (the address), then the prose heading.
+        let _ = writeln!(self.output, "{}", format!("↘ {}", qualified).dark_grey());
+        render_section(&mut self.output, numeral, title);
+    }
+
     fn announce(&mut self, message: &str) {
         write_indented(&mut self.output, message);
     }
 
     fn ask(&mut self, qualified: &str, choices: &[&str], produced: Value) -> UserInput {
-        let mut interaction = Interaction::begin(choices, produced);
-        // The interactive path is guarded on stdout being a terminal before
-        // the walk begins, so a raw-mode failure here is an unexpected
-        // terminal fault rather than a redirect; bail by quitting.
-        if enable_raw_mode().is_err() {
-            let _ = writeln!(self.output, "(could not enter raw mode)");
-            return UserInput::Quit;
-        }
-        let result = loop {
-            if draw(&mut self.output, qualified, &interaction).is_err() {
-                break UserInput::Quit;
-            }
-            match event::read() {
-                Ok(event::Event::Key(key)) if key.kind != KeyEventKind::Release => {
-                    if let Some(input) = interaction.handle(key) {
-                        break input;
-                    }
-                }
-                Ok(_) => {}
-                Err(_) => break UserInput::Quit,
-            }
-        };
-        let _ = disable_raw_mode();
-        // On settle the live `▶` prompt is replaced by a `→` verdict line in the
-        // outcome colour, which scrolls up into the permanent record — except
-        // Quit, which leaves the step unfinished (resume re-runs it) and so just
-        // clears the row. Restore the cursor, hidden while a menu was shown.
-        let _ = queue!(
-            self.output,
-            cursor::Show,
-            cursor::MoveToColumn(0),
-            Clear(ClearType::CurrentLine)
-        );
-        match &result {
-            UserInput::Done(_) => {
-                let _ = writeln!(self.output, "{}", format!("→ {}", qualified).green());
-            }
-            UserInput::Skip => {
-                let _ = writeln!(self.output, "{}", format!("→ {}", qualified).yellow());
-            }
-            UserInput::Fail(_) => {
-                let _ = writeln!(self.output, "{}", format!("→ {}", qualified).red());
-            }
-            UserInput::Quit => {}
-        }
-        let _ = self
-            .output
-            .flush();
-        result
+        prompt(&mut self.output, qualified, "→", choices, produced)
     }
+
+    fn seal(&mut self, qualified: &str, produced: Value) -> UserInput {
+        prompt(&mut self.output, qualified, "↙", &[], produced)
+    }
+}
+
+/// Run one interactive prompt and settle it. The live `▶` line is drawn and
+/// re-drawn as keys arrive; on settle it is replaced by a `settle` verdict line
+/// (`→` for a step, `↙` for a scope close) in the outcome colour, which scrolls
+/// up into the record — except Quit, which leaves the scope unfinished (resume
+/// re-runs it) and just clears the row.
+fn prompt<W: Write>(
+    out: &mut W,
+    qualified: &str,
+    settle: &str,
+    choices: &[&str],
+    produced: Value,
+) -> UserInput {
+    let mut interaction = Interaction::begin(choices, produced);
+    // The interactive path is guarded on stdout being a terminal before the
+    // walk begins, so a raw-mode failure here is an unexpected terminal fault
+    // rather than a redirect; bail by quitting.
+    if enable_raw_mode().is_err() {
+        let _ = writeln!(out, "(could not enter raw mode)");
+        return UserInput::Quit;
+    }
+    let result = loop {
+        if draw(out, qualified, &interaction).is_err() {
+            break UserInput::Quit;
+        }
+        match event::read() {
+            Ok(event::Event::Key(key)) if key.kind != KeyEventKind::Release => {
+                if let Some(input) = interaction.handle(key) {
+                    break input;
+                }
+            }
+            Ok(_) => {}
+            Err(_) => break UserInput::Quit,
+        }
+    };
+    let _ = disable_raw_mode();
+    // Restore the cursor, hidden while a menu was shown.
+    let _ = queue!(
+        out,
+        cursor::Show,
+        cursor::MoveToColumn(0),
+        Clear(ClearType::CurrentLine)
+    );
+    match &result {
+        UserInput::Done(_) => {
+            let _ = writeln!(out, "{}", format!("{} {}", settle, qualified).green());
+        }
+        UserInput::Skip => {
+            let _ = writeln!(out, "{}", format!("{} {}", settle, qualified).yellow());
+        }
+        UserInput::Fail(_) => {
+            let _ = writeln!(out, "{}", format!("{} {}", settle, qualified).red());
+        }
+        UserInput::Quit => {}
+    }
+    let _ = out.flush();
+    result
 }
 
 /// Write prompt text into the two character gutter, one line at a time.
@@ -196,6 +229,17 @@ fn render_enter<W: Write>(out: &mut W, qualified: &str, title: &str) {
 /// Render a named scope's `↙` ascent line.
 fn render_leave<W: Write>(out: &mut W, qualified: &str) {
     let _ = writeln!(out, "↙ {}", qualified);
+}
+
+/// Render a Section heading: its numeral and title, e.g.
+/// `II. Check internet connectivity`. Default colour — a heading is prose, not
+/// a status marker — so `Console` and `Automatic` share it.
+fn render_section<W: Write>(out: &mut W, numeral: &str, title: &str) {
+    if title.is_empty() {
+        let _ = writeln!(out, "{}.", numeral);
+    } else {
+        let _ = writeln!(out, "{}. {}", numeral, title);
+    }
 }
 
 /// One Esc-menu option. `Edit` reshapes the produced value in place; the rest
@@ -740,11 +784,20 @@ impl<W: Write> Driver for Automatic<W> {
         render_leave(&mut self.output, qualified);
     }
 
+    fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
+        let _ = writeln!(self.output, "↘ {}", qualified);
+        render_section(&mut self.output, numeral, title);
+    }
+
     fn announce(&mut self, message: &str) {
         write_indented(&mut self.output, message);
     }
 
     fn ask(&mut self, _qualified: &str, _choices: &[&str], produced: Value) -> UserInput {
+        UserInput::Done(produced)
+    }
+
+    fn seal(&mut self, _qualified: &str, produced: Value) -> UserInput {
         UserInput::Done(produced)
     }
 }
@@ -775,10 +828,18 @@ pub enum Event {
     Leave {
         qualified: String,
     },
+    Section {
+        qualified: String,
+        numeral: String,
+        title: String,
+    },
     Announce(String),
     Ask {
         qualified: String,
         choices: Vec<String>,
+    },
+    Seal {
+        qualified: String,
     },
 }
 
@@ -833,6 +894,15 @@ impl Driver for Mock {
             });
     }
 
+    fn section(&mut self, qualified: &str, numeral: &str, title: &str) {
+        self.events
+            .push(Event::Section {
+                qualified: qualified.to_string(),
+                numeral: numeral.to_string(),
+                title: title.to_string(),
+            });
+    }
+
     fn announce(&mut self, message: &str) {
         self.events
             .push(Event::Announce(message.to_string()));
@@ -850,6 +920,18 @@ impl Driver for Mock {
         self.answers
             .pop_front()
             .expect("Mock::ask called with no canned answers remaining")
+    }
+
+    /// A scope sign-off auto-accepts (records `Done`) and records the event,
+    /// rather than draining the `ask` answer queue — the structural-scope
+    /// close is orthogonal to the step verdicts a test drives. A test
+    /// asserting sign-off behaviour inspects the recorded `Seal` event.
+    fn seal(&mut self, qualified: &str, _produced: Value) -> UserInput {
+        self.events
+            .push(Event::Seal {
+                qualified: qualified.to_string(),
+            });
+        UserInput::Done(Value::Unitus)
     }
 }
 

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -164,24 +164,7 @@ pub fn evaluate<'i>(
             }
             Ok(last)
         }
-        Operation::Execute(executable) => match &executable.target {
-            ExecutableRef::Resolved(id) => {
-                let mut args = Vec::with_capacity(
-                    executable
-                        .arguments
-                        .len(),
-                );
-                for arg in &executable.arguments {
-                    args.push(evaluate(library, context, env, arg)?);
-                }
-                library.call(*id, context, &args)
-            }
-            ExecutableRef::Unresolved(target) => Err(RunnerError::UnknownFunction(
-                target
-                    .value
-                    .to_string(),
-            )),
-        },
+        Operation::Execute(executable) => dispatch(library, context, env, executable, None),
         Operation::Section { .. }
         | Operation::Step { .. }
         | Operation::Loop { .. }
@@ -228,6 +211,43 @@ pub(super) fn bind_names(
         }
     }
     Ok(())
+}
+
+/// Run a builtin function. When `override_args` is `None`, arguments are
+/// evaluated from the executable's AST. When `Some`, the pre-evaluated
+/// values are used directly (the Action path, where the user may have
+/// edited the command before confirming). This is the single site that
+/// calls into the Library.
+#[allow(dead_code)]
+pub fn dispatch<'i>(
+    library: &Library,
+    context: &Context,
+    env: &mut Environment,
+    executable: &crate::program::Executable<'i>,
+    override_args: Option<&[Value]>,
+) -> Result<Value, RunnerError> {
+    match &executable.target {
+        ExecutableRef::Resolved(id) => {
+            if let Some(args) = override_args {
+                library.call(*id, context, args)
+            } else {
+                let mut args = Vec::with_capacity(
+                    executable
+                        .arguments
+                        .len(),
+                );
+                for arg in &executable.arguments {
+                    args.push(evaluate(library, context, env, arg)?);
+                }
+                library.call(*id, context, &args)
+            }
+        }
+        ExecutableRef::Unresolved(target) => Err(RunnerError::UnknownFunction(
+            target
+                .value
+                .to_string(),
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/src/runner/library.rs
+++ b/src/runner/library.rs
@@ -14,10 +14,19 @@ use crate::value::{Numeric, Value};
 /// it.
 pub type Native = fn(&Context, &[Value]) -> Result<Value, RunnerError>;
 
+/// Whether a builtin is a pure function that computes a value or whether it
+/// is an action which performs a side-effect in the real world.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Nature {
+    Pure,
+    Action,
+}
+
 /// A function in the Library's table
 pub struct Builtin {
     pub name: &'static str,
     pub arity: usize,
+    pub nature: Nature,
     pub function: Native,
 }
 
@@ -40,26 +49,31 @@ impl Library {
                 Builtin {
                     name: "seq",
                     arity: 2,
+                    nature: Nature::Pure,
                     function: seq,
                 },
                 Builtin {
                     name: "zip",
                     arity: 2,
+                    nature: Nature::Pure,
                     function: zip,
                 },
                 Builtin {
                     name: "values",
                     arity: 1,
+                    nature: Nature::Pure,
                     function: values,
                 },
                 Builtin {
                     name: "labels",
                     arity: 1,
+                    nature: Nature::Pure,
                     function: labels,
                 },
                 Builtin {
                     name: "pairs",
                     arity: 1,
+                    nature: Nature::Pure,
                     function: pairs,
                 },
             ],
@@ -75,11 +89,13 @@ impl Library {
             Builtin {
                 name: "exec",
                 arity: 1,
+                nature: Nature::Action,
                 function: exec,
             },
             Builtin {
                 name: "now",
                 arity: 0,
+                nature: Nature::Pure,
                 function: now,
             },
         ]
@@ -108,6 +124,12 @@ impl Library {
     /// The name of the function at `id`.
     pub fn name(&self, id: ExecutableId) -> &'static str {
         self.functions[id.0].name
+    }
+
+    /// Whether the function at `id` is a commanded `Action` or a `Pure`
+    /// computation.
+    pub fn nature(&self, id: ExecutableId) -> Nature {
+        self.functions[id.0].nature
     }
 
     /// Call the function at `id` with the execution context and (already
@@ -290,61 +312,73 @@ impl Library {
                 Builtin {
                     name: "seq",
                     arity: 2,
+                    nature: Nature::Pure,
                     function: unit,
                 },
                 Builtin {
                     name: "zip",
                     arity: 2,
+                    nature: Nature::Pure,
                     function: unit,
                 },
                 Builtin {
                     name: "exec",
                     arity: 1,
+                    nature: Nature::Action,
                     function: unit,
                 },
                 Builtin {
                     name: "cmd",
                     arity: 1,
+                    nature: Nature::Action,
                     function: unit,
                 },
                 Builtin {
                     name: "now",
                     arity: 0,
+                    nature: Nature::Pure,
                     function: unit,
                 },
                 Builtin {
                     name: "uuid",
                     arity: 0,
+                    nature: Nature::Pure,
                     function: unit,
                 },
                 Builtin {
                     name: "timer",
                     arity: 1,
+                    nature: Nature::Pure,
                     function: unit,
                 },
                 Builtin {
                     name: "journal",
                     arity: 1,
+                    nature: Nature::Pure,
                     function: unit,
                 },
                 Builtin {
                     name: "click",
                     arity: 1,
+                    nature: Nature::Action,
                     function: unit,
                 },
                 Builtin {
                     name: "navigate",
                     arity: 1,
+                    nature: Nature::Action,
                     function: unit,
                 },
                 Builtin {
                     name: "select",
                     arity: 1,
+                    nature: Nature::Action,
                     function: unit,
                 },
                 Builtin {
                     name: "deselect",
                     arity: 1,
+                    nature: Nature::Action,
                     function: unit,
                 },
             ],

--- a/src/runner/path.rs
+++ b/src/runner/path.rs
@@ -46,42 +46,24 @@ impl<'i> QualifiedPath<'i> {
             .pop()
     }
 
-    /// Render the current path as a PFFTT absolute path string,
-    /// always rooted at `/`. A `Procedure` segment opens a fresh scope,
-    /// so only segments after the last `Procedure` are shown; the
-    /// procedure's name (with trailing `:`) joins immediately to the
-    /// root. Other segments are `/`-joined after the procedure prefix.
-    /// An attribute frame containing the `@*` reset role contributes
-    /// nothing.
+    /// Render the current path as a PFFTT absolute path string, always
+    /// rooted at `/`. The full enclosing hierarchy is shown: every scope
+    /// level is its own `/`-delimited component, with a `Procedure`
+    /// segment suffixed by `:`. An attribute frame containing the `@*`
+    /// reset role contributes nothing.
     ///
     /// A `foreach` or `repeat` keyword creates a scope as well. When
     /// iterating it is recorded using a path segment of the form `[n]`,
     /// one-origin. Thus `/5/[2]/a` would be the first substep within the
     /// second iteration of a scope within the 5th step of a Technique.
     pub fn render(&self) -> String {
-        let mut prefix: Option<&str> = None;
-        let mut start: usize = 0;
-        for (i, segment) in self
+        let pieces: Vec<String> = self
             .segments
-            .iter()
-            .enumerate()
-        {
-            if let PathSegment::Procedure(name) = segment {
-                prefix = Some(*name);
-                start = i + 1;
-            }
-        }
-
-        let pieces: Vec<String> = self.segments[start..]
             .iter()
             .filter_map(render_segment)
             .collect();
 
         let mut text = String::from("/");
-        if let Some(name) = prefix {
-            text.push_str(name);
-            text.push(':');
-        }
         text.push_str(&pieces.join("/"));
         text
     }
@@ -94,7 +76,7 @@ fn render_segment(segment: &PathSegment) -> Option<String> {
         PathSegment::ParallelStep(index) => Some(format!("-{}", index)),
         PathSegment::Iteration(number) => Some(format!("[{}]", number)), // you can't "index" into it!
         PathSegment::Attributes(frame) => render_attributes(frame),
-        PathSegment::Procedure(_) => None,
+        PathSegment::Procedure(name) => Some(format!("{}:", name)),
     }
 }
 

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -325,18 +325,24 @@ impl<'i, D: Driver> Runner<'i, D> {
                 // is dropped on return, leaving the caller's `env` untouched.
                 let result = self.walk(&mut local, &subroutine.body);
 
+                // An invoked procedure is a structural scope: the operator signs
+                // it off at its close, like a Section, before control returns to
+                // the caller. A Quit or error walk skips the prompt — the
+                // procedure did not complete.
                 if name.is_some() {
-                    let descended = self
+                    let qualified = self
                         .path
                         .render();
                     self.path
                         .pop();
-                    if completed(&result) {
-                        self.driver
-                            .leave(&descended);
+                    match result {
+                        Ok(Outcome::Stopped) => Ok(Outcome::Stopped),
+                        Ok(outcome) => self.seal_scope(&qualified, outcome),
+                        Err(error) => Err(error),
                     }
+                } else {
+                    result
                 }
-                result
             }
             SubroutineRef::Unresolved(id) => {
                 self.driver
@@ -680,16 +686,6 @@ fn describe_loop(
 
 fn describe_execute(function: &str) -> String {
     format!("{}()", function)
-}
-
-/// Whether a scope's walk ran to completion. The `↙` close line is emitted
-/// only then — never on a Quit (`Stopped`) or an error unwind, where the scope
-/// did not finish and a green close would misread as success.
-fn completed(result: &Result<Outcome, RunnerError>) -> bool {
-    match result {
-        Ok(Outcome::Stopped) | Err(_) => false,
-        Ok(_) => true,
-    }
 }
 
 /// Lift a `UserInput` from the prompt into the runner's `Outcome`.

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -370,6 +370,22 @@ impl<'i, D: Driver> Runner<'i, D> {
                     .as_ref()
                     .map(|n| n.value);
                 if let Some(name) = name {
+                    self.path
+                        .push(PathSegment::Procedure(name));
+                    let descended = self
+                        .path
+                        .render();
+                    if self
+                        .completed
+                        .contains(&descended)
+                    {
+                        self.path
+                            .pop();
+                        return Ok(Outcome::Done(Value::Unitus));
+                    }
+                    self.path
+                        .pop();
+
                     let qualified = self
                         .path
                         .render();
@@ -384,11 +400,9 @@ impl<'i, D: Driver> Runner<'i, D> {
                     };
                     self.appender
                         .append(&record)?;
+
                     self.path
                         .push(PathSegment::Procedure(name));
-                    let descended = self
-                        .path
-                        .render();
                     let title_text = match subroutine.title {
                         Some(t) => crate::formatting::formatter::render_title(
                             t,
@@ -536,10 +550,18 @@ impl<'i, D: Driver> Runner<'i, D> {
     ) -> Result<Outcome, RunnerError> {
         self.path
             .push(PathSegment::Section(numeral));
-        let result = self.perform_section(env, numeral, title, body);
         let qualified = self
             .path
             .render();
+        if self
+            .completed
+            .contains(&qualified)
+        {
+            self.path
+                .pop();
+            return Ok(Outcome::Done(Value::Unitus));
+        }
+        let result = self.perform_section(env, numeral, title, body);
         self.path
             .pop();
         // A section is a structural scope: the operator signs it off at its

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -569,7 +569,7 @@ impl<'i, D: Driver> Runner<'i, D> {
             .collect();
         let input = self
             .driver
-            .ask(&choices, produced);
+            .ask(qualified, &choices, produced);
 
         // Quit halts the walk and is recorded as a Stop lifecycle event at the
         // root path, distinguishing a deliberate stop from a crash (which records

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -389,8 +389,15 @@ impl<'i, D: Driver> Runner<'i, D> {
                     let descended = self
                         .path
                         .render();
+                    let title_text = match subroutine.title {
+                        Some(t) => crate::formatting::formatter::render_title(
+                            t,
+                            self.driver.renderer(),
+                        ),
+                        None => String::new(),
+                    };
                     self.driver
-                        .enter(&descended, "");
+                        .enter(&descended, &title_text);
                 }
 
                 // Walk the body against the callee's own environment; `local`
@@ -576,9 +583,10 @@ impl<'i, D: Driver> Runner<'i, D> {
         let Operation::Step {
             ordinal,
             attributes,
-            description,
+            source,
             body,
             responses,
+            ..
         } = op
         else {
             unreachable!("walk_step called with non-Step operation");
@@ -598,7 +606,14 @@ impl<'i, D: Driver> Runner<'i, D> {
             .path
             .render();
 
-        let result = self.perform_step(env, &qualified, body, description, responses);
+        let result = self.perform_step(
+            env,
+            &qualified,
+            ordinal,
+            body,
+            source,
+            responses,
+        );
 
         self.path
             .pop();
@@ -614,8 +629,9 @@ impl<'i, D: Driver> Runner<'i, D> {
         &mut self,
         env: &mut Environment,
         qualified: &str,
+        _ordinal: &Ordinal<'i>,
         body: &'i Operation<'i>,
-        description: &'i [Operation<'i>],
+        source: &'i language::Scope<'i>,
         responses: &[&'i language::Response<'i>],
     ) -> Result<Outcome, RunnerError> {
         if self
@@ -640,23 +656,13 @@ impl<'i, D: Driver> Runner<'i, D> {
         self.appender
             .append(&begin)?;
 
-        // Show the step's heading and description before walking its body,
-        // so any output the body streams (e.g. exec) appears beneath the step
-        // it belongs to rather than ahead of it. The description interpolates
-        // only values bound by enclosing scopes, so it reads cleanly here.
-        let mut description_text = String::new();
-        for op in description {
-            if !description_text.is_empty() {
-                description_text.push('\n');
-            }
-            match super::evaluator::evaluate(&self.library, &self.context, env, op)? {
-                Value::Literali(s) => description_text.push_str(&s),
-                other => description_text.push_str(&other.to_string()),
-            }
-        }
+        let step_text = crate::formatting::formatter::render_scope(
+            source,
+            self.driver.renderer(),
+        );
 
         self.driver
-            .step(qualified, &description_text);
+            .step(qualified, &step_text);
 
         let produced = match self.walk(env, body)? {
             Outcome::Stopped => return Ok(Outcome::Stopped),
@@ -755,6 +761,7 @@ impl<'i, D: Driver> Runner<'i, D> {
         Ok(outcome)
     }
 }
+
 
 fn describe_loop(
     names: &[crate::language::Identifier<'_>],

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -151,6 +151,27 @@ impl<'i, D: Driver> Runner<'i, D> {
         if let Some(name) = name {
             self.path
                 .push(PathSegment::Procedure(name));
+            let qualified = self
+                .path
+                .render();
+            self.driver
+                .enter(&qualified);
+            let declaration = crate::formatting::formatter::render_declaration(
+                name,
+                entry.parameters,
+                entry.signature,
+                self.driver.renderer(),
+            );
+            self.driver
+                .display(&declaration);
+            if let Some(t) = entry.title {
+                let title_text = crate::formatting::formatter::render_title(
+                    t,
+                    self.driver.renderer(),
+                );
+                self.driver
+                    .display(&title_text);
+            }
         }
         let result = self.walk(&mut env, &entry.body);
         // A named entry procedure is a structural scope: a completed run closes
@@ -403,15 +424,24 @@ impl<'i, D: Driver> Runner<'i, D> {
 
                     self.path
                         .push(PathSegment::Procedure(name));
-                    let title_text = match subroutine.title {
-                        Some(t) => crate::formatting::formatter::render_title(
+                    self.driver
+                        .enter(&descended);
+                    let declaration = crate::formatting::formatter::render_declaration(
+                        name,
+                        subroutine.parameters,
+                        subroutine.signature,
+                        self.driver.renderer(),
+                    );
+                    self.driver
+                        .display(&declaration);
+                    if let Some(t) = subroutine.title {
+                        let title_text = crate::formatting::formatter::render_title(
                             t,
                             self.driver.renderer(),
-                        ),
-                        None => String::new(),
-                    };
-                    self.driver
-                        .enter(&descended, &title_text);
+                        );
+                        self.driver
+                            .display(&title_text);
+                    }
                 }
 
                 // Walk the body against the callee's own environment; `local`

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -151,10 +151,25 @@ impl<'i, D: Driver> Runner<'i, D> {
                 .push(PathSegment::Procedure(name));
         }
         let result = self.walk(&mut env, &entry.body);
-        if name.is_some() {
+        // A named entry procedure is a structural scope: a completed run closes
+        // with a final sign-off prompt at its path. A Quit or error walk skips
+        // it — the run did not finish. An anonymous entry (a bare series of
+        // steps) has no procedure to accept, so it just ends.
+        let result = if name.is_some() {
+            let qualified = self
+                .path
+                .render();
+            let sealed = match result {
+                Ok(Outcome::Stopped) => Ok(Outcome::Stopped),
+                Ok(outcome) => self.seal_scope(&qualified, outcome),
+                Err(error) => Err(error),
+            };
             self.path
                 .pop();
-        }
+            sealed
+        } else {
+            result
+        };
         result
     }
 
@@ -316,8 +331,10 @@ impl<'i, D: Driver> Runner<'i, D> {
                         .render();
                     self.path
                         .pop();
-                    self.driver
-                        .leave(&descended);
+                    if completed(&result) {
+                        self.driver
+                            .leave(&descended);
+                    }
                 }
                 result
             }
@@ -434,20 +451,26 @@ impl<'i, D: Driver> Runner<'i, D> {
     ) -> Result<Outcome, RunnerError> {
         self.path
             .push(PathSegment::Section(numeral));
-        let result = self.perform_section(env, title, body);
+        let result = self.perform_section(env, numeral, title, body);
         let qualified = self
             .path
             .render();
         self.path
             .pop();
-        self.driver
-            .leave(&qualified);
-        result
+        // A section is a structural scope: the operator signs it off at its
+        // close before the next sibling runs. A Quit or error walk skips the
+        // prompt — the section did not complete.
+        match result {
+            Ok(Outcome::Stopped) => Ok(Outcome::Stopped),
+            Ok(outcome) => self.seal_scope(&qualified, outcome),
+            Err(error) => Err(error),
+        }
     }
 
     fn perform_section(
         &mut self,
         env: &mut Environment,
+        numeral: &'i str,
         title: Option<&'i Operation<'i>>,
         body: &'i Operation<'i>,
     ) -> Result<Outcome, RunnerError> {
@@ -462,7 +485,7 @@ impl<'i, D: Driver> Runner<'i, D> {
             None => String::new(),
         };
         self.driver
-            .enter(&qualified, &title_text);
+            .section(&qualified, numeral, &title_text);
         self.walk(env, body)
     }
 
@@ -600,6 +623,44 @@ impl<'i, D: Driver> Runner<'i, D> {
             .insert(qualified.to_string());
         Ok(outcome)
     }
+
+    /// Sign off a completed structural scope — a Section at its close, or the
+    /// whole run at the entry procedure.
+    fn seal_scope(&mut self, qualified: &str, outcome: Outcome) -> Result<Outcome, RunnerError> {
+        let produced = match outcome {
+            Outcome::Done(value) => value,
+            _ => Value::Unitus,
+        };
+        let run_id = self
+            .appender
+            .run_id();
+        let input = self
+            .driver
+            .seal(qualified, produced);
+        if let UserInput::Quit = input {
+            let suspend = Record {
+                recorded: now_iso8601(),
+                run_id,
+                path: "/".to_string(),
+                state: State::Stop,
+            };
+            self.appender
+                .append(&suspend)?;
+            return Ok(Outcome::Stopped);
+        }
+        let outcome = outcome_from(input);
+        let record = Record {
+            recorded: now_iso8601(),
+            run_id,
+            path: qualified.to_string(),
+            state: record_state(&outcome),
+        };
+        self.appender
+            .append(&record)?;
+        self.completed
+            .insert(qualified.to_string());
+        Ok(outcome)
+    }
 }
 
 fn describe_loop(
@@ -619,6 +680,16 @@ fn describe_loop(
 
 fn describe_execute(function: &str) -> String {
     format!("{}()", function)
+}
+
+/// Whether a scope's walk ran to completion. The `↙` close line is emitted
+/// only then — never on a Quit (`Stopped`) or an error unwind, where the scope
+/// did not finish and a green close would misread as success.
+fn completed(result: &Result<Outcome, RunnerError>) -> bool {
+    match result {
+        Ok(Outcome::Stopped) | Err(_) => false,
+        Ok(_) => true,
+    }
 }
 
 /// Lift a `UserInput` from the prompt into the runner's `Outcome`.

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -7,13 +7,15 @@ use std::path::PathBuf;
 use super::context::Context;
 use super::driver::{Driver, UserInput};
 use super::evaluator::Environment;
-use super::library::Library;
+use super::library::{Library, Nature};
 use super::path::{PathSegment, QualifiedPath};
 use super::state::{
     Appender, InvokeTarget, Record, RecordError, RunId, State, Value as RecordValue,
 };
 use crate::language;
-use crate::program::{ExecutableRef, Invocable, Operation, Ordinal, Program, SubroutineRef};
+use crate::program::{
+    Executable, ExecutableRef, Invocable, Operation, Ordinal, Program, SubroutineRef,
+};
 use crate::value::Value;
 
 /// What executing an Operation (or evaluating a Step at any scale) produced.
@@ -208,21 +210,70 @@ impl<'i, D: Driver> Runner<'i, D> {
                 let record = Record {
                     recorded: now_iso8601(),
                     run_id,
-                    path: qualified,
+                    path: qualified.clone(),
                     state: State::Execute {
                         function: function.clone(),
                     },
                 };
                 self.appender
                     .append(&record)?;
-                self.driver
-                    .announce(&describe_execute(&function));
-                // Linking resolves every Execute against the library, so a
-                // target still Unresolved here means a resume-time runtime
-                // missing a builtin the run started with; the evaluator
-                // surfaces that as an error rather than running anything.
-                let value = super::evaluator::evaluate(&self.library, &self.context, env, op)?;
-                Ok(Outcome::Done(value))
+                // An `Action` builtin (e.g. `exec`, `click`) is a command the
+                // user must command: show the script and run it only on their
+                // say-so. Skip or Fail declines the run and settles the step;
+                // Quit stops.
+                //
+                // `Pure` builtins (coercions, reading the clock) just announce
+                // and run.
+                let is_action = match &executable.target {
+                    ExecutableRef::Resolved(id) => {
+                        self.library
+                            .nature(*id)
+                            == Nature::Action
+                    }
+                    _ => false,
+                };
+                if is_action {
+                    let script = self.script_text(env, executable)?;
+                    match self
+                        .driver
+                        .command(&qualified, &script)
+                    {
+                        UserInput::Done(chosen) => {
+                            let value = super::evaluator::dispatch(
+                                &self.library,
+                                &self.context,
+                                env,
+                                executable,
+                                Some(&[chosen]),
+                            )?;
+                            Ok(Outcome::Done(value))
+                        }
+                        UserInput::Skip => Ok(Outcome::Skipped),
+                        UserInput::Fail(reason) => Ok(Outcome::Failed(Failure::Aborted(reason))),
+                        UserInput::Quit => {
+                            let suspend = Record {
+                                recorded: now_iso8601(),
+                                run_id,
+                                path: "/".to_string(),
+                                state: State::Stop,
+                            };
+                            self.appender
+                                .append(&suspend)?;
+                            Ok(Outcome::Stopped)
+                        }
+                    }
+                } else {
+                    self.driver
+                        .announce(&describe_execute(&function));
+                    let value = super::evaluator::dispatch(
+                        &self.library,
+                        &self.context,
+                        env,
+                        executable,
+                        None,
+                    )?;
+                    Ok(Outcome::Done(value))
+                }
             }
             Operation::Bind { .. }
             | Operation::Variable(_)
@@ -248,6 +299,27 @@ impl<'i, D: Driver> Runner<'i, D> {
             ExecutableRef::Unresolved(id) => id
                 .value
                 .to_string(),
+        }
+    }
+
+    /// The shell script an `exec` will run, rendered for the operator to see
+    /// before they command it. The command's first argument is the script.
+    fn script_text(
+        &self,
+        env: &mut Environment,
+        executable: &'i Executable<'i>,
+    ) -> Result<String, RunnerError> {
+        match executable
+            .arguments
+            .first()
+        {
+            Some(arg) => {
+                match super::evaluator::evaluate(&self.library, &self.context, env, arg)? {
+                    Value::Literali(s) => Ok(s),
+                    other => Ok(other.to_string()),
+                }
+            }
+            None => Ok(String::new()),
         }
     }
 
@@ -589,7 +661,22 @@ impl<'i, D: Driver> Runner<'i, D> {
         let produced = match self.walk(env, body)? {
             Outcome::Stopped => return Ok(Outcome::Stopped),
             Outcome::Done(value) => value,
-            Outcome::Skipped | Outcome::Failed(_) => Value::Unitus,
+            // The body declined its exec command beat (Skip / Fail), which
+            // settles the step: there is no result to judge, so record the
+            // outcome and return without the verdict prompt.
+            settled => {
+                let record = Record {
+                    recorded: now_iso8601(),
+                    run_id,
+                    path: qualified.to_string(),
+                    state: record_state(&settled),
+                };
+                self.appender
+                    .append(&record)?;
+                self.completed
+                    .insert(qualified.to_string());
+                return Ok(settled);
+            }
         };
 
         let choices: Vec<&str> = responses

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -264,6 +264,7 @@ impl<'i> Translator<'i> {
                     ordinal: Ordinal::Dependent(ordinal),
                     attributes: attrs.to_vec(),
                     description: description_ops,
+                    source: scope,
                     body: Box::new(Operation::Sequence(body_ops)),
                     responses,
                 }
@@ -284,6 +285,7 @@ impl<'i> Translator<'i> {
                     ordinal: Ordinal::Parallel,
                     attributes: attrs.to_vec(),
                     description: description_ops,
+                    source: scope,
                     body: Box::new(Operation::Sequence(body_ops)),
                     responses,
                 }


### PR DESCRIPTION
Place path in prompt.

We now render the fully qualified path, and have made an adjustment that each segment of a  qualified paths is separated by a `/` character. This matches expectations, and although collapsing a procedure and it's step was cute, it was harder to parse visually. Using the separator consistently at all layers considerably simplifies understanding the path. Also, the full nested scope of the location is shown; although a procedure can be invoked anywhere in a document, it's fully qualified path is that reflecting the top-level procedure, section, procedure, step etc it is a part of

We now get the user confirm completion on exit from each scope. While it is momentarily convenient to automatically close a procedure if all its steps are done, or likewise for a section, the judgment that a scope is actually complete is best left up to the user.

Finally, we also request confirmation _before_ running external commands via `exec()`.