### PR TITLE
Specify library at check and run time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -124,6 +124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,15 +168,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.13.0",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -189,13 +200,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -262,15 +304,15 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -337,7 +379,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -346,7 +388,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -465,16 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "semver",
 ]
 
 [[package]]
@@ -486,8 +524,8 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -504,6 +542,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -613,9 +657,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -647,8 +691,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -768,6 +812,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,7 +867,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -834,85 +884,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.5.16", features = [ "wrap_help" ] }
-crossterm = "0.28"
+crossterm = "0.29"
 ignore = "0.4"
 lsp-server = "0.7.9"
 lsp-types = "0.97"

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -25,17 +25,8 @@ pub use procedure::Procedure;
 pub use recipe::Recipe;
 pub use source::Source;
 
-use crate::runner::Builtin;
-
-/// The runtime facet of a domain: the domain-specific host functions it
-/// contributes to the interpreter's function table, on top of `Library::core`
-/// and the `Library::system` layer. Orthogonal to a domain's rendering
-/// projection (the `Template` trait).
-pub trait Domain {
-    fn functions(&self) -> Vec<Builtin> {
-        Vec::new()
-    }
-}
+/// A known domain, selected by name for the renderer and the runtime.
+pub trait Domain {}
 
 /// Select a domain by name, for both the renderer and the runtime.
 /// `None` if the name matches no known domain — the caller reports that as an

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,11 @@ use std::str::FromStr;
 use tracing::debug;
 use tracing_subscriber::{self, EnvFilter};
 
-use technique::domain::{self, Domain};
 use technique::formatting::{self, Identity};
 use technique::highlighting::{self, Terminal};
 use technique::linking;
 use technique::parsing;
-use technique::runner::{self, Library, Mode, Outcome, RunId};
+use technique::runner::{self, Builtin, Library, Mode, Outcome, RunId};
 use technique::templating::{self, Checklist, NasaEsaIss, Procedure, Recipe, Source};
 use technique::translation;
 
@@ -119,15 +118,25 @@ impl TypedValueParser for PaperSizeParser {
     }
 }
 
