### PR TITLE
Improve handling of bound variables when executing

### DIFF
--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -3,6 +3,36 @@
 use crate::formatting::*;
 use crate::language::*;
 use std::borrow::Cow;
+use std::collections::HashMap;
+
+/// Runtime values for the variables a step's prose interpolates, so the
+/// runner can splice the values the user supplied in place of the `{ name }`
+/// reference. Each entry is the pre-styled fragments for one variable.
+/// Non-runtime rendering (formatting, error messages) uses an empty set, so
+/// interpolations render as their source `{ name }`.
+#[derive(Default)]
+pub struct Substitutions {
+    bindings: HashMap<String, Vec<(Syntax, Cow<'static, str>)>>,
+}
+
+impl Substitutions {
+    pub fn new() -> Self {
+        Substitutions {
+            bindings: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, name: String, fragments: Vec<(Syntax, Cow<'static, str>)>) {
+        self.bindings
+            .insert(name, fragments);
+    }
+
+    fn lookup(&self, name: &str) -> Option<&[(Syntax, Cow<'static, str>)]> {
+        self.bindings
+            .get(name)
+            .map(|fragments| fragments.as_slice())
+    }
+}
 
 // Helper function to convert numbers to superscript
 fn to_superscript(num: i8) -> String {
@@ -226,8 +256,13 @@ pub fn render_description<'i>(paragraphs: &'i [Paragraph<'i>], renderer: &dyn Re
 }
 
 /// Render step's without descending into nested subscopes.
-pub fn render_step<'i>(scope: &'i Scope, renderer: &dyn Render) -> String {
+pub fn render_step<'i>(
+    scope: &'i Scope,
+    subs: &'i Substitutions,
+    renderer: &dyn Render,
+) -> String {
     let mut sub = Formatter::new(78);
+    sub.substitutions = Some(subs);
     match scope {
         Scope::DependentBlock { .. } | Scope::ParallelBlock { .. } => {
             sub.append_step(scope);
@@ -279,6 +314,7 @@ struct Formatter<'i> {
     width: u8,
     current: Syntax,
     buffer: String,
+    substitutions: Option<&'i Substitutions>,
 }
 
 impl<'i> Formatter<'i> {
@@ -289,6 +325,7 @@ impl<'i> Formatter<'i> {
             width,
             current: Syntax::Neutral,
             buffer: String::new(),
+            substitutions: None,
         }
     }
 
@@ -406,6 +443,7 @@ impl<'i> Formatter<'i> {
             width: self.width,
             current: Syntax::Neutral,
             buffer: String::new(),
+            substitutions: self.substitutions,
         }
     }
 
@@ -787,6 +825,7 @@ impl<'i> Formatter<'i> {
 
     fn append_descriptives(&mut self, descriptives: &'i [Descriptive<'i>]) {
         let syntax = self.current;
+        let subs = self.substitutions;
         let mut line = self.builder();
 
         for descriptive in descriptives {
@@ -796,6 +835,14 @@ impl<'i> Formatter<'i> {
                 }
                 Descriptive::CodeInline(exprs) if exprs.len() == 1 => {
                     let expr = &exprs[0];
+                    // A bare `{ variable }` for which the runner has a bound
+                    // value renders as that value in place of the source name.
+                    if let Expression::Variable(name, _) = expr {
+                        if let Some(fragments) = subs.and_then(|subs| subs.lookup(name.value)) {
+                            line.add_value(fragments);
+                            continue;
+                        }
+                    }
                     match expr {
                         _ if is_tablet_list_expr(expr) => {
                             line.flush();
@@ -1548,6 +1595,36 @@ impl<'a, 'i> Line<'a, 'i> {
                 .push((syntax, Cow::Borrowed(word)));
             self.position += word.len() as u8;
         }
+    }
+
+    /// Splice a substituted variable's pre-styled fragments into the line as
+    /// one non-breaking unit, wrapping before it if it would overflow.
+    fn add_value(&mut self, fragments: &[(Syntax, Cow<'static, str>)]) {
+        let len: u8 = fragments
+            .iter()
+            .map(|(_, content)| content.len() as u8)
+            .sum();
+        if !self
+            .current
+            .is_empty()
+        {
+            if self.position + 1 + len
+                > self
+                    .output
+                    .width
+            {
+                self.wrap_line();
+            } else {
+                self.current
+                    .push((Syntax::Neutral, Cow::Borrowed(" ")));
+                self.position += 1;
+            }
+        }
+        for (syntax, content) in fragments {
+            self.current
+                .push((*syntax, content.clone()));
+        }
+        self.position += len;
     }
 
     fn add_inline_code(&mut self, expr: &'i Expression) {

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -248,6 +248,19 @@ fn render_fragments<'i>(fragments: &[(Syntax, Cow<'i, str>)], renderer: &dyn Ren
     result
 }
 
+/// Whether a word opens with sentence punctuation that should sit flush
+/// against the preceding token rather than after a separating space. Lets the
+/// formatter preserve `{ code },` written without an intervening space.
+fn hugs_left(word: &str) -> bool {
+    match word
+        .chars()
+        .next()
+    {
+        Some(c) => c == ',' || c == '.' || c == ';' || c == ':' || c == '!' || c == '?',
+        None => false,
+    }
+}
+
 /// A list reads as a tablet when it is non-empty and every element is a
 /// labelled value. Such lists are laid out and treated as blocks rather than
 /// inline.
@@ -788,11 +801,21 @@ impl<'i> Formatter<'i> {
     fn append_descriptives(&mut self, descriptives: &'i [Descriptive<'i>]) {
         let syntax = self.current;
         let mut line = self.builder();
+        // Whether the previous descriptive emitted an inline construct (code,
+        // application, binding). Sentence punctuation opening the next text
+        // then hugs it, preserving `{ code },` written without a space.
+        let mut after_construct = false;
 
         for descriptive in descriptives {
             match descriptive {
                 Descriptive::Text(text) => {
-                    line.add_breakable(syntax, text);
+                    if after_construct {
+                        line.add_breakable_hugging(syntax, text);
+                    } else {
+                        line.add_breakable(syntax, text);
+                    }
+                    after_construct = false;
+                    continue;
                 }
                 Descriptive::CodeInline(exprs) if exprs.len() == 1 => {
                     let expr = &exprs[0];
@@ -926,6 +949,7 @@ impl<'i> Formatter<'i> {
                     line.add_binding(inner_descriptive, variables);
                 }
             }
+            after_construct = true;
         }
 
         line.flush();
@@ -1519,6 +1543,26 @@ impl<'a, 'i> Line<'a, 'i> {
         }
     }
 
+    /// Like `add_breakable`, but a leading sentence-punctuation word hugs the
+    /// preceding token with no separating space, so `{ code },` round-trips.
+    fn add_breakable_hugging(&mut self, syntax: Syntax, content: &'i str) {
+        let mut words = content.split_ascii_whitespace();
+        if let Some(first) = words.next() {
+            if !self
+                .current
+                .is_empty()
+                && hugs_left(first)
+            {
+                self.add_hugging(syntax, first);
+            } else {
+                self.add_word(syntax, first);
+            }
+            for word in words {
+                self.add_word(syntax, word);
+            }
+        }
+    }
+
     fn add_word(&mut self, syntax: Syntax, word: &'i str) {
         if !self
             .current
@@ -1548,6 +1592,13 @@ impl<'a, 'i> Line<'a, 'i> {
                 .push((syntax, Cow::Borrowed(word)));
             self.position += word.len() as u8;
         }
+    }
+
+    /// Append a fragment that must hug the preceding token with no separating
+    /// space. Used for sentence punctuation written flush against an inline
+    /// construct, e.g. the `,` in `{ code },`.
+    fn add_hugging(&mut self, syntax: Syntax, word: &'i str) {
+        self.add_no_wrap(syntax, Cow::Borrowed(word));
     }
 
     fn add_inline_code(&mut self, expr: &'i Expression) {

--- a/src/program/types.rs
+++ b/src/program/types.rs
@@ -151,6 +151,9 @@ pub enum Operation<'i> {
     Bind {
         names: &'i [language::Identifier<'i>],
         value: Box<Operation<'i>>,
+        /// Inferred shape of the bound value, set in resolution: a wildcard
+        /// list `[*]` when the name is iterated by a `foreach`, else `None`.
+        inferred: Option<language::Genus<'i>>,
     },
 }
 

--- a/src/resolution/checks/resolver.rs
+++ b/src/resolution/checks/resolver.rs
@@ -4,6 +4,7 @@
 
 use std::path::Path;
 
+use crate::language;
 use crate::parsing;
 use crate::program::{ExecutableRef, Operation, SubroutineId, SubroutineRef};
 use crate::resolution::{resolve, ResolutionError};
@@ -359,4 +360,94 @@ settle(amount) : Owed -> Paid
     let mut program = translate(&document).expect("translate");
 
     resolve(&mut program).expect("resolve");
+}
+
+// Find the first single-name `Bind` whose name matches, returning its inferred
+// genus.
+fn inferred_for<'a>(op: &'a Operation<'a>, name: &str) -> Option<&'a Option<language::Genus<'a>>> {
+    match op {
+        Operation::Bind {
+            names, inferred, ..
+        } if names.len() == 1 && names[0].value == name => Some(inferred),
+        Operation::Bind { value, .. } | Operation::Step { body: value, .. } => {
+            inferred_for(value, name)
+        }
+        Operation::Sequence(ops) | Operation::List(ops) => ops
+            .iter()
+            .find_map(|op| inferred_for(op, name)),
+        Operation::Loop { over, body, .. } => over
+            .as_ref()
+            .and_then(|over| inferred_for(over, name))
+            .or_else(|| inferred_for(body, name)),
+        Operation::Section { body, .. } => inferred_for(body, name),
+        _ => None,
+    }
+}
+
+#[test]
+fn iterated_binding_is_inferred_list() {
+    // `regions` is bound by a descriptive step and then iterated by a foreach,
+    // so resolution marks it `[*]`.
+    let source = r#"
+% technique v1
+
+sweep :
+    1.  enumerate the regions ~ regions
+    2.  { foreach region in regions }
+        -   note { region }
+        "#
+    .trim_ascii();
+    let path = Path::new("Test.tq");
+    let document = parsing::parse(path, source).expect("parse");
+    let mut program = translate(&document).expect("translate");
+    resolve(&mut program).expect("resolve");
+
+    let inferred =
+        inferred_for(&program.subroutines[0].body, "regions").expect("regions bind present");
+    assert_eq!(
+        inferred,
+        &Some(language::Genus::List(language::Forma::new("*")))
+    );
+}
+
+#[test]
+fn non_iterated_binding_stays_unknown() {
+    // `noted` is bound but never iterated, so its shape is left `None`.
+    let source = r#"
+% technique v1
+
+record :
+    1.  write it down ~ noted
+    2.  confirm { noted }
+        "#
+    .trim_ascii();
+    let path = Path::new("Test.tq");
+    let document = parsing::parse(path, source).expect("parse");
+    let mut program = translate(&document).expect("translate");
+    resolve(&mut program).expect("resolve");
+
+    let inferred = inferred_for(&program.subroutines[0].body, "noted").expect("noted bind present");
+    assert_eq!(inferred, &None);
+}
+
+#[test]
+fn multi_name_binding_stays_unknown() {
+    // A tuple binding is never marked, even if one of its names is iterated:
+    // only single-name binds carry an inferred list shape.
+    let source = r#"
+% technique v1
+
+split :
+    1.  divide it ~ (regions, rest)
+    2.  { foreach region in regions }
+        -   note { region }
+        "#
+    .trim_ascii();
+    let path = Path::new("Test.tq");
+    let document = parsing::parse(path, source).expect("parse");
+    let mut program = translate(&document).expect("translate");
+    resolve(&mut program).expect("resolve");
+
+    // The tuple bind is skipped, so no single-name `regions` bind exists to mark.
+    assert!(inferred_for(&program.subroutines[0].body, "regions").is_none());
 }

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -58,6 +58,7 @@ pub fn resolve<'i>(program: &mut Program<'i>) -> Result<(), Vec<ResolutionError<
     let mut problems = Vec::new();
     for subroutine in &mut program.subroutines {
         resolve_operation(&mut subroutine.body, &known, &arities, &mut problems);
+        infer_iterated(&mut subroutine.body);
     }
     for subroutine in &program.subroutines {
         check_bindings(subroutine, &mut problems);
@@ -147,6 +148,130 @@ fn resolve_operation<'i>(
     }
 }
 
+// Annotate each single-name `Bind` whose name is later iterated by a `foreach`
+// with an inferred `[*]` genus, so the runner can offer list entry when
+// prompting for it. Two passes: gather the names used as bare loop collections,
+// then mark the matching binds. The gathered set is scope-insensitive — a name
+// reused across procedures would mark every same-named single bind — so the
+// analysis is confined to one subroutine body, where names are normally unique.
+fn infer_iterated(body: &mut Operation) {
+    let mut iterated = HashSet::new();
+    gather_iterated(body, &mut iterated);
+    mark_iterated(body, &iterated);
+}
+
+fn gather_iterated<'i>(op: &Operation<'i>, iterated: &mut HashSet<&'i str>) {
+    match op {
+        Operation::Loop { over, body, .. } => {
+            if let Some(over) = over {
+                if let Operation::Variable(id) = over.as_ref() {
+                    iterated.insert(id.value);
+                }
+                gather_iterated(over, iterated);
+            }
+            gather_iterated(body, iterated);
+        }
+        Operation::Bind { value, .. } => gather_iterated(value, iterated),
+        Operation::Sequence(ops) | Operation::List(ops) => {
+            for op in ops {
+                gather_iterated(op, iterated);
+            }
+        }
+        Operation::Section { title, body, .. } => {
+            if let Some(title) = title {
+                gather_iterated(title, iterated);
+            }
+            gather_iterated(body, iterated);
+        }
+        Operation::Step { body, .. } => gather_iterated(body, iterated),
+        Operation::Invoke(invocable) => {
+            for arg in &invocable.arguments {
+                gather_iterated(arg, iterated);
+            }
+        }
+        Operation::Execute(executable) => {
+            for arg in &executable.arguments {
+                gather_iterated(arg, iterated);
+            }
+        }
+        Operation::String(fragments) => {
+            for fragment in fragments {
+                if let Fragment::Interpolation(op) = fragment {
+                    gather_iterated(op, iterated);
+                }
+            }
+        }
+        Operation::Tablet(entries) => {
+            for entry in entries {
+                gather_iterated(&entry.value, iterated);
+            }
+        }
+        Operation::Variable(_)
+        | Operation::Number(_)
+        | Operation::Multiline(_, _)
+        | Operation::Hole => {}
+    }
+}
+
+fn mark_iterated<'i>(op: &mut Operation<'i>, iterated: &HashSet<&str>) {
+    match op {
+        Operation::Bind {
+            names,
+            value,
+            inferred,
+        } => {
+            if names.len() == 1 && iterated.contains(names[0].value) {
+                *inferred = Some(language::Genus::List(language::Forma::new("*")));
+            }
+            mark_iterated(value, iterated);
+        }
+        Operation::Loop { over, body, .. } => {
+            if let Some(over) = over {
+                mark_iterated(over, iterated);
+            }
+            mark_iterated(body, iterated);
+        }
+        Operation::Sequence(ops) | Operation::List(ops) => {
+            for op in ops {
+                mark_iterated(op, iterated);
+            }
+        }
+        Operation::Section { title, body, .. } => {
+            if let Some(title) = title {
+                mark_iterated(title, iterated);
+            }
+            mark_iterated(body, iterated);
+        }
+        Operation::Step { body, .. } => mark_iterated(body, iterated),
+        Operation::Invoke(invocable) => {
+            for arg in &mut invocable.arguments {
+                mark_iterated(arg, iterated);
+            }
+        }
+        Operation::Execute(executable) => {
+            for arg in &mut executable.arguments {
+                mark_iterated(arg, iterated);
+            }
+        }
+        Operation::String(fragments) => {
+            for fragment in fragments {
+                if let Fragment::Interpolation(op) = fragment {
+                    mark_iterated(op, iterated);
+                }
+            }
+        }
+        Operation::Tablet(entries) => {
+            for entry in entries {
+                mark_iterated(&mut entry.value, iterated);
+            }
+        }
+        Operation::Variable(_)
+        | Operation::Number(_)
+        | Operation::Multiline(_, _)
+        | Operation::Hole => {}
+    }
+}
+
 // Flag any Variable read that names nothing yet in scope. Scope starts with
 // the subroutine's parameters and grows as the walk passes each `Bind`/`Loop`
 // in execution order — so a read is bound only if its name was bound by an
@@ -178,7 +303,7 @@ fn check_scope<'i>(
         // A binding's value is evaluated before its name is bound, so the
         // value is checked against the scope as it stands; only then do the
         // names come into scope for what follows.
-        Operation::Bind { names, value } => {
+        Operation::Bind { names, value, .. } => {
             check_scope(value, scope, problems);
             for name in *names {
                 scope.insert(name.value);

--- a/src/runner/checks/driver.rs
+++ b/src/runner/checks/driver.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::runner::driver::{
-    draw, Automatic, Console, Driver, Event, Interaction, Mock, UserInput,
+    draw, edit, is_list_forma, Automatic, Console, Driver, Event, Interaction, Mock, UserInput,
 };
 use crate::value::{Numeric, Value};
 
@@ -494,4 +494,59 @@ fn render_choices_lists_options() {
     assert!(written.contains('▶'));
     assert!(written.contains("Yes"));
     assert!(written.contains("No"));
+}
+
+#[test]
+fn is_list_forma_recognises_brackets() {
+    assert!(is_list_forma(Some("[*]")));
+    assert!(is_list_forma(Some("[Region]")));
+    assert!(!is_list_forma(Some("Region")));
+    assert!(!is_list_forma(Some("()")));
+    assert!(!is_list_forma(None));
+}
+
+// A bracketed list field, as prompt_acquire seeds it for an iterated binding.
+fn list_prompt() -> Interaction {
+    Interaction {
+        field: edit(String::new(), Value::Literali(String::new()), true),
+        menu: None,
+        reason: None,
+    }
+}
+
+#[test]
+fn list_prompt_empty_submits_empty_list() {
+    // Enter on an untouched list field yields `[]`, which coerce_to_list reads
+    // as zero iterations.
+    let mut it = list_prompt();
+    assert_eq!(
+        it.handle(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(UserInput::Done(Value::Literali("[]".to_string())))
+    );
+}
+
+#[test]
+fn list_prompt_wraps_typed_buffer() {
+    // Whatever the operator types is wrapped in brackets on submit, so the
+    // result parses through the existing list-literal path.
+    let mut it = list_prompt();
+    for c in "east, west".chars() {
+        it.handle(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+    }
+    assert_eq!(
+        it.handle(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(UserInput::Done(Value::Literali("[east, west]".to_string())))
+    );
+}
+
+#[test]
+fn list_prompt_draws_bracketed_buffer() {
+    let mut it = list_prompt();
+    for c in "east".chars() {
+        it.handle(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+    }
+    let mut out: Vec<u8> = Vec::new();
+    draw(&mut out, "I/1", "↘", &it).expect("draw");
+    let written = String::from_utf8(out).expect("utf8");
+    assert!(written.contains("[east]"));
 }

--- a/src/runner/checks/driver.rs
+++ b/src/runner/checks/driver.rs
@@ -23,7 +23,7 @@ fn mock_returns_canned_answers_in_order() {
 #[test]
 fn mock_records_step_and_ask_events() {
     let mut p = Mock::with_answers([UserInput::Done(Value::Unitus)]);
-    p.step("/local_network:I/1", "Check the cable.");
+    p.step("/local_network:I/1", "Check the cable.", 1);
     let _ = p.ask("/local_network:I/1", &[], Value::Unitus, true);
     assert_eq!(
         p.events(),
@@ -80,10 +80,23 @@ fn mock_ask_without_answers_panics() {
 fn console_step_writes_fqn_and_description() {
     let mut output: Vec<u8> = Vec::new();
     let mut p = Console::with_output(&mut output);
-    p.step("local_network:I/1", "Check the cable.");
+    p.step("local_network:I/1", "Check the cable.", 1);
     let written = String::from_utf8(output).expect("utf8");
     assert!(written.contains("→ local_network:I/1"));
     assert!(written.contains("    Check the cable."));
+}
+
+#[test]
+fn console_step_indents_description_to_depth() {
+    let mut output: Vec<u8> = Vec::new();
+    let mut p = Console::with_output(&mut output);
+    // A depth-2 substep indents its prose by eight spaces while the marker
+    // stays at the left margin.
+    p.step("local_network:I/1/a", "Inspect the connector.", 2);
+    let written = String::from_utf8(output).expect("utf8");
+    assert!(written.contains("→ local_network:I/1/a"));
+    assert!(written.contains("\n        Inspect the connector."));
+    assert!(!written.contains("\n    Inspect the connector."));
 }
 
 #[test]

--- a/src/runner/checks/evaluator.rs
+++ b/src/runner/checks/evaluator.rs
@@ -404,6 +404,17 @@ fn coerce_list_passthrough_and_widening() {
         coerce_to_list(value::Value::Literali("solo".to_string())).expect("coerced"),
         vec![value::Value::Literali("solo".to_string())]
     );
+
+    // A blank answer (the empty default at a list prompt) is the empty list,
+    // so a `foreach` over it runs zero times rather than once over "".
+    assert_eq!(
+        coerce_to_list(value::Value::Literali(String::new())).expect("coerced"),
+        Vec::<value::Value>::new()
+    );
+    assert_eq!(
+        coerce_to_list(value::Value::Literali("   ".to_string())).expect("coerced"),
+        Vec::<value::Value>::new()
+    );
 }
 
 #[test]

--- a/src/runner/checks/evaluator.rs
+++ b/src/runner/checks/evaluator.rs
@@ -135,6 +135,7 @@ fn bind_extends_env_for_subsequent_lookup() {
     let bind = Operation::Bind {
         names: &names,
         value: Box::new(Operation::String(vec![Fragment::Text("Hello")])),
+        inferred: None,
     };
     let lookup = Operation::Variable(Identifier::new("greeting"));
     let seq = Operation::Sequence(vec![bind, lookup]);
@@ -190,6 +191,7 @@ fn multi_name_bind_destructures_parametriq() {
     let bind = Operation::Bind {
         names: &names,
         value: Box::new(Operation::Variable(Identifier::new("triple"))),
+        inferred: None,
     };
     let result = evaluate(&library, &context, &mut env, &bind).expect("evaluated");
     assert_eq!(result, value::Value::Unitus);
@@ -227,6 +229,7 @@ fn multi_name_bind_wrong_arity_errors() {
     let bind = Operation::Bind {
         names: &names,
         value: Box::new(Operation::Variable(Identifier::new("pair"))),
+        inferred: None,
     };
     match evaluate(&library, &context, &mut env, &bind) {
         Err(RunnerError::BindArityMismatch { expected, actual }) => {
@@ -250,6 +253,7 @@ fn multi_name_bind_against_scalar_errors_as_not_tuple() {
     let bind = Operation::Bind {
         names: &names,
         value: Box::new(Operation::Variable(Identifier::new("scalar"))),
+        inferred: None,
     };
     match evaluate(&library, &context, &mut env, &bind) {
         Err(RunnerError::BindNotTuple { expected }) => {

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -637,12 +637,10 @@ test :
             }
         })
         .collect();
-    // Both steps render from their source paragraphs: the binding syntax
-    // and the interpolation reference are shown as-written, with ordinals.
-    assert_eq!(
-        descriptions,
-        vec!["1.  { 42 ~ answer }", "2.  Result: { answer }"]
-    );
+    // Step 1's binding syntax shows as-written (the value isn't bound until
+    // its body walks). By step 2 `answer` is bound, so its interpolation
+    // renders the value in place of the variable name.
+    assert_eq!(descriptions, vec!["1.  { 42 ~ answer }", "2.  Result: 42"]);
 }
 
 #[test]
@@ -1030,9 +1028,10 @@ greet(name) :
             _ => None,
         })
         .collect();
-    // The step renders from its source paragraph, showing the template.
-    // `greet` is a top-level procedure, addressed at its own root.
-    assert_eq!(steps, vec![("/greet:/1", "1.  Hello { name }")]);
+    // `name` is bound to the invocation argument, so the step renders the
+    // value in place of the interpolation. `greet` is a top-level procedure,
+    // addressed at its own root.
+    assert_eq!(steps, vec![("/greet:/1", "1.  Hello \"World\"")]);
 }
 
 #[test]
@@ -1490,7 +1489,7 @@ fn foreach_walks_body_once_per_list_element() {
         .collect();
     assert_eq!(
         steps,
-        vec![("/[1]/a", "a.  { item }"), ("/[2]/a", "a.  { item }")]
+        vec![("/[1]/a", "a.  \"first\""), ("/[2]/a", "a.  \"second\"")]
     );
 }
 
@@ -1573,9 +1572,9 @@ fn foreach_over_seq_builtin_runs() {
     assert_eq!(
         steps,
         vec![
-            ("/[1]/a", "a.  { n }"),
-            ("/[2]/a", "a.  { n }"),
-            ("/[3]/a", "a.  { n }"),
+            ("/[1]/a", "a.  1"),
+            ("/[2]/a", "a.  2"),
+            ("/[3]/a", "a.  3"),
         ]
     );
 }
@@ -1658,10 +1657,7 @@ fn foreach_destructures_tuple_elements() {
             _ => None,
         })
         .collect();
-    assert_eq!(
-        steps,
-        vec!["a.  { first } / { second }", "a.  { first } / { second }"]
-    );
+    assert_eq!(steps, vec!["a.  \"a\" / \"b\"", "a.  \"c\" / \"d\""]);
 }
 
 #[test]
@@ -1724,7 +1720,7 @@ fn foreach_widens_primitive_to_singleton() {
             _ => None,
         })
         .collect();
-    assert_eq!(steps, vec![("/[1]/a", "a.  { item }")]);
+    assert_eq!(steps, vec![("/[1]/a", "a.  \"lonely\"")]);
 }
 
 #[test]
@@ -2027,7 +2023,7 @@ greet(name) :
             }
         })
         .collect();
-    assert_eq!(descriptions, vec!["1.  Hello { name }"]);
+    assert_eq!(descriptions, vec!["1.  Hello \"world\""]);
 }
 
 #[test]

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -2007,7 +2007,7 @@ connectivity_check(e, s, address) :
         .unwrap()
         .parameters
         .unwrap();
-    let echo = render_argument_echo("connectivity_check", params, &env);
+    let echo = render_argument_echo("connectivity_check:", params, &env);
     assert_eq!(
         echo,
         "connectivity_check: ([] ~ e, 0 ~ s, \"10 Downing Street\" ~ address)"

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1449,12 +1449,14 @@ fn foreach_walks_body_once_per_list_element() {
         .subroutines
         .push(sub);
 
+    // A string and a number, so the echo pins both: a string value shows
+    // quoted, a number bare.
     let mut env = Environment::new();
     env.extend(
         "items".to_string(),
         Value::Arraeum(vec![
             Value::Literali("first".to_string()),
-            Value::Literali("second".to_string()),
+            Value::Quanticle(crate::value::Numeric::Integral(5)),
         ]),
     );
 
@@ -1491,6 +1493,21 @@ fn foreach_walks_body_once_per_list_element() {
     assert_eq!(
         steps,
         vec![("/[1]/a", "a.  { item }"), ("/[2]/a", "a.  { item }")]
+    );
+
+    // Each iteration's descent echoes the loop variable bound for that pass,
+    // in the same `value ~ name` form a procedure call's arguments use.
+    let enters: Vec<&str> = prompt
+        .events()
+        .iter()
+        .filter_map(|event| match event {
+            Event::Enter { qualified } => Some(qualified.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        enters,
+        vec!["/[1] (\"first\" ~ item)", "/[2] (5 ~ item)"]
     );
 }
 

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1505,10 +1505,7 @@ fn foreach_walks_body_once_per_list_element() {
             _ => None,
         })
         .collect();
-    assert_eq!(
-        enters,
-        vec!["/[1] (\"first\" ~ item)", "/[2] (5 ~ item)"]
-    );
+    assert_eq!(enters, vec!["/[1] (\"first\" ~ item)", "/[2] (5 ~ item)"]);
 }
 
 #[test]
@@ -2743,4 +2740,123 @@ fn resume_restores_invoke_input_without_reprompting() {
         })
         .count();
     assert_eq!(acquired, 0);
+}
+
+#[test]
+fn iterated_binding_prompts_as_list() {
+    // `regions` is bound by a descriptive step and then iterated by a foreach,
+    // so resolution marks it `[*]` and the prompt carries that forma. An empty
+    // answer (`[]`) iterates zero times, so the substep never runs.
+    let source = r#"
+% technique v1
+
+sweep :
+
+1.  enumerate the regions ~ regions
+2.  { foreach region in regions }
+    -   note { region }
+        "#
+    .trim_ascii();
+    let document = parsing::parse(Path::new("Test.tq"), source).expect("parse");
+    let mut program = translate(&document).expect("translate");
+    resolve(&mut program).expect("resolve");
+
+    let mut fixture = StoreFixture::new("iterated-binding");
+    let prompt = Mock::with_answers([
+        UserInput::Done(Value::Literali("[]".to_string())),
+        UserInput::Done(Value::Unitus),
+        UserInput::Done(Value::Unitus),
+        UserInput::Done(Value::Unitus),
+    ]);
+    let mut runner = Runner::new(
+        &program,
+        fixture.take_appender(),
+        HashMap::new(),
+        prompt,
+        Library::stub(),
+    );
+    runner
+        .run(Environment::new())
+        .expect("run");
+
+    let prompt = runner.into_driver();
+    let acquired: Vec<(Option<&str>, Option<&str>)> = prompt
+        .events()
+        .iter()
+        .filter_map(|e| {
+            if let Event::Acquire { name, forma } = e {
+                Some((
+                    name.as_ref()
+                        .map(String::as_str),
+                    forma
+                        .as_ref()
+                        .map(String::as_str),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(acquired, vec![(Some("regions"), Some("[*]"))]);
+}
+
+#[test]
+fn declared_list_parameter_prompts_bracketed() {
+    // A procedure declaring a single list parameter `[Region]` is invoked with
+    // a hole, so its argument is acquired at entry — and the forma renders
+    // bracketed so the driver offers list entry.
+    let source = r#"
+% technique v1
+
+main :
+
+{
+    <sweep>(?)
+}
+
+sweep(regions) : [Region] -> ()
+
+1.  note { regions }
+        "#
+    .trim_ascii();
+    let document = parsing::parse(Path::new("Test.tq"), source).expect("parse");
+    let mut program = translate(&document).expect("translate");
+    resolve(&mut program).expect("resolve");
+
+    let mut fixture = StoreFixture::new("declared-list-param");
+    let prompt = Mock::with_answers([
+        UserInput::Done(Value::Literali("[]".to_string())),
+        UserInput::Done(Value::Unitus),
+        UserInput::Done(Value::Unitus),
+    ]);
+    let mut runner = Runner::new(
+        &program,
+        fixture.take_appender(),
+        HashMap::new(),
+        prompt,
+        Library::stub(),
+    );
+    runner
+        .run(Environment::new())
+        .expect("run");
+
+    let prompt = runner.into_driver();
+    let acquired: Vec<(Option<&str>, Option<&str>)> = prompt
+        .events()
+        .iter()
+        .filter_map(|e| {
+            if let Event::Acquire { name, forma } = e {
+                Some((
+                    name.as_ref()
+                        .map(String::as_str),
+                    forma
+                        .as_ref()
+                        .map(String::as_str),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(acquired, vec![(Some("regions"), Some("[Region]"))]);
 }

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1774,12 +1774,14 @@ fn foreach_over_unit_iterates_nothing() {
 }
 
 #[test]
-fn foreach_over_non_list_or_unbound_errors() {
+fn foreach_over_non_list_errors_unbound_is_empty() {
     // foreach item in source, where `source` is supplied by the caller's
     // environment. A tuple or tablet source is `NotIterable` (lists iterate
     // and scalars widen, but a tablet is a record that must be projected via
-    // values()/labels()/pairs() first, and a tuple does neither); an unbound
-    // source propagates `UnboundVariable` rather than being swallowed.
+    // values()/labels()/pairs() first, and a tuple does neither). An unbound
+    // `source` iterates nothing rather than aborting: a statically undefined
+    // name is caught earlier by resolution, so a name unbound at runtime is one
+    // a zero-iteration or skipped loop never populated.
     let names = [Identifier::new("item")];
     let loop_op = Operation::Loop {
         names: &names,
@@ -1839,7 +1841,8 @@ fn foreach_over_non_list_or_unbound_errors() {
         other => panic!("expected NotIterable, got {:?}", other),
     }
 
-    // An unbound `source` propagates the evaluation error.
+    // An unbound `source` iterates nothing: the run completes and the loop
+    // body never executes.
     let mut unbound_fixture = StoreFixture::new("foreach-unbound");
     let mut runner = Runner::new(
         &program,
@@ -1849,10 +1852,18 @@ fn foreach_over_non_list_or_unbound_errors() {
         Library::stub(),
     );
     let env = Environment::new();
-    match runner.run(env) {
-        Err(RunnerError::UnboundVariable(name)) => assert_eq!(name, "source"),
-        other => panic!("expected UnboundVariable, got {:?}", other),
-    }
+    runner
+        .run(env)
+        .expect("run");
+    let ran = runner
+        .into_driver()
+        .events()
+        .iter()
+        .any(|event| match event {
+            Event::Step { .. } => true,
+            _ => false,
+        });
+    assert!(!ran, "loop body must not run when source is unbound");
 }
 
 #[test]

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1966,7 +1966,7 @@ fn argument_echo_binds_each_parameter() {
     let source = r#"
 % technique v1
 
-connectivity_check(e, s) :
+connectivity_check(e, s, address) :
 
 1.  step
         "#
@@ -1974,7 +1974,11 @@ connectivity_check(e, s) :
     let document = parsing::parse(Path::new("Test.tq"), source).expect("parse");
     let mut program = translate(&document).expect("translate");
     resolve(&mut program).expect("resolve");
-    let args = ["[]".to_string(), "0".to_string()];
+    let args = [
+        "[]".to_string(),
+        "0".to_string(),
+        "10 Downing Street".to_string(),
+    ];
     let env = bind_parameters(&program, &args).expect("bind");
     let params = program
         .subroutines
@@ -1983,7 +1987,10 @@ connectivity_check(e, s) :
         .parameters
         .unwrap();
     let echo = render_argument_echo("connectivity_check", params, &env);
-    assert_eq!(echo, "connectivity_check: ([] ~ e, 0 ~ s)");
+    assert_eq!(
+        echo,
+        "connectivity_check: ([] ~ e, 0 ~ s, \"10 Downing Street\" ~ address)"
+    );
 }
 
 #[test]

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -48,10 +48,12 @@ pub enum UserInput {
 /// console `Console`, the no-operator `Automatic`, the no-output `Headless`,
 /// the debugging `Transcript`, and the test `Mock`.
 pub trait Driver {
-    /// Show the step's Qualified Name and rendered description.
-    /// The implementation displays them; it does not block waiting for
-    /// input — the walker calls `ask` for that separately.
-    fn step(&mut self, qualified: &str, description: &str);
+    /// Show the step's Qualified Name and rendered description. `depth` is the
+    /// step's document nesting level (one-origin), indenting the description to
+    /// match while the `→` marker stays at the left margin. The implementation
+    /// displays them; it does not block waiting for input — the walker calls
+    /// `ask` for that separately.
+    fn step(&mut self, qualified: &str, description: &str, depth: usize);
 
     /// Announce descent into a named scope — a Section or an invoked
     /// subroutine — with its Qualified Name (the `↘` marker).
@@ -157,9 +159,15 @@ impl<W: Write> Console<W> {
 }
 
 impl<W: Write> Driver for Console<W> {
-    fn step(&mut self, fqn: &str, description: &str) {
+    fn step(&mut self, fqn: &str, description: &str, depth: usize) {
         let renderer = self.renderer();
-        render_step(&mut self.output, &display_path(fqn), description, renderer);
+        render_step(
+            &mut self.output,
+            &display_path(fqn),
+            description,
+            depth,
+            renderer,
+        );
     }
 
     fn enter(&mut self, qualified: &str) {
@@ -380,8 +388,16 @@ fn interact<W: Write>(
 /// Write text indented by four spaces, replicating the canonical source
 /// layout the code formatter emits.
 fn write_indented<W: Write>(out: &mut W, text: &str) {
+    write_indented_by(out, text, 1);
+}
+
+/// Write text indented by four spaces per `depth` level, so a step's prose
+/// sits at the same nesting it has in the source document. A `depth` of zero
+/// is treated as one — every step is indented at least one level.
+fn write_indented_by<W: Write>(out: &mut W, text: &str, depth: usize) {
+    let pad = " ".repeat(4 * depth.max(1));
     for line in text.lines() {
-        let _ = writeln!(out, "    {}", line);
+        let _ = writeln!(out, "{}{}", pad, line);
     }
 }
 
@@ -389,11 +405,18 @@ fn write_marker_line<W: Write>(out: &mut W, text: &str, renderer: &dyn Render) {
     let _ = writeln!(out, "{}", renderer.style(Syntax::Marker, text));
 }
 
-/// Render a step's `→` line and description.
-fn render_step<W: Write>(out: &mut W, fqn: &str, description: &str, renderer: &dyn Render) {
+/// Render a step's `→` line and description. The marker stays at the left
+/// margin; the description is indented to its document nesting `depth`.
+fn render_step<W: Write>(
+    out: &mut W,
+    fqn: &str,
+    description: &str,
+    depth: usize,
+    renderer: &dyn Render,
+) {
     write_marker_line(out, &format!("→ {}", fqn), renderer);
     let _ = writeln!(out);
-    write_indented(out, description);
+    write_indented_by(out, description, depth);
     let _ = writeln!(out);
 }
 
@@ -1100,11 +1123,12 @@ impl<W: Write> Automatic<W> {
 }
 
 impl<W: Write> Driver for Automatic<W> {
-    fn step(&mut self, fqn: &str, description: &str) {
+    fn step(&mut self, fqn: &str, description: &str, depth: usize) {
         render_step(
             &mut self.output,
             &display_path(fqn),
             description,
+            depth,
             self.renderer,
         );
     }
@@ -1263,12 +1287,12 @@ impl<D, W: Write> Transcript<D, W> {
 }
 
 impl<D: Driver, W: Write> Driver for Transcript<D, W> {
-    fn step(&mut self, qualified: &str, description: &str) {
+    fn step(&mut self, qualified: &str, description: &str, depth: usize) {
         self.emit(Trace::Enter {
             path: qualified.to_string(),
         });
         self.inner
-            .step(qualified, description);
+            .step(qualified, description, depth);
     }
 
     fn enter(&mut self, qualified: &str) {
@@ -1395,7 +1419,7 @@ impl Headless {
 }
 
 impl Driver for Headless {
-    fn step(&mut self, _qualified: &str, _description: &str) {}
+    fn step(&mut self, _qualified: &str, _description: &str, _depth: usize) {}
 
     fn enter(&mut self, _qualified: &str) {}
 
@@ -1533,7 +1557,7 @@ impl Mock {
 
 #[cfg(test)]
 impl Driver for Mock {
-    fn step(&mut self, fqn: &str, description: &str) {
+    fn step(&mut self, fqn: &str, description: &str, _depth: usize) {
         self.events
             .push(Event::Step {
                 qualified: fqn.to_string(),

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -236,7 +236,7 @@ impl<W: Write> Driver for Console<W> {
             name.unwrap_or("?"),
             forma.unwrap_or("?")
         );
-        prompt_acquire(&mut self.output, &label)
+        prompt_acquire(&mut self.output, &label, is_list_forma(forma))
     }
 
     fn renderer(&self) -> &'static dyn Render {
@@ -292,7 +292,11 @@ fn prompt_action<W: Write>(
 /// and the step's own verdict prompt judges the result.
 fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserInput {
     let qualified = display_path(qualified);
-    let field = edit(script.to_string(), Value::Literali(script.to_string()));
+    let field = edit(
+        script.to_string(),
+        Value::Literali(script.to_string()),
+        false,
+    );
     let result = interact(
         out,
         Interaction {
@@ -334,8 +338,8 @@ fn prompt_command<W: Write>(out: &mut W, qualified: &str, script: &str) -> UserI
 /// Solicit a deferred input on the `▶` prompt line: `<Enter>` accepts the
 /// empty default, typing overrides it; the `<Esc>` menu and `<Ctrl-C>` abandon
 /// the call.
-fn prompt_acquire<W: Write>(out: &mut W, label: &str) -> UserInput {
-    let field = edit(String::new(), Value::Literali(String::new()));
+fn prompt_acquire<W: Write>(out: &mut W, label: &str, list: bool) -> UserInput {
+    let field = edit(String::new(), Value::Literali(String::new()), list);
     let result = interact(
         out,
         Interaction {
@@ -546,6 +550,9 @@ enum Field {
         cursor: usize,
         edited: bool,
         original: Value,
+        /// A list field renders its buffer between `[` and `]` and submits the
+        /// buffer wrapped as `[buffer]`, so an empty answer yields `[]`.
+        bracketed: bool,
     },
     Frozen {
         produced: Value,
@@ -648,7 +655,7 @@ impl Interaction {
         if let Field::Frozen { produced } = &mut self.field {
             let taken = std::mem::replace(produced, Value::Unitus);
             match editable_seed(&taken) {
-                Some(seed) => self.field = edit(seed, taken),
+                Some(seed) => self.field = edit(seed, taken, false),
                 None => self.field = Field::Frozen { produced: taken },
             }
         }
@@ -772,9 +779,15 @@ impl Interaction {
                 cursor,
                 edited,
                 original,
+                bracketed,
             } => match code {
                 KeyCode::Enter => {
-                    if !*edited {
+                    if *bracketed {
+                        // A list field always submits its buffer wrapped, so an
+                        // empty answer is `[]` and `coerce_to_list` iterates it
+                        // zero times.
+                        Some(UserInput::Done(Value::Literali(format!("[{}]", buffer))))
+                    } else if !*edited {
                         // Unchanged: return the original value verbatim, with
                         // its type and exact value intact.
                         Some(UserInput::Done(std::mem::replace(original, Value::Unitus)))
@@ -898,10 +911,22 @@ fn draw_tail<W: Write>(
             None => render_menu(out, interaction, active)?,
         },
         None => match &interaction.field {
-            Field::Edit { buffer, cursor, .. } => {
-                write!(out, "{}", buffer)?;
+            Field::Edit {
+                buffer,
+                cursor,
+                bracketed,
+                ..
+            } => {
+                let lead = if *bracketed {
+                    write!(out, "[{}]", buffer)?;
+                    1
+                } else {
+                    write!(out, "{}", buffer)?;
+                    0
+                };
                 cursor_col = Some(
                     prefix
+                        + lead
                         + buffer[..*cursor]
                             .chars()
                             .count() as u16,
@@ -1023,13 +1048,23 @@ fn editable_seed(produced: &Value) -> Option<String> {
 
 /// Build an editable field from a scalar's text, cursor at the end. The
 /// `original` value is returned verbatim if the buffer is accepted unedited.
-fn edit(buffer: String, original: Value) -> Field {
+fn edit(buffer: String, original: Value, bracketed: bool) -> Field {
     let cursor = buffer.len();
     Field::Edit {
         buffer,
         cursor,
         edited: false,
         original,
+        bracketed,
+    }
+}
+
+/// Whether a forma display string reads as a list (`[…]`), the cue for the
+/// bracketed list-entry prompt.
+fn is_list_forma(forma: Option<&str>) -> bool {
+    match forma {
+        Some(text) => text.starts_with('[') && text.ends_with(']'),
+        None => false,
     }
 }
 

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -194,9 +194,24 @@ pub(super) fn coerce_to_list(value: Value) -> Result<Vec<Value>, RunnerError> {
     }
 }
 
-/// Parse a `[ "a", b, ... ]` literal into its elements, each a string with
-/// any surrounding quotes stripped. Returns `None` for text that is not
-/// bracketed. Commas inside element text are not supported.
+/// Coerce a raw user-supplied string — a command-line argument or an unquoted
+/// list element — into its natural Value type: a `[ … ]` literal becomes a
+/// list, a number becomes a quantity, anything else stays a string.
+pub(super) fn parse_value(text: &str) -> Value {
+    let trimmed = text.trim();
+    if let Some(items) = parse_list_literal(trimmed) {
+        return Value::Arraeum(items);
+    }
+    if let Some(numeric) = crate::parsing::parse_numeric(trimmed) {
+        return Value::Quanticle(Numeric::from(&numeric));
+    }
+    Value::Literali(text.to_string())
+}
+
+/// Parse a `[ "a", b, ... ]` literal into its elements. A quoted element is a
+/// string verbatim; an unquoted one takes its natural type via `parse_value`.
+/// Returns `None` for text that is not bracketed. TODO This splits naively on
+/// ',' so commas inside element text are not supported.
 fn parse_list_literal(text: &str) -> Option<Vec<Value>> {
     let inner = text
         .trim()
@@ -212,11 +227,13 @@ fn parse_list_literal(text: &str) -> Option<Vec<Value>> {
         .split(',')
         .map(|element| {
             let element = element.trim();
-            let unquoted = element
+            match element
                 .strip_prefix('"')
                 .and_then(|e| e.strip_suffix('"'))
-                .unwrap_or(element);
-            Value::Literali(unquoted.to_string())
+            {
+                Some(unquoted) => Value::Literali(unquoted.to_string()),
+                None => parse_value(element),
+            }
         })
         .collect();
     Some(items)

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -1,11 +1,13 @@
 //! Variable bindings and the evaluator that turns value-bearing
 //! Operations into Values for description rendering and binding.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use super::context::Context;
 use super::library::Library;
 use super::runner::RunnerError;
+use crate::formatting::{Substitutions, Syntax};
 use crate::program::{ExecutableRef, Fragment, Operation};
 use crate::value::{Numeric, Value};
 
@@ -33,6 +35,34 @@ impl Environment {
     pub fn extend(&mut self, name: String, value: Value) {
         self.bindings
             .insert(name, value);
+    }
+
+    /// Pre-styled fragments for each bound value, for splicing into a step's
+    /// prose where it interpolates that variable. See `render_value`.
+    pub fn substitutions(&self) -> Substitutions {
+        let mut subs = Substitutions::new();
+        for (name, value) in &self.bindings {
+            if let Some(fragments) = render_value(value) {
+                subs.insert(name.clone(), fragments);
+            }
+        }
+        subs
+    }
+}
+
+/// Pre-styled fragments for splicing a bound value into a step's prose,
+/// highlighted as it would be in source: strings quoted, numbers bare. Value
+/// kinds with no sensible inline prose form yield None, leaving the variable's
+/// `{ name }` interpolation to render as written.
+fn render_value(value: &Value) -> Option<Vec<(Syntax, Cow<'static, str>)>> {
+    match value {
+        Value::Literali(text) => Some(vec![
+            (Syntax::Quote, Cow::Borrowed("\"")),
+            (Syntax::String, Cow::Owned(text.clone())),
+            (Syntax::Quote, Cow::Borrowed("\"")),
+        ]),
+        Value::Quanticle(numeric) => Some(vec![(Syntax::Numeric, Cow::Owned(numeric.to_string()))]),
+        _ => None,
     }
 }
 

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -153,7 +153,7 @@ pub fn evaluate<'i>(
             }
             Ok(Value::Arraeum(values))
         }
-        Operation::Bind { names, value } => {
+        Operation::Bind { names, value, .. } => {
             let v = evaluate(library, context, env, value)?;
             bind_names(env, names, v)?;
             Ok(Value::Unitus)

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -177,14 +177,22 @@ pub fn evaluate<'i>(
 }
 
 /// Reduce a value to the elements a `foreach` iterates. A list yields its
-/// members; `Unit` (the absence of a value) is empty; a string acquired at a
-/// prompt may be a `[a, b]` literal, which parses into its elements, else it
-/// is a one-element list; a bare quantity widens likewise. A tablet, tuple,
-/// or future is not iterable.
+/// members; `Unit` (the absence of a value) is empty; a blank string (an empty
+/// prompt answer) is likewise empty, so a `foreach` over it runs zero times; a
+/// non-blank string may be a `[a, b]` literal, which parses into its elements,
+/// else it is a one-element list; a bare quantity widens likewise. A tablet,
+/// tuple, or future is not iterable.
 pub(super) fn coerce_to_list(value: Value) -> Result<Vec<Value>, RunnerError> {
     match value {
         Value::Arraeum(items) => Ok(items),
         Value::Unitus => Ok(Vec::new()),
+        Value::Literali(text)
+            if text
+                .trim()
+                .is_empty() =>
+        {
+            Ok(Vec::new())
+        }
         Value::Literali(text) => match parse_list_literal(&text) {
             Some(items) => Ok(items),
             None => Ok(vec![Value::Literali(text)]),

--- a/src/runner/path.rs
+++ b/src/runner/path.rs
@@ -52,6 +52,21 @@ impl<'i> QualifiedPath<'i> {
         std::mem::replace(&mut self.segments, segments)
     }
 
+    /// Document indentation level of the current step: the count of nested
+    /// step scopes on the path — dependent and parallel steps and rendered
+    /// attribute frames. Iteration, section, procedure, and external segments
+    /// carry no visual indent, matching the formatter's nesting.
+    pub fn depth(&self) -> usize {
+        self.segments
+            .iter()
+            .filter(|segment| match segment {
+                PathSegment::DependentStep(_) | PathSegment::ParallelStep(_) => true,
+                PathSegment::Attributes(frame) => render_attributes(frame).is_some(),
+                _ => false,
+            })
+            .count()
+    }
+
     /// Render the current path as a PFFTT absolute path string, always
     /// rooted at `/`. The full enclosing hierarchy is shown: every scope
     /// level is its own `/`-delimited component, with a `Procedure`

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -894,7 +894,7 @@ impl<'i, D: Driver> Runner<'i, D> {
             None => {
                 let mut number = 1;
                 loop {
-                    if let Outcome::Stopped = self.walk_iteration(env, number, body)? {
+                    if let Outcome::Stopped = self.walk_iteration(env, names, number, body)? {
                         return Ok(Outcome::Stopped);
                     }
                     number += 1;
@@ -923,7 +923,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                     super::evaluator::bind_names(env, names, item)?;
 
                     let number = i + 1;
-                    if let Outcome::Stopped = self.walk_iteration(env, number, body)? {
+                    if let Outcome::Stopped = self.walk_iteration(env, names, number, body)? {
                         return Ok(Outcome::Stopped);
                     }
                 }
@@ -933,10 +933,13 @@ impl<'i, D: Driver> Runner<'i, D> {
     }
 
     /// Walk one pass of a loop body within its `[number]` iteration scope,
-    /// bracketing it with `↘`/`↙` chrome.
+    /// bracketing it with `↘`/`↙` chrome. The `↘` line echoes the loop
+    /// variable(s) bound for this pass, in the same `value ~ name` form used
+    /// for a procedure call's arguments.
     fn walk_iteration(
         &mut self,
         env: &mut Environment,
+        names: &'i [language::Identifier<'i>],
         number: usize,
         body: &'i Operation<'i>,
     ) -> Result<Outcome, RunnerError> {
@@ -945,8 +948,9 @@ impl<'i, D: Driver> Runner<'i, D> {
         let qualified = self
             .path
             .render();
+        let echo = render_iteration_echo(&qualified, names, env);
         self.driver
-            .enter(&qualified);
+            .enter(&echo);
         let result = self.walk(env, body);
         let verdict = match &result {
             Ok(Outcome::Done(_)) => Some(UserInput::Done(Value::Unitus)),
@@ -1497,6 +1501,21 @@ fn nests_work(op: &Operation) -> bool {
 /// `value ~ name` form, e.g. `connectivity_check([] ~ e, 0 ~ s)`.
 fn render_argument_echo(name: &str, params: &[language::Identifier], env: &Environment) -> String {
     format!("{}: ({})", name, render_bindings(params, env))
+}
+
+/// Append a loop iteration's bound variable(s) to its path in `value ~ name`
+/// form, e.g. `cleanup_ec2:/3/[1] ("i-1234" ~ instance)` — a string value
+/// shows quoted. A `repeat` with no iteration variable echoes the bare path.
+fn render_iteration_echo(
+    qualified: &str,
+    names: &[language::Identifier],
+    env: &Environment,
+) -> String {
+    if names.is_empty() {
+        qualified.to_string()
+    } else {
+        format!("{} ({})", qualified, render_bindings(names, env))
+    }
 }
 
 /// Comma-join a set of bindings in `value ~ name` form with each value read

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -1128,8 +1128,10 @@ impl<'i, D: Driver> Runner<'i, D> {
         self.appender
             .append(&begin)?;
 
+        let subs = env.substitutions();
         let step_text = crate::formatting::formatter::render_step(
             source,
+            &subs,
             self.driver
                 .renderer(),
         );

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -408,7 +408,11 @@ impl<'i, D: Driver> Runner<'i, D> {
                 }
                 Ok(outcome)
             }
-            Operation::Bind { names, value } => self.walk_bind(env, names, value),
+            Operation::Bind {
+                names,
+                value,
+                inferred,
+            } => self.walk_bind(env, names, value, inferred.as_ref()),
             Operation::Variable(_)
             | Operation::Number(_)
             | Operation::String(_)
@@ -561,13 +565,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                         .render();
                     let invoked = format!("{} <{}>", caller, name);
 
-                    let formae = subroutine
-                        .signature
-                        .map(|s| {
-                            s.requires
-                                .formae()
-                        })
-                        .unwrap_or_default();
+                    let formae = render_parameter_formae(subroutine.signature);
 
                     // A prior run's recorded inputs for this callee. A
                     // prompted argument (an elided call or a `?` hole) is
@@ -589,7 +587,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                                 .map(|p| p.value);
                             let forma = formae
                                 .get(i)
-                                .map(|f| f.value);
+                                .map(|s| s.as_str());
                             let value = match recorded
                                 .as_ref()
                                 .and_then(|r| r.get(taken))
@@ -634,7 +632,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                                     None => {
                                         let forma = formae
                                             .get(i)
-                                            .map(|f| f.value);
+                                            .map(|s| s.as_str());
                                         match self
                                             .driver
                                             .acquire(&invoked, bind, forma)
@@ -802,6 +800,7 @@ impl<'i, D: Driver> Runner<'i, D> {
         env: &mut Environment,
         names: &'i [language::Identifier<'i>],
         value: &'i Operation<'i>,
+        inferred: Option<&'i language::Genus<'i>>,
     ) -> Result<Outcome, RunnerError> {
         let descriptive = if let Operation::Sequence(ops) = value {
             ops.is_empty()
@@ -816,11 +815,17 @@ impl<'i, D: Driver> Runner<'i, D> {
             let qualified = self
                 .path
                 .render();
+            let rendered = inferred
+                .map(|genus| crate::formatting::render_genus(genus, &crate::formatting::Identity));
+            let forma = match &rendered {
+                Some(text) => Some(text.as_str()),
+                None => None,
+            };
             let mut acquired = Vec::with_capacity(names.len());
             for name in names {
                 match self
                     .driver
-                    .acquire(&qualified, Some(name.value), None)
+                    .acquire(&qualified, Some(name.value), forma)
                 {
                     UserInput::Done(value) => acquired.push(value),
                     UserInput::Skip => {
@@ -1532,6 +1537,29 @@ fn render_bindings(names: &[language::Identifier], env: &Environment) -> String 
         })
         .collect();
     bindings.join(", ")
+}
+
+/// Render each parameter's forma as a prompt display string. A single declared
+/// list parameter (`[Region]`) renders bracketed so the driver offers list
+/// entry; every other genus renders its bare element formae.
+fn render_parameter_formae(signature: Option<&language::Signature>) -> Vec<String> {
+    match signature.map(|s| &s.requires) {
+        Some(genus @ language::Genus::List(_)) => {
+            vec![crate::formatting::render_genus(
+                genus,
+                &crate::formatting::Identity,
+            )]
+        }
+        Some(genus) => genus
+            .formae()
+            .iter()
+            .map(|f| {
+                f.value
+                    .to_string()
+            })
+            .collect(),
+        None => Vec::new(),
+    }
 }
 
 /// Describe a procedure's expected parameters as `name : Type` fragments for

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -1147,8 +1147,11 @@ impl<'i, D: Driver> Runner<'i, D> {
                 .renderer(),
         );
 
+        let depth = self
+            .path
+            .depth();
         self.driver
-            .step(qualified, &step_text);
+            .step(qualified, &step_text, depth);
 
         let produced = match self.walk(env, body)? {
             Outcome::Stopped => return Ok(Outcome::Stopped),

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -901,6 +901,19 @@ impl<'i, D: Driver> Runner<'i, D> {
                 }
             }
             Some(expr) => {
+                // A collection naming an as-yet-unbound variable — e.g. a list
+                // a zero-iteration or skipped earlier loop never populated —
+                // iterates nothing rather than aborting the run. The name is
+                // statically in scope (resolution guarantees it); it simply has
+                // no value yet at runtime.
+                if let Operation::Variable(id) = expr {
+                    if env
+                        .lookup(id.value)
+                        .is_none()
+                    {
+                        return Ok(Outcome::Done(Value::Unitus));
+                    }
+                }
                 let value = super::evaluator::evaluate(&self.library, &self.context, env, expr)?;
                 let items = super::evaluator::coerce_to_list(value)?;
                 for (i, item) in items

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -1480,18 +1480,23 @@ fn nests_work(op: &Operation) -> bool {
 /// Render the entry call with arguments bound to each parameter in
 /// `value ~ name` form, e.g. `connectivity_check([] ~ e, 0 ~ s)`.
 fn render_argument_echo(name: &str, params: &[language::Identifier], env: &Environment) -> String {
-    let bindings: Vec<String> = params
+    format!("{}: ({})", name, render_bindings(params, env))
+}
+
+/// Comma-join a set of bindings in `value ~ name` form with each value read
+/// from the environment.
+fn render_bindings(names: &[language::Identifier], env: &Environment) -> String {
+    let bindings: Vec<String> = names
         .iter()
-        .map(|p| {
-            let value = match env.lookup(p.value) {
-                Some(Value::Literali(text)) => text.clone(),
-                Some(other) => other.to_string(),
+        .map(|n| {
+            let value = match env.lookup(n.value) {
+                Some(value) => value.to_string(),
                 None => String::new(),
             };
-            format!("{} ~ {}", value, p.value)
+            format!("{} ~ {}", value, n.value)
         })
         .collect();
-    format!("{}: ({})", name, bindings.join(", "))
+    bindings.join(", ")
 }
 
 /// Describe a procedure's expected parameters as `name : Type` fragments for
@@ -1567,7 +1572,7 @@ pub(super) fn bind_parameters(
             param
                 .value
                 .to_string(),
-            Value::Literali(argument.clone()),
+            super::evaluator::parse_value(argument),
         );
     }
     Ok(env)

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -197,7 +197,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                 self.driver
                     .enter(&qualified);
             } else {
-                let echo = render_argument_echo(name, params, &env);
+                let echo = render_argument_echo(&qualified, params, &env);
                 self.driver
                     .enter(&echo);
             }
@@ -691,7 +691,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                     let saved = self
                         .path
                         .replace(lexical_segments);
-                    self.announce_procedure(subroutine, name, &lexical);
+                    self.announce_procedure(subroutine, name, &lexical, &local);
 
                     // Walk the callee's body in its own `local` environment,
                     // then sign off its scope; a Quit or error skips the
@@ -1236,9 +1236,19 @@ impl<'i, D: Driver> Runner<'i, D> {
         subroutine: &'i Subroutine<'i>,
         name: &'i str,
         qualified: &str,
+        env: &Environment,
     ) {
-        self.driver
-            .enter(qualified);
+        let params = subroutine
+            .parameters
+            .unwrap_or(&[]);
+        if params.is_empty() {
+            self.driver
+                .enter(qualified);
+        } else {
+            let echo = render_argument_echo(qualified, params, env);
+            self.driver
+                .enter(&echo);
+        }
         let declaration = crate::formatting::formatter::render_declaration(
             name,
             subroutine.parameters,
@@ -1504,10 +1514,15 @@ fn nests_work(op: &Operation) -> bool {
     }
 }
 
-/// Render the entry call with arguments bound to each parameter in
-/// `value ~ name` form, e.g. `connectivity_check([] ~ e, 0 ~ s)`.
-fn render_argument_echo(name: &str, params: &[language::Identifier], env: &Environment) -> String {
-    format!("{}: ({})", name, render_bindings(params, env))
+/// Render a procedure's qualified path with arguments bound to each parameter
+/// in `value ~ name` form, e.g. `connectivity_check: ([] ~ e, 0 ~ s)`. The
+/// qualified path already carries its trailing `:`.
+fn render_argument_echo(
+    qualified: &str,
+    params: &[language::Identifier],
+    env: &Environment,
+) -> String {
+    format!("{} ({})", qualified, render_bindings(params, env))
 }
 
 /// Append a loop iteration's bound variable(s) to its path in `value ~ name`

--- a/src/translation/checks/translate.rs
+++ b/src/translation/checks/translate.rs
@@ -842,7 +842,7 @@ run :
     let Operation::Sequence(ops) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Bind { names, value } = &ops[0] else {
+    let Operation::Bind { names, value, .. } = &ops[0] else {
         panic!("expected Bind, got {:?}", ops[0]);
     };
     assert_eq!(names.len(), 1);
@@ -1033,7 +1033,7 @@ run :
         panic!("expected Sequence");
     };
     assert_eq!(body_ops.len(), 1);
-    let Operation::Bind { names, value } = &body_ops[0] else {
+    let Operation::Bind { names, value, .. } = &body_ops[0] else {
         panic!("expected Bind, got {:?}", body_ops[0]);
     };
     assert_eq!(names.len(), 1);
@@ -1071,7 +1071,7 @@ helper : () -> Result
         panic!("expected Sequence");
     };
     assert_eq!(body_ops.len(), 1);
-    let Operation::Bind { names, value } = &body_ops[0] else {
+    let Operation::Bind { names, value, .. } = &body_ops[0] else {
         panic!("expected Bind");
     };
     assert_eq!(names[0].value, "outcome");

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -575,6 +575,7 @@ impl<'i> Translator<'i> {
                 Some(Operation::Bind {
                     names: names.as_slice(),
                     value: Box::new(value),
+                    inferred: None,
                 })
             }
         }
@@ -790,6 +791,7 @@ impl<'i> Translator<'i> {
                 Operation::Bind {
                     names,
                     value: Box::new(self.translate_expression(value)),
+                    inferred: None,
                 }
             }
             language::Expression::Hole(_) => Operation::Hole,


### PR DESCRIPTION
When running a Technique we now print the values of bound variables. This picks up the notion of "echoing" them that was used when a Technique run was started and extends it to procedure invocation and also loop iteration. This feature was extended to do partial detection of the type of the value being input so that this is rendered as a string literal, numeric, or list as appropriate.

Fix behaviour of `foreach` so that if the input list is empty no iterations are performed.

Finally, we make a small UI improvement to the prompt when we can infer that a list value is being demanded and render `[` and `]` around the input cursor to hint to the user that they are in fact being asked to enter a list.

Fix the indentation of substeps when running so that they appear nested as they do in the source Technique document.

Refine output of code block in descriptives. In particular, variables with known values are substituted into the content and shown syntax highlighted during the run (distinct from interpolations, which insert the raw variable Display into the String).

