### PR TITLE
Fix descent display

### DIFF
--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -156,9 +156,16 @@ pub fn render_expression<'i>(expression: &'i Expression, renderer: &dyn Render) 
 
 pub fn render_procedure_declaration<'i>(procedure: &'i Procedure, renderer: &dyn Render) -> String {
     render_declaration(
-        procedure.name.value,
-        procedure.parameters.as_ref().map(|v| v.as_slice()),
-        procedure.signature.as_ref(),
+        procedure
+            .name
+            .value,
+        procedure
+            .parameters
+            .as_ref()
+            .map(|v| v.as_slice()),
+        procedure
+            .signature
+            .as_ref(),
         renderer,
     )
 }

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -190,6 +190,20 @@ pub fn render_scope<'i>(scope: &'i Scope, renderer: &dyn Render) -> String {
             sub.append_attributes(attributes);
         }
         Scope::DependentBlock { .. } | Scope::ParallelBlock { .. } => {
+            sub.append_scope(scope);
+        }
+        _ => unreachable!(),
+    }
+    render_fragments(&sub.fragments, renderer)
+        .trim_end()
+        .to_string()
+}
+
+/// Render step's without descending into nested subscopes.
+pub fn render_step<'i>(scope: &'i Scope, renderer: &dyn Render) -> String {
+    let mut sub = Formatter::new(78);
+    match scope {
+        Scope::DependentBlock { .. } | Scope::ParallelBlock { .. } => {
             sub.append_step(scope);
         }
         _ => unreachable!(),
@@ -795,13 +809,13 @@ impl<'i> Formatter<'i> {
         self.decrease(4);
     }
 
+    /// Render a step's its ordinal or bullet and its description paragraphs.
+    /// Nested subscopes are walked separately by append_scope().
     fn append_step(&mut self, step: &'i Scope) {
-        self.add_fragment_reference(Syntax::BlockBegin, "");
         match step {
             Scope::DependentBlock {
                 ordinal,
                 description: content,
-                subscopes: scopes,
                 ..
             } => {
                 self.indent();
@@ -812,21 +826,14 @@ impl<'i> Formatter<'i> {
                 }
 
                 self.increase(4);
-
                 if content.len() > 0 {
                     self.append_paragraphs(content);
                 }
-
-                if scopes.len() > 0 {
-                    self.append_scopes(scopes);
-                }
-
                 self.decrease(4);
             }
             Scope::ParallelBlock {
                 bullet,
                 description,
-                subscopes,
                 ..
             } => {
                 self.indent();
@@ -834,21 +841,13 @@ impl<'i> Formatter<'i> {
                 self.add_fragment_reference(Syntax::Neutral, "   ");
 
                 self.increase(4);
-
                 if description.len() > 0 {
                     self.append_paragraphs(description);
                 }
-
-                if subscopes.len() > 0 {
-                    self.append_scopes(subscopes);
-                }
-
                 self.decrease(4);
             }
             _ => panic!("Shouldn't be calling append_step() with a non-step Scope"),
         }
-
-        self.add_fragment_reference(Syntax::BlockEnd, "");
     }
 
     fn append_responses(&mut self, responses: &'i Vec<Response>) {
@@ -875,8 +874,15 @@ impl<'i> Formatter<'i> {
 
     fn append_scope(&mut self, scope: &'i Scope) {
         match scope {
-            Scope::DependentBlock { .. } | Scope::ParallelBlock { .. } => {
+            Scope::DependentBlock { subscopes, .. } | Scope::ParallelBlock { subscopes, .. } => {
+                self.add_fragment_reference(Syntax::BlockBegin, "");
                 self.append_step(scope);
+                if subscopes.len() > 0 {
+                    self.increase(4);
+                    self.append_scopes(subscopes);
+                    self.decrease(4);
+                }
+                self.add_fragment_reference(Syntax::BlockEnd, "");
             }
             Scope::AttributeBlock {
                 attributes,

--- a/src/program/types.rs
+++ b/src/program/types.rs
@@ -108,7 +108,6 @@ pub enum Operation<'i> {
     Step {
         ordinal: Ordinal<'i>,
         attributes: Vec<&'i [language::Attribute<'i>]>,
-        description: Vec<Operation<'i>>,
         source: &'i language::Scope<'i>,
         body: Box<Operation<'i>>,
         responses: Vec<&'i language::Response<'i>>,

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -102,7 +102,6 @@ fn step(ordinal: Ordinal<'static>, body: Operation<'static>) -> Operation<'stati
     Operation::Step {
         ordinal,
         attributes: Vec::new(),
-        description: Vec::new(),
         source: scope_for(ordinal),
         body: Box::new(body),
         responses: Vec::new(),
@@ -848,7 +847,6 @@ fn loop_inside_step_produces_one_result() {
     let the_step = Operation::Step {
         ordinal: Ordinal::Dependent("1"),
         attributes: Vec::new(),
-        description: Vec::new(),
         source: scope_for(Ordinal::Dependent("1")),
         body: Box::new(loop_op),
         responses: Vec::new(),
@@ -896,7 +894,6 @@ fn repeat_loops_until_quit() {
     let inner = Operation::Step {
         ordinal: Ordinal::Dependent("1"),
         attributes: Vec::new(),
-        description: Vec::new(),
         source: scope_for(Ordinal::Dependent("1")),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
@@ -944,9 +941,6 @@ fn foreach_walks_body_once_per_list_element() {
 
     // foreach item in items: a substep whose description interpolates the
     // iteration variable, so each walk reveals which element it saw.
-    let description = Operation::String(vec![Fragment::Interpolation(Operation::Variable(
-        Identifier::new("item"),
-    ))]);
     let source_paragraphs = vec![language::Paragraph::new(vec![
         language::Descriptive::CodeInline(language::Expression::Variable(
             Identifier::new("item"),
@@ -956,7 +950,6 @@ fn foreach_walks_body_once_per_list_element() {
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
-        description: vec![description],
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
@@ -1032,9 +1025,6 @@ fn foreach_over_seq_builtin_runs() {
         .resolve("seq")
         .expect("seq registered");
 
-    let description = Operation::String(vec![Fragment::Interpolation(Operation::Variable(
-        Identifier::new("n"),
-    ))]);
     let source_paragraphs = vec![language::Paragraph::new(vec![
         language::Descriptive::CodeInline(language::Expression::Variable(
             Identifier::new("n"),
@@ -1044,7 +1034,6 @@ fn foreach_over_seq_builtin_runs() {
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
-        description: vec![description],
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
@@ -1117,11 +1106,6 @@ fn foreach_destructures_tuple_elements() {
 
     // foreach (first, second) in pairs: two names destructure each
     // tuple-shaped element positionally.
-    let description = Operation::String(vec![
-        Fragment::Interpolation(Operation::Variable(Identifier::new("first"))),
-        Fragment::Text("/"),
-        Fragment::Interpolation(Operation::Variable(Identifier::new("second"))),
-    ]);
     let source_paragraphs = vec![language::Paragraph::new(vec![
         language::Descriptive::CodeInline(language::Expression::Variable(
             Identifier::new("first"),
@@ -1136,7 +1120,6 @@ fn foreach_destructures_tuple_elements() {
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
-        description: vec![description],
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),
@@ -1195,7 +1178,10 @@ fn foreach_destructures_tuple_elements() {
             _ => None,
         })
         .collect();
-    assert_eq!(steps, vec!["a.  { first } / { second }", "a.  { first } / { second }"]);
+    assert_eq!(
+        steps,
+        vec!["a.  { first } / { second }", "a.  { first } / { second }"]
+    );
 }
 
 #[test]
@@ -1204,9 +1190,6 @@ fn foreach_widens_primitive_to_singleton() {
 
     // foreach item in source, where `source` is a bare scalar: it widens
     // to a one-element list and the body walks exactly once.
-    let description = Operation::String(vec![Fragment::Interpolation(Operation::Variable(
-        Identifier::new("item"),
-    ))]);
     let source_paragraphs = vec![language::Paragraph::new(vec![
         language::Descriptive::CodeInline(language::Expression::Variable(
             Identifier::new("item"),
@@ -1216,7 +1199,6 @@ fn foreach_widens_primitive_to_singleton() {
     let substep = Operation::Step {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
-        description: vec![description],
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
         body: Box::new(Operation::Sequence(Vec::new())),
         responses: Vec::new(),

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -179,7 +179,12 @@ fn prompt<W: Write>(
     choices: &[&str],
     produced: Value,
 ) -> UserInput {
-    let result = interact(out, qualified, settle, Interaction::begin(choices, produced));
+    let result = interact(
+        out,
+        qualified,
+        settle,
+        Interaction::begin(choices, produced),
+    );
     let col = settle
         .chars()
         .count() as u16
@@ -226,7 +231,11 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
         out,
         qualified,
         "→",
-        Interaction { field, menu: None, reason: None },
+        Interaction {
+            field,
+            menu: None,
+            reason: None,
+        },
     );
     let col = "→"
         .chars()
@@ -260,7 +269,12 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
 /// Drive one raw-mode interaction to a settled `UserInput`, leaving the prompt
 /// row cleared. Shared by the step/scope prompt and the exec command gate; the
 /// caller writes whatever record line it wants afterward.
-fn interact<W: Write>(out: &mut W, qualified: &str, settle: &str, mut interaction: Interaction) -> UserInput {
+fn interact<W: Write>(
+    out: &mut W,
+    qualified: &str,
+    settle: &str,
+    mut interaction: Interaction,
+) -> UserInput {
     // The interactive path is guarded on stdout being a terminal before the
     // walk begins, so a raw-mode failure here is an unexpected terminal fault
     // rather than a redirect; bail by quitting.
@@ -643,7 +657,12 @@ impl Interaction {
 /// Layout: `{settle} {path} ▶ {content}` — the settle arrow and path are dark
 /// grey (matching the trace lines above), and ▶ is the shell-prompt character
 /// before the cursor/content area.
-fn draw<W: Write>(out: &mut W, qualified: &str, settle: &str, interaction: &Interaction) -> io::Result<()> {
+fn draw<W: Write>(
+    out: &mut W,
+    qualified: &str,
+    settle: &str,
+    interaction: &Interaction,
+) -> io::Result<()> {
     queue!(out, cursor::MoveToColumn(0), Clear(ClearType::CurrentLine))?;
 
     let prefix = prompt_prefix_width(qualified, settle);

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -160,14 +160,16 @@ impl<'i, D: Driver> Runner<'i, D> {
                 name,
                 entry.parameters,
                 entry.signature,
-                self.driver.renderer(),
+                self.driver
+                    .renderer(),
             );
             self.driver
                 .display(&declaration);
             if let Some(t) = entry.title {
                 let title_text = crate::formatting::formatter::render_title(
                     t,
-                    self.driver.renderer(),
+                    self.driver
+                        .renderer(),
                 );
                 self.driver
                     .display(&title_text);
@@ -430,14 +432,16 @@ impl<'i, D: Driver> Runner<'i, D> {
                         name,
                         subroutine.parameters,
                         subroutine.signature,
-                        self.driver.renderer(),
+                        self.driver
+                            .renderer(),
                     );
                     self.driver
                         .display(&declaration);
                     if let Some(t) = subroutine.title {
                         let title_text = crate::formatting::formatter::render_title(
                             t,
-                            self.driver.renderer(),
+                            self.driver
+                                .renderer(),
                         );
                         self.driver
                             .display(&title_text);
@@ -663,14 +667,7 @@ impl<'i, D: Driver> Runner<'i, D> {
             .path
             .render();
 
-        let result = self.perform_step(
-            env,
-            &qualified,
-            ordinal,
-            body,
-            source,
-            responses,
-        );
+        let result = self.perform_step(env, &qualified, ordinal, body, source, responses);
 
         self.path
             .pop();
@@ -715,7 +712,8 @@ impl<'i, D: Driver> Runner<'i, D> {
 
         let step_text = crate::formatting::formatter::render_step(
             source,
-            self.driver.renderer(),
+            self.driver
+                .renderer(),
         );
 
         self.driver
@@ -818,7 +816,6 @@ impl<'i, D: Driver> Runner<'i, D> {
         Ok(outcome)
     }
 }
-
 
 fn describe_loop(
     names: &[crate::language::Identifier<'_>],

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -713,7 +713,7 @@ impl<'i, D: Driver> Runner<'i, D> {
         self.appender
             .append(&begin)?;
 
-        let step_text = crate::formatting::formatter::render_scope(
+        let step_text = crate::formatting::formatter::render_step(
             source,
             self.driver.renderer(),
         );

--- a/src/translation/checks/translate.rs
+++ b/src/translation/checks/translate.rs
@@ -217,7 +217,7 @@ I. First section
 }
 
 #[test]
-fn section_holding_procedures_yields_empty_body() {
+fn section_holding_procedures_invokes_first() {
     let source = r#"
 % technique v1
 
@@ -257,8 +257,12 @@ inner : () -> ()
     let Operation::Sequence(inner) = section_body.as_ref() else {
         panic!("expected inner Sequence");
     };
-    // Procedures-bodied section carries no executable operations of its own.
-    assert!(inner.is_empty());
+    // A procedures-bodied section descends into its first procedure.
+    assert_eq!(inner.len(), 1);
+    let Operation::Invoke(invocable) = &inner[0] else {
+        panic!("expected Invoke, got {:?}", inner[0]);
+    };
+    assert_eq!(invocable.target, SubroutineRef::Resolved(SubroutineId(1)));
 }
 
 #[test]
@@ -1729,7 +1733,9 @@ init : () -> ()
     let Operation::Sequence(section_body) = body.as_ref() else {
         panic!("expected Section body Sequence");
     };
-    assert_eq!(section_body.len(), 1, "title's Application is hoisted");
+    // First the title's hoisted `<init>` Application, then the descent into
+    // the section's first (and only) declared procedure, also `init`.
+    assert_eq!(section_body.len(), 2, "title's Application is hoisted");
     let Operation::Invoke(invocable) = &section_body[0] else {
         panic!("expected Invoke, got {:?}", section_body[0]);
     };

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -272,11 +272,9 @@ impl<'i> Translator<'i> {
                 for sub in subscopes {
                     self.append_attributes(&mut body_ops, &mut responses, sub, attrs);
                 }
-                let description_ops = self.translate_paragraphs(description);
                 Operation::Step {
                     ordinal: Ordinal::Dependent(ordinal),
                     attributes: attrs.to_vec(),
-                    description: description_ops,
                     source: scope,
                     body: Box::new(Operation::Sequence(body_ops)),
                     responses,
@@ -293,11 +291,9 @@ impl<'i> Translator<'i> {
                 for sub in subscopes {
                     self.append_attributes(&mut body_ops, &mut responses, sub, attrs);
                 }
-                let description_ops = self.translate_paragraphs(description);
                 Operation::Step {
                     ordinal: Ordinal::Parallel,
                     attributes: attrs.to_vec(),
-                    description: description_ops,
                     source: scope,
                     body: Box::new(Operation::Sequence(body_ops)),
                     responses,

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -232,10 +232,23 @@ impl<'i> Translator<'i> {
                     // scan for operations in section content
                     self.translate_descriptions(&mut body_ops, std::slice::from_ref(paragraph));
                 }
-                if let language::Technique::Steps(scopes) = body {
-                    for sub in scopes {
-                        self.append_attributes(&mut body_ops, &mut responses, sub, attrs);
+                match body {
+                    language::Technique::Steps(scopes) => {
+                        for sub in scopes {
+                            self.append_attributes(&mut body_ops, &mut responses, sub, attrs);
+                        }
                     }
+                    language::Technique::Procedures(procedures) => {
+                        // A section whose body declares procedures descends
+                        // into the first, its entry point.
+                        if let Some(procedure) = procedures.first() {
+                            body_ops.push(Operation::Invoke(Invocable {
+                                target: SubroutineRef::Unresolved(procedure.name),
+                                arguments: Vec::new(),
+                            }));
+                        }
+                    }
+                    language::Technique::Empty => {}
                 }
                 let title_op = title
                     .as_ref()


### PR DESCRIPTION
Fix a bug where running through a document where Sections that contained Procedures (an entirely normal pattern) were not being entered into.

Fix a glitch whereby the entire step (including its substeps etc) was printed during the run when only the step it self (ie `1. Do first thing`) needs to be emitted. We're trying to show "moving through the document" a logical piece at a time.