-/// Resolve a domain name to its handle.
-fn select_domain(name: &str) -> &'static dyn Domain {
-    match domain::domain_for(name) {
-        Some(domain) => domain,
-        None => {
-            eprintln!("{}: unrecognized domain \"{}\"", "error".bright_red(), name);
-            std::process::exit(1);
+/// Resolve the `--library` selections to the host functions they contribute.
+fn select_libraries(matches: &clap::ArgMatches) -> Vec<Builtin> {
+    let mut builtins = Vec::new();
+    if let Some(names) = matches.get_many::<String>("library") {
+        for name in names {
+            match runner::library_for(name) {
+                Some(functions) => builtins.extend(functions),
+                None => {
+                    eprintln!(
+                        "{}: unrecognized library \"{}\"",
+                        "error".bright_red(),
+                        name
+                    );
+                    std::process::exit(1);
+                }
+            }
         }
     }
+    builtins
 }
 
 fn main() {
@@ -193,6 +202,18 @@ fn main() {
                             parsing, where the input is parsed from the surface language to an internal abstract syntax tree; \
                             translation, which resolves names, checks references, and ensures the input is valid Technique; then finally \
                             linking, which ensures functions being called are available, checks parameters being passed, and provides the context to the execution environment.")
+                )
+                .arg(
+                    Arg::new("library")
+                        .short('l')
+                        .long("library")
+                        .value_name("name")
+                        .value_parser(["system", "browser"])
+                        .value_delimiter(',')
+                        .action(ArgAction::Append)
+                        .default_value("system")
+                        .help("Inject one or more libraries into the runtime so that references to functions from those libraries can be resolved. \
+                            Multiple libraries can be specified, separated by commas. The `core` library is always loaded."),
                 )
                 .arg(
                     Arg::new("filename")
@@ -294,12 +315,16 @@ fn main() {
                         .help("The file containing the Technique document to run."),
                 )
                 .arg(
-                    Arg::new("domain")
-                        .short('d')
-                        .long("domain")
-                        .value_parser(["checklist", "nasa-esa-iss", "procedure", "recipe", "source"])
-                        .action(ArgAction::Set)
-                        .help("The kind of procedure this Technique document represents. By default the value specified in the input document's metadata will be used, falling back to source if unspecified."),
+                    Arg::new("library")
+                        .short('l')
+                        .long("library")
+                        .value_name("name")
+                        .value_parser(["system", "browser"])
+                        .value_delimiter(',')
+                        .action(ArgAction::Append)
+                        .default_value("system")
+                        .help("Inject one or more libraries into the runtime so that references to functions from those libraries can be resolved. \
+                            Multiple libraries can be specified, separated by commas. The `core` library is always loaded."),
                 )
                 .arg(
                     Arg::new("mode")
@@ -455,16 +480,10 @@ fn main() {
             }
 
             // Check validates against the functions a run would resolve
-            // against: core and system, plus the document's declared domain.
-            let name = technique
-                .header
-                .as_ref()
-                .and_then(|m| m.domain)
-                .unwrap_or("source");
-            let domain = select_domain(name);
+            // against: the always-present core, plus the selected libraries
+            // (system by default).
             let mut library = Library::core();
-            library.extend(Library::system());
-            library.extend(domain.functions());
+            library.extend(select_libraries(submatches));
             if let Err(errors) = linking::link(&mut program, &library) {
                 for (i, error) in errors
                     .iter()
@@ -775,26 +794,11 @@ fn main() {
                 }
             };
 
-            // Add domain-specific host functions to the Library based on
-            // whether the document or command-line indicate the domain being
-            // used. FUTURE the `core` and `system` functions are added here
-            // regardless, in time we should make that more configurable.
-
-            let name = submatches
-                .get_one::<String>("domain")
-                .map(String::as_str)
-                .or_else(|| {
-                    technique
-                        .header
-                        .as_ref()
-                        .and_then(|m| m.domain)
-                })
-                .unwrap_or("source");
-            let domain = select_domain(name);
-
+            // The runner resolves against the always-present core, plus the
+            // libraries selected with --library (system by default),
+            // independent of the document's domain.
             let mut library = Library::core();
-            library.extend(Library::system());
-            library.extend(domain.functions());
+            library.extend(select_libraries(submatches));
             if let Err(errors) = linking::link(&mut program, &library) {
                 for (i, error) in errors
                     .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,25 +118,40 @@ impl TypedValueParser for PaperSizeParser {
     }
 }
 
-/// Resolve the `--library` selections to the host functions they contribute.
-fn select_libraries(matches: &clap::ArgMatches) -> Vec<Builtin> {
+/// The `--library` names selected on the command line.
+fn library_names(matches: &clap::ArgMatches) -> Vec<String> {
+    matches
+        .get_many::<String>("library")
+        .map(|names| {
+            names
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Resolve library names to the host functions they contribute.
+fn resolve_libraries(names: &[String]) -> Vec<Builtin> {
     let mut builtins = Vec::new();
-    if let Some(names) = matches.get_many::<String>("library") {
-        for name in names {
-            match runner::library_for(name) {
-                Some(functions) => builtins.extend(functions),
-                None => {
-                    eprintln!(
-                        "{}: unrecognized library \"{}\"",
-                        "error".bright_red(),
-                        name
-                    );
-                    std::process::exit(1);
-                }
+    for name in names {
+        match runner::library_for(name) {
+            Some(functions) => builtins.extend(functions),
+            None => {
+                eprintln!(
+                    "{}: unrecognized library \"{}\"",
+                    "error".bright_red(),
+                    name
+                );
+                std::process::exit(1);
             }
         }
     }
     builtins
+}
+
+/// Resolve the `--library` selections to the host functions they contribute.
+fn select_libraries(matches: &clap::ArgMatches) -> Vec<Builtin> {
+    resolve_libraries(&library_names(matches))
 }
 
 fn main() {
@@ -796,9 +811,12 @@ fn main() {
 
             // The runner resolves against the always-present core, plus the
             // libraries selected with --library (system by default),
-            // independent of the document's domain.
+            // independent of the document's domain. The selected names are
+            // recorded in the run's Start record so `resume` can rebuild the
+            // same library.
+            let names = library_names(submatches);
             let mut library = Library::core();
-            library.extend(select_libraries(submatches));
+            library.extend(resolve_libraries(&names));
             if let Err(errors) = linking::link(&mut program, &library) {
                 for (i, error) in errors
                     .iter()
@@ -815,7 +833,9 @@ fn main() {
                 std::process::exit(1);
             }
 
-            match runner::start(mode, colour, filename, &program, &arguments, library) {
+            match runner::start(
+                mode, colour, filename, &program, &arguments, library, &names,
+            ) {
                 Ok((run_id, Outcome::Stopped)) => {
                     eprintln!(
                         "stopped; resume with `technique resume {}`",
@@ -845,8 +865,8 @@ fn main() {
                 }
             };
 
-            let filename = match runner::locate(run_id) {
-                Ok(path) => path,
+            let (filename, names) = match runner::locate(run_id) {
+                Ok(located) => located,
                 Err(error) => {
                     eprintln!("{}", problem::concise_runner_error(&error, &Terminal));
                     std::process::exit(1);
@@ -901,12 +921,11 @@ fn main() {
                 }
             };
 
-            // TODO it is slightly problematic that we have to reconstruct the
-            // Library here and at present are hard-coding the functions being
-            // brought into scope.
-
+            // Rebuild the library from the names recorded in the run's Start
+            // record so resume resolves against the same functions as the
+            // original run.
             let mut library = Library::core();
-            library.extend(Library::system());
+            library.extend(resolve_libraries(&names));
             if let Err(errors) = linking::link(&mut program, &library) {
                 for (i, error) in errors
                     .iter()

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -34,7 +34,7 @@ impl StoreFixture {
         let store = Store::new(base.clone());
         let document = PathBuf::from("/tmp/Test.tq");
         let (run_id, run_dir) = store
-            .create(&document, "2026-05-16T00:00:00Z".to_string())
+            .create(&document, "2026-05-16T00:00:00Z".to_string(), &[])
             .expect("create");
         let pfftt = crate::runner::state::construct_state_path(&run_dir, &document);
         let appender = Appender::open(pfftt, run_id).expect("open appender");

--- a/src/runner/checks/state.rs
+++ b/src/runner/checks/state.rs
@@ -106,7 +106,7 @@ fn create_writes_start_record_at_head() {
             .clone(),
     );
     let (run_id, run_dir) = store
-        .create(&document, started)
+        .create(&document, started, &[])
         .expect("create");
 
     let pfftt = run_dir.join("NetworkProbe.pfftt");
@@ -132,14 +132,38 @@ fn create_and_open_round_trips_document_path() {
             .clone(),
     );
     let (run_id, _) = store
-        .create(&document, started)
+        .create(&document, started, &[])
         .expect("create");
-    let (read_document, completed, _) = store
+    let (read_document, libraries, completed, _) = store
         .open(run_id)
         .expect("open");
 
     assert_eq!(read_document, document);
+    assert!(libraries.is_empty());
     assert!(completed.is_empty());
+}
+
+#[test]
+fn create_and_open_round_trips_libraries() {
+    let dir = TempDir::new("create-open-libraries");
+
+    let document = PathBuf::from("/somewhere/NetworkProbe.tq");
+    let started = "2026-05-14T12:34:56Z".to_string();
+    let selected = vec!["system".to_string(), "browser".to_string()];
+
+    let store = Store::new(
+        dir.path
+            .clone(),
+    );
+    let (run_id, _) = store
+        .create(&document, started, &selected)
+        .expect("create");
+    let (read_document, libraries, _, _) = store
+        .open(run_id)
+        .expect("open");
+
+    assert_eq!(read_document, document);
+    assert_eq!(libraries, selected);
 }
 
 #[test]
@@ -183,7 +207,7 @@ fn open_replays_done_skip_fail_into_completed() {
         dir.path
             .clone(),
     );
-    let (document, completed, _) = store
+    let (document, _, completed, _) = store
         .open(RunId(1))
         .expect("open");
 
@@ -238,7 +262,7 @@ fn open_skips_resume_and_begin_during_replay() {
         dir.path
             .clone(),
     );
-    let (_, completed, _) = store
+    let (_, _, completed, _) = store
         .open(RunId(1))
         .expect("open");
 

--- a/src/runner/library.rs
+++ b/src/runner/library.rs
@@ -101,8 +101,22 @@ impl Library {
         ]
     }
 
+    /// Interactions with a web browser (or rather, instructions that a user
+    /// do these interactions in their web browser).
+    pub fn browser() -> Vec<Builtin> {
+        ["click", "select", "deselect", "scroll", "type", "task"]
+            .into_iter()
+            .map(|name| Builtin {
+                name,
+                arity: 1,
+                nature: Nature::Action,
+                function: interact,
+            })
+            .collect()
+    }
+
     /// Add functions to the table, after the core builtins — the system layer
-    /// or a domain's own host functions.
+    /// or an injected library's host functions.
     pub fn extend(&mut self, builtins: impl IntoIterator<Item = Builtin>) {
         self.functions
             .extend(builtins);
@@ -149,6 +163,18 @@ impl Library {
             });
         }
         (builtin.function)(context, args)
+    }
+}
+
+/// Resolve a named library to the host functions it contributes, or `None`
+/// if the name matches no known library. The orthogonal counterpart to a
+/// document's domain: a library is selected with `--library` regardless of
+/// which domain the Technique declares.
+pub fn library_for(name: &str) -> Option<Vec<Builtin>> {
+    match name {
+        "system" => Some(Library::system()),
+        "browser" => Some(Library::browser()),
+        _ => None,
     }
 }
 
@@ -271,6 +297,12 @@ fn exec(context: &Context, args: &[Value]) -> Result<Value, RunnerError> {
 /// external state, hence part of the system layer rather than `core`.
 fn now(_context: &Context, _args: &[Value]) -> Result<Value, RunnerError> {
     Ok(Value::Literali(super::runner::now_iso8601()))
+}
+
+/// A browser-library action: the operator performs the UI manipulation when
+/// the runner commands the step, so the call settles to unit.
+fn interact(_context: &Context, _args: &[Value]) -> Result<Value, RunnerError> {
+    Ok(Value::Unitus)
 }
 
 fn as_integer(function: &'static str, value: &Value) -> Result<i64, RunnerError> {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -40,10 +40,11 @@ pub fn start<'i>(
     program: &'i Program<'i>,
     arguments: &[String],
     library: Library,
+    libraries: &[String],
 ) -> Result<(RunId, Outcome), RunnerError> {
     let env = bind_parameters(program, arguments)?;
     let store = Store::new(PathBuf::from(STORE_ROOT));
-    let (run_id, run_dir) = store.create(document, now_iso8601())?;
+    let (run_id, run_dir) = store.create(document, now_iso8601(), libraries)?;
     let pfftt = construct_state_path(&run_dir, document);
     let appender = Appender::open(pfftt, run_id)?;
     let outcome = match mode {
@@ -69,13 +70,13 @@ pub fn start<'i>(
     Ok((run_id, outcome))
 }
 
-/// Read the opening `Start` record of an existing run, returning the
-/// source document path so the caller can load and re-translate it
-/// before resuming.
-pub fn locate(run_id: RunId) -> Result<PathBuf, RunnerError> {
+/// Read the opening `Start` record of an existing run, returning the source
+/// document path and the libraries it was run with so the caller can load,
+/// re-translate, and re-link it before resuming.
+pub fn locate(run_id: RunId) -> Result<(PathBuf, Vec<String>), RunnerError> {
     let store = Store::new(PathBuf::from(STORE_ROOT));
-    let (document, _, _) = store.open(run_id)?;
-    Ok(document)
+    let (document, libraries, _, _) = store.open(run_id)?;
+    Ok((document, libraries))
 }
 
 /// Open an existing run and walk the given program, short-circuiting
@@ -90,7 +91,7 @@ pub fn resume<'i>(
         return Err(RunnerError::TerminalRequired);
     }
     let store = Store::new(PathBuf::from(STORE_ROOT));
-    let (document, completed, run_dir) = store.open(run_id)?;
+    let (document, _, completed, run_dir) = store.open(run_id)?;
     let pfftt = construct_state_path(&run_dir, &document);
     let mut appender = Appender::open(pfftt, run_id)?;
     let record = Record {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -19,7 +19,7 @@ mod state;
 pub use context::Context;
 pub use driver::{Headless, Mode};
 pub use evaluator::Environment;
-pub use library::{Builtin, Library, Native};
+pub use library::{library_for, Builtin, Library, Native};
 pub use runner::{Outcome, Runner, RunnerError};
 pub use state::{Appender, RecordError, RunId};
 

--- a/src/runner/state.rs
+++ b/src/runner/state.rs
@@ -153,6 +153,7 @@ impl Store {
         &self,
         document: &Path,
         started: String,
+        libraries: &[String],
     ) -> Result<(RunId, PathBuf), RunnerError> {
         let absolute = std::path::absolute(document).map_err(|error| RunnerError::StoreError {
             path: document.to_path_buf(),
@@ -160,13 +161,16 @@ impl Store {
         })?;
         let (run_id, run_dir) = self.allocate()?;
         let pfftt = construct_state_path(&run_dir, &absolute);
+        let mut uri = format!("file://{}", absolute.display());
+        if !libraries.is_empty() {
+            uri.push_str("?library=");
+            uri.push_str(&libraries.join(","));
+        }
         let record = Record {
             recorded: started,
             run_id,
             path: "/".to_string(),
-            state: State::Start {
-                uri: format!("file://{}", absolute.display()),
-            },
+            state: State::Start { uri },
         };
         std::fs::write(&pfftt, format_record(&record))
             .map_err(|error| RunnerError::StoreError { path: pfftt, error })?;
@@ -174,10 +178,13 @@ impl Store {
     }
 
     /// Open an existing run. Parses the leading `Start` record to recover
-    /// the source document, then replays `Done` / `Skip` / `Fail` records
-    /// into a set of completed step paths. `Stop` and `Resume` records
-    /// are passed over.
-    pub fn open(&self, run_id: RunId) -> Result<(PathBuf, HashSet<String>, PathBuf), RunnerError> {
+    /// the source document and the libraries it was run with, then replays
+    /// `Done` / `Skip` / `Fail` records into a set of completed step paths.
+    /// `Stop` and `Resume` records are passed over.
+    pub fn open(
+        &self,
+        run_id: RunId,
+    ) -> Result<(PathBuf, Vec<String>, HashSet<String>, PathBuf), RunnerError> {
         let run_dir = self
             .base
             .join(run_id.render());
@@ -203,13 +210,8 @@ impl Store {
             .ok_or(RunnerError::StartMissing(run_id))?;
         let head =
             parse_record(first).map_err(|error| RunnerError::MalformedRecord { run_id, error })?;
-        let document = match head.state {
-            State::Start { uri, .. } => {
-                let stripped = uri
-                    .strip_prefix("file://")
-                    .unwrap_or(&uri);
-                PathBuf::from(stripped)
-            }
+        let (document, libraries) = match head.state {
+            State::Start { uri, .. } => parse_run_uri(&uri),
             _ => return Err(RunnerError::StartMissing(run_id)),
         };
 
@@ -229,7 +231,7 @@ impl Store {
                 | State::Begin => {}
             }
         }
-        Ok((document, completed, run_dir))
+        Ok((document, libraries, completed, run_dir))
     }
 
     // Scan the store for the highest existing run identifier and return
@@ -264,6 +266,32 @@ impl Store {
         }
         Ok(RunId(max + 1))
     }
+}
+
+// Recover the source document's file path and the libraries that were
+// selected from a Start URI of the form
+// 
+// file://{path}?library=a,b
+
+// written by `create` records. The query string parameters are optional.
+fn parse_run_uri(uri: &str) -> (PathBuf, Vec<String>) {
+    let (location, query) = match uri.split_once('?') {
+        Some((location, query)) => (location, Some(query)),
+        None => (uri, None),
+    };
+    let path = location
+        .strip_prefix("file://")
+        .unwrap_or(location);
+    let libraries = query
+        .and_then(|query| query.strip_prefix("library="))
+        .map(|names| {
+            names
+                .split(',')
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    (PathBuf::from(path), libraries)
 }
 
 // Compute the on-disk PFFTT file path for a run, named using the source

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -342,9 +342,7 @@ impl<'i> Translator<'i> {
                 let mut body_ops = Vec::new();
                 let mut responses = Vec::new();
                 self.translate_descriptions(&mut body_ops, description);
-                for sub in subscopes {
-                    self.append_attributes(&mut body_ops, &mut responses, sub, attrs);
-                }
+                self.attach_subscopes(&mut body_ops, &mut responses, subscopes, attrs);
                 Operation::Step {
                     ordinal: Ordinal::Dependent(ordinal),
                     attributes: attrs.to_vec(),
@@ -361,9 +359,7 @@ impl<'i> Translator<'i> {
                 let mut body_ops = Vec::new();
                 let mut responses = Vec::new();
                 self.translate_descriptions(&mut body_ops, description);
-                for sub in subscopes {
-                    self.append_attributes(&mut body_ops, &mut responses, sub, attrs);
-                }
+                self.attach_subscopes(&mut body_ops, &mut responses, subscopes, attrs);
                 Operation::Step {
                     ordinal: Ordinal::Parallel,
                     attributes: attrs.to_vec(),
@@ -440,6 +436,36 @@ impl<'i> Translator<'i> {
                 })
             }
             _ => None,
+        }
+    }
+
+    // Subscopes form the body of a trailing inline `foreach`, else they follow
+    // the description as siblings.
+    fn attach_subscopes(
+        &mut self,
+        body_ops: &mut Vec<Operation<'i>>,
+        responses: &mut Vec<&'i language::Response<'i>>,
+        subscopes: &'i [language::Scope<'i>],
+        attrs: &[&'i [language::Attribute<'i>]],
+    ) {
+        if let Some(Operation::Loop {
+            over: Some(_),
+            body,
+            responses: loop_responses,
+            ..
+        }) = body_ops.last_mut()
+        {
+            if let Operation::Sequence(loop_body) = body.as_mut() {
+                if loop_body.is_empty() {
+                    for sub in subscopes {
+                        self.append_attributes(loop_body, loop_responses, sub, attrs);
+                    }
+                    return;
+                }
+            }
+        }
+        for sub in subscopes {
+            self.append_attributes(body_ops, responses, sub, attrs);
         }
     }
 


### PR DESCRIPTION
Domains were not the right holder for groups of functions; something could be in the general `procedure` domain and yet need access to actions in a web browser, running system commands, etc.

Instead, generalize the idea of Library to be akin to Domain; but in this case groups of capabilities in a specific host environment.

The `core` library with the built-in pure functions and coercions is always loaded. 
Add `--library` to the _technique check_ and _technique run_ commands to specify which librar(ies) are to be active. The default is defined as `system`, but by not loading it automatically a host environment that needs `browser`, say, but doesn't need I/O can be run with just the function surface it needs.

In order to _technique resume_ a run the program needs to know what libraries it was originally run with. To this end we add query string style parameters to the URI recorded on the `Start` line of the PFFTT, for example:

```
2026-06-19T00:01:17.200Z 000001 / Start file:///home/arthur/Documents/Procedures/MakeTea.tq?library=kitchen
```