### PR TITLE
Correct results of steps with mixed prose and function calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "technique"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "technique"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "A domain specific language for procedures."
 authors = [ "Andrew Cowie" ]

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -256,11 +256,7 @@ pub fn render_description<'i>(paragraphs: &'i [Paragraph<'i>], renderer: &dyn Re
 }
 
 /// Render step's without descending into nested subscopes.
-pub fn render_step<'i>(
-    scope: &'i Scope,
-    subs: &'i Substitutions,
-    renderer: &dyn Render,
-) -> String {
+pub fn render_step<'i>(scope: &'i Scope, subs: &'i Substitutions, renderer: &dyn Render) -> String {
     let mut sub = Formatter::new(78);
     sub.substitutions = Some(subs);
     match scope {

--- a/src/linking/linker.rs
+++ b/src/linking/linker.rs
@@ -114,6 +114,7 @@ fn link_operation<'i>(
         Operation::Variable(_)
         | Operation::Number(_)
         | Operation::Multiline(_, _)
+        | Operation::Prose(_)
         | Operation::Hole => {}
     }
 }

--- a/src/linking/linker.rs
+++ b/src/linking/linker.rs
@@ -80,7 +80,7 @@ fn link_operation<'i>(
                 link_operation(arg, library, problems);
             }
         }
-        Operation::Sequence(ops) => {
+        Operation::Sequence(ops) | Operation::Prologue(ops) => {
             for op in ops {
                 link_operation(op, library, problems);
             }

--- a/src/program/types.rs
+++ b/src/program/types.rs
@@ -128,6 +128,7 @@ pub enum Operation<'i> {
     Invoke(Invocable<'i>),
     Execute(Executable<'i>),
     Hole,
+    Prose(&'i str),
     Sequence(Vec<Operation<'i>>),
     Section {
         numeral: &'i str,

--- a/src/program/types.rs
+++ b/src/program/types.rs
@@ -130,6 +130,11 @@ pub enum Operation<'i> {
     Hole,
     Prose(&'i str),
     Sequence(Vec<Operation<'i>>),
+    /// The executable work hoisted from a procedure's description is an
+    /// anonymous "step 0". Present only when the description carries
+    /// instructions, not for prose alone. Its outcome folds into the
+    /// procedure's own sign-off rather than prompting itself.
+    Prologue(Vec<Operation<'i>>),
     Section {
         numeral: &'i str,
         title: Option<Box<Operation<'i>>>,

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -144,6 +144,7 @@ fn resolve_operation<'i>(
         Operation::Variable(_)
         | Operation::Number(_)
         | Operation::Multiline(_, _)
+        | Operation::Prose(_)
         | Operation::Hole => {}
     }
 }
@@ -209,6 +210,7 @@ fn gather_iterated<'i>(op: &Operation<'i>, iterated: &mut HashSet<&'i str>) {
         Operation::Variable(_)
         | Operation::Number(_)
         | Operation::Multiline(_, _)
+        | Operation::Prose(_)
         | Operation::Hole => {}
     }
 }
@@ -268,6 +270,7 @@ fn mark_iterated<'i>(op: &mut Operation<'i>, iterated: &HashSet<&str>) {
         Operation::Variable(_)
         | Operation::Number(_)
         | Operation::Multiline(_, _)
+        | Operation::Prose(_)
         | Operation::Hole => {}
     }
 }
@@ -356,7 +359,10 @@ fn check_scope<'i>(
                 check_scope(&entry.value, scope, problems);
             }
         }
-        Operation::Number(_) | Operation::Multiline(_, _) | Operation::Hole => {}
+        Operation::Number(_)
+        | Operation::Multiline(_, _)
+        | Operation::Prose(_)
+        | Operation::Hole => {}
     }
 }
 

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -105,7 +105,7 @@ fn resolve_operation<'i>(
                 resolve_operation(arg, known, arities, problems);
             }
         }
-        Operation::Sequence(ops) | Operation::List(ops) => {
+        Operation::Sequence(ops) | Operation::List(ops) | Operation::Prologue(ops) => {
             for op in ops {
                 resolve_operation(op, known, arities, problems);
             }
@@ -173,7 +173,7 @@ fn gather_iterated<'i>(op: &Operation<'i>, iterated: &mut HashSet<&'i str>) {
             gather_iterated(body, iterated);
         }
         Operation::Bind { value, .. } => gather_iterated(value, iterated),
-        Operation::Sequence(ops) | Operation::List(ops) => {
+        Operation::Sequence(ops) | Operation::List(ops) | Operation::Prologue(ops) => {
             for op in ops {
                 gather_iterated(op, iterated);
             }
@@ -233,7 +233,7 @@ fn mark_iterated<'i>(op: &mut Operation<'i>, iterated: &HashSet<&str>) {
             }
             mark_iterated(body, iterated);
         }
-        Operation::Sequence(ops) | Operation::List(ops) => {
+        Operation::Sequence(ops) | Operation::List(ops) | Operation::Prologue(ops) => {
             for op in ops {
                 mark_iterated(op, iterated);
             }
@@ -325,7 +325,7 @@ fn check_scope<'i>(
             }
             check_scope(body, scope, problems);
         }
-        Operation::Sequence(ops) | Operation::List(ops) => {
+        Operation::Sequence(ops) | Operation::List(ops) | Operation::Prologue(ops) => {
             for op in ops {
                 check_scope(op, scope, problems);
             }

--- a/src/runner/checks/library.rs
+++ b/src/runner/checks/library.rs
@@ -15,7 +15,7 @@ fn text(s: &str) -> Value {
 // evaluator takes once a call is resolved.
 fn call(name: &str, args: &[Value]) -> Result<Value, RunnerError> {
     let library = Library::core();
-    let context = Context::native();
+    let context = Context::capture();
     let id = library
         .resolve(name)
         .expect("builtin registered");
@@ -27,7 +27,7 @@ fn call(name: &str, args: &[Value]) -> Result<Value, RunnerError> {
 fn call_system(name: &str, args: &[Value]) -> Result<Value, RunnerError> {
     let mut library = Library::core();
     library.extend(Library::system());
-    let context = Context::native();
+    let context = Context::capture();
     let id = library
         .resolve(name)
         .expect("builtin registered");

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -2679,7 +2679,7 @@ cleanup :
         &program,
         Appender::memory(),
         completed,
-        Automatic::new(false),
+        Automatic::with_handle(Vec::new()),
         Library::stub(),
     );
     let outcome = runner

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1311,6 +1311,70 @@ check :
 }
 
 #[test]
+fn description_instruction_records_under_step_zero() {
+    // An exec in the procedure description runs in the anonymous step-0
+    // Prologue scope, recording under the `/0` path ahead of the steps.
+    let source = r#"
+% technique v1
+
+check :
+
+Prepare the ground { exec("true") } before the steps.
+
+1.  Do the work.
+        "#
+    .trim_ascii();
+    let document = parsing::parse(Path::new("Test.tq"), source).expect("parsed");
+    let mut program = translate(&document).expect("translated");
+    resolve(&mut program).expect("resolve");
+    let mut library = Library::core();
+    library.extend(Library::system());
+    crate::linking::link(&mut program, &library).expect("linked");
+
+    let mut fixture = StoreFixture::new("description-step-zero");
+    let mut runner = Runner::new(
+        &program,
+        fixture.take_appender(),
+        HashMap::new(),
+        Automatic::with_handle(Vec::new()),
+        library,
+    );
+    runner
+        .run(Environment::new())
+        .expect("run");
+
+    let pfftt = fixture.pfftt_contents();
+    let records: Vec<_> = pfftt
+        .lines()
+        .filter_map(|line| parse_record(line).ok())
+        .collect();
+    let zero: Vec<_> = records
+        .iter()
+        .filter(|r| r.path == "/check:/0")
+        .map(|r| &r.state)
+        .collect();
+    // The /0 scope is bracketed Begin…Done with the exec's trace between.
+    let State::Begin = zero[0] else {
+        panic!("expected Begin first at /check:/0, got {:?}", zero[0]);
+    };
+    let State::Done(_) = zero[zero.len() - 1] else {
+        panic!(
+            "expected Done last at /check:/0, got {:?}",
+            zero[zero.len() - 1]
+        );
+    };
+    assert!(zero
+        .iter()
+        .any(|state| {
+            if let State::Execute { .. } = state {
+                true
+            } else {
+                false
+            }
+        }));
+}
+
+#[test]
 fn loop_inside_step_produces_one_result() {
     let mut fixture = StoreFixture::new("loop-in-step");
 

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -199,7 +199,8 @@ pub fn evaluate<'i>(
         // A `?` reached outside a procedure invocation has no parameter name
         // to defer against; it stands for an as-yet-unsupplied value.
         Operation::Hole => Ok(Value::Futurae(String::new())),
-        Operation::Section { .. }
+        Operation::Prose(_)
+        | Operation::Section { .. }
         | Operation::Step { .. }
         | Operation::Loop { .. }
         | Operation::Invoke(_) => Ok(Value::Unitus),

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -200,6 +200,7 @@ pub fn evaluate<'i>(
         // to defer against; it stands for an as-yet-unsupplied value.
         Operation::Hole => Ok(Value::Futurae(String::new())),
         Operation::Prose(_)
+        | Operation::Prologue(_)
         | Operation::Section { .. }
         | Operation::Step { .. }
         | Operation::Loop { .. }

--- a/src/runner/path.rs
+++ b/src/runner/path.rs
@@ -10,6 +10,7 @@ use crate::language;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PathSegment<'i> {
     Section(&'i str),
+    Prologue,
     DependentStep(&'i str),
     ParallelStep(usize),
     Iteration(usize),
@@ -125,6 +126,7 @@ pub fn render_path(segments: &[PathSegment]) -> String {
 fn render_segment(segment: &PathSegment) -> Option<String> {
     match segment {
         PathSegment::Section(numeral) => Some(numeral.to_string()),
+        PathSegment::Prologue => Some("0".to_string()),
         PathSegment::DependentStep(ordinal) => Some(ordinal.to_string()),
         PathSegment::ParallelStep(index) => Some(format!("-{}", index)),
         PathSegment::Iteration(number) => Some(format!("[{}]", number)), // you can't "index" into it!

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -143,6 +143,12 @@ impl<'i, D: Driver> Runner<'i, D> {
         self
     }
 
+    /// Override the host context builtins write through (default: the terminal).
+    pub fn with_context(mut self, context: Context) -> Self {
+        self.context = context;
+        self
+    }
+
     /// Consume the runner and return the inner driver after a run completes.
     /// Used to read a `Headless` driver's result count or to assert on the
     /// Mock's event log.

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -263,6 +263,17 @@ impl<'i, D: Driver> Runner<'i, D> {
     ) -> Result<Outcome, RunnerError> {
         match op {
             Operation::Sequence(ops) => self.walk_sequence(env, ops),
+            Operation::Prologue(ops) => {
+                self.path
+                    .push(PathSegment::Prologue);
+                let qualified = self
+                    .path
+                    .render();
+                let result = self.perform_prologue(env, &qualified, ops);
+                self.path
+                    .pop();
+                result
+            }
             Operation::Section {
                 numeral,
                 title,
@@ -1108,6 +1119,56 @@ impl<'i, D: Driver> Runner<'i, D> {
         result
     }
 
+    // Walk the anonymous step-0 scope. Its `/0` address is bracketed
+    // Begin…Done like a step's, so a completed prologue short-circuits on
+    // resume (and rehydrates any bindings it made) rather than re-running its
+    // commands; unlike a step it takes no sign-off of its own, folding its
+    // outcome into the enclosing procedure's seal.
+    fn perform_prologue(
+        &mut self,
+        env: &mut Environment,
+        qualified: &str,
+        ops: &'i [Operation<'i>],
+    ) -> Result<Outcome, RunnerError> {
+        if let Some(value) = self
+            .completed
+            .get(qualified)
+        {
+            let value = value.clone();
+            if ops
+                .iter()
+                .any(nests_work)
+            {
+                for op in ops {
+                    self.walk(env, op)?;
+                }
+            } else if let Some(names) = ops
+                .iter()
+                .find_map(binding_names)
+            {
+                super::evaluator::bind_names(env, names, value.clone())?;
+            }
+            return Ok(Outcome::Done(value));
+        }
+
+        self.begin_scope(qualified)?;
+        let outcome = self.walk_sequence(env, ops)?;
+        if let Outcome::Stopped = outcome {
+            return Ok(outcome);
+        }
+        let record = Record {
+            recorded: now_iso8601(),
+            run_id: self
+                .appender
+                .run_id(),
+            path: qualified.to_string(),
+            state: record_state(&outcome),
+        };
+        self.appender
+            .append(&record)?;
+        Ok(outcome)
+    }
+
     fn perform_step(
         &mut self,
         env: &mut Environment,
@@ -1447,7 +1508,7 @@ fn computable(op: &Operation) -> bool {
     match op {
         // A pure-prose body is not computable (this is fine!).
         Operation::Sequence(ops) if ops.is_empty() => false,
-        Operation::Sequence(ops) => ops
+        Operation::Sequence(ops) | Operation::Prologue(ops) => ops
             .iter()
             .any(computable),
         Operation::Step { body, .. } | Operation::Section { body, .. } => computable(body),

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -419,6 +419,7 @@ impl<'i, D: Driver> Runner<'i, D> {
             | Operation::Multiline(_, _)
             | Operation::Tablet(_)
             | Operation::List(_)
+            | Operation::Prose(_)
             | Operation::Hole => {
                 let value = super::evaluator::evaluate(&self.library, &self.context, env, op)?;
                 Ok(Outcome::Done(value))
@@ -1450,6 +1451,7 @@ fn computable(op: &Operation) -> bool {
             .iter()
             .any(computable),
         Operation::Step { body, .. } | Operation::Section { body, .. } => computable(body),
+        Operation::Prose(_) => false,
         _ => true,
     }
 }

--- a/src/translation/checks/translate.rs
+++ b/src/translation/checks/translate.rs
@@ -1212,10 +1212,9 @@ run :
 }
 
 #[test]
-fn procedure_description_executables_hoist_as_prefix() {
-    // Hoisting at the procedure level: an executable Descriptive in the
-    // procedure's description forms an "anonymous step 0" prefix ahead of
-    // the explicit Steps.
+fn procedure_description_executables_hoist_as_prologue() {
+    // An executable Descriptive in the procedure's description forms an
+    // anonymous step-0 Prologue scope ahead of the explicit Steps.
     let source = r#"
 % technique v1
 
@@ -1235,11 +1234,22 @@ init : () -> ()
     let Operation::Sequence(ops) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    // Prefix Invoke from the description, then the explicit Step.
+    // Prologue from the description, then the explicit Step.
     assert_eq!(ops.len(), 2);
-    let Operation::Invoke(_) = &ops[0] else {
-        panic!("expected Invoke prefix, got {:?}", ops[0]);
+    let Operation::Prologue(prologue) = &ops[0] else {
+        panic!("expected Prologue, got {:?}", ops[0]);
     };
+    let invokes = prologue
+        .iter()
+        .filter(|op| {
+            if let Operation::Invoke(_) = op {
+                true
+            } else {
+                false
+            }
+        })
+        .count();
+    assert_eq!(invokes, 1);
     let Operation::Step { .. } = &ops[1] else {
         panic!("expected Step, got {:?}", ops[1]);
     };

--- a/src/translation/checks/translate.rs
+++ b/src/translation/checks/translate.rs
@@ -398,12 +398,12 @@ make_coffee :
     };
     let inner_ordinals: Vec<&str> = inner
         .iter()
-        .map(|op| match op {
+        .filter_map(|op| match op {
             Operation::Step {
                 ordinal: Ordinal::Dependent(n),
                 ..
-            } => *n,
-            _ => panic!("expected dependent substep"),
+            } => Some(*n),
+            _ => None,
         })
         .collect();
     assert_eq!(inner_ordinals, vec!["a", "b"]);
@@ -542,10 +542,11 @@ make_coffee :
     let Operation::Sequence(inner) = outer_body.as_ref() else {
         panic!("expected inner Sequence");
     };
+    // inner[0] is the outer step's own prose; the substep follows.
     let Operation::Step {
         attributes: substep_attrs,
         ..
-    } = &inner[0]
+    } = &inner[1]
     else {
         panic!("expected substep");
     };
@@ -1070,8 +1071,8 @@ helper : () -> Result
     let Operation::Sequence(body_ops) = body.as_ref() else {
         panic!("expected Sequence");
     };
-    assert_eq!(body_ops.len(), 1);
-    let Operation::Bind { names, value, .. } = &body_ops[0] else {
+    assert_eq!(body_ops.len(), 2);
+    let Operation::Bind { names, value, .. } = &body_ops[1] else {
         panic!("expected Bind");
     };
     assert_eq!(names[0].value, "outcome");
@@ -1107,15 +1108,17 @@ helper : () -> Result
     let Operation::Sequence(body_ops) = body.as_ref() else {
         panic!("expected Sequence");
     };
-    assert_eq!(body_ops.len(), 1);
-    let Operation::Invoke(_) = &body_ops[0] else {
-        panic!("expected Invoke, got {:?}", body_ops[0]);
+    // [Prose("Do"), Invoke, Prose("first.")] — the invoke sits between prose.
+    assert_eq!(body_ops.len(), 3);
+    let Operation::Invoke(_) = &body_ops[1] else {
+        panic!("expected Invoke, got {:?}", body_ops[1]);
     };
 }
 
 #[test]
-fn step_plain_text_does_not_hoist() {
-    // Plain text in a step description is display-only; nothing hoists.
+fn step_plain_text_becomes_prose() {
+    // Plain text in a step description is kept as an inert Prose operation, so
+    // the step's last value reflects source order (here, no value: Done unit).
     let source = r#"
 % technique v1
 
@@ -1137,7 +1140,11 @@ run :
     let Operation::Sequence(body_ops) = body.as_ref() else {
         panic!("expected Sequence");
     };
-    assert!(body_ops.is_empty());
+    assert_eq!(body_ops.len(), 1);
+    let Operation::Prose(text) = &body_ops[0] else {
+        panic!("expected Prose, got {:?}", body_ops[0]);
+    };
+    assert_eq!(*text, "Just a plain step with no executable bits.");
 }
 
 #[test]
@@ -1165,9 +1172,9 @@ run :
     let Operation::Sequence(body_ops) = body.as_ref() else {
         panic!("expected Sequence");
     };
-    assert_eq!(body_ops.len(), 1);
-    let Operation::Execute(_) = &body_ops[0] else {
-        panic!("expected Execute, got {:?}", body_ops[0]);
+    assert_eq!(body_ops.len(), 2);
+    let Operation::Execute(_) = &body_ops[1] else {
+        panic!("expected Execute, got {:?}", body_ops[1]);
     };
 }
 
@@ -1197,9 +1204,9 @@ run :
     let Operation::Sequence(body_ops) = body.as_ref() else {
         panic!("expected Sequence");
     };
-    assert_eq!(body_ops.len(), 1);
-    let Operation::Variable(id) = &body_ops[0] else {
-        panic!("expected Variable, got {:?}", body_ops[0]);
+    assert_eq!(body_ops.len(), 2);
+    let Operation::Variable(id) = &body_ops[1] else {
+        panic!("expected Variable, got {:?}", body_ops[1]);
     };
     assert_eq!(id.value, "x");
 }
@@ -1357,7 +1364,7 @@ run :
     let Operation::Loop {
         responses: loop_responses,
         ..
-    } = &step_body[0]
+    } = &step_body[1]
     else {
         panic!("expected Loop");
     };
@@ -1525,14 +1532,14 @@ delete_rds_instance :
     // Step body, one Execute per call.
     let names: Vec<&str> = step_body
         .iter()
-        .map(|op| match op {
+        .filter_map(|op| match op {
             Operation::Execute(executable) => {
                 let ExecutableRef::Unresolved(target) = &executable.target else {
                     panic!("expected Unresolved, got {:?}", executable.target);
                 };
-                target.value
+                Some(target.value)
             }
-            other => panic!("expected Execute, got {:?}", other),
+            _ => None,
         })
         .collect();
     assert_eq!(
@@ -1569,7 +1576,7 @@ run :
     let Operation::Sequence(outer_ops) = outer.as_ref() else {
         panic!("expected Sequence");
     };
-    let Operation::Step { body: substep, .. } = &outer_ops[0] else {
+    let Operation::Step { body: substep, .. } = &outer_ops[1] else {
         panic!("expected substep");
     };
     let Operation::Sequence(sub_ops) = substep.as_ref() else {
@@ -1577,12 +1584,12 @@ run :
     };
     let ordinals: Vec<&str> = sub_ops
         .iter()
-        .map(|op| match op {
+        .filter_map(|op| match op {
             Operation::Step {
                 ordinal: Ordinal::Dependent(n),
                 ..
-            } => *n,
-            _ => panic!("expected sub-substep"),
+            } => Some(*n),
+            _ => None,
         })
         .collect();
     assert_eq!(ordinals, vec!["i", "ii"]);

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -292,8 +292,7 @@ impl<'i> Translator<'i> {
                 let mut responses = Vec::new();
 
                 if let Some(paragraph) = title {
-                    // scan for operations in section content
-                    self.translate_descriptions(&mut body_ops, std::slice::from_ref(paragraph));
+                    self.hoist_title_executables(&mut body_ops, paragraph);
                 }
                 match body {
                     language::Technique::Steps(scopes) => {
@@ -472,29 +471,29 @@ impl<'i> Translator<'i> {
         }
     }
 
-    // Hoist the executable Descriptives out of a paragraph, dropping its
-    // prose. Used to scan a section title for any invocations it makes.
-    fn translate_descriptions(
+    // A section title can itself invoke a procedure (`I. Run <setup>`). Hoist
+    // any such executables into the section body so they run on entry; the
+    // title's prose is rendered separately, so it is dropped here.
+    fn hoist_title_executables(
         &mut self,
         ops: &mut Vec<Operation<'i>>,
-        paragraphs: &'i [language::Paragraph<'i>],
+        title: &'i language::Paragraph<'i>,
     ) {
-        for paragraph in paragraphs {
-            let language::Paragraph(descriptives, _) = paragraph;
-            for descriptive in descriptives {
-                match self.executable_from_descriptive(descriptive) {
-                    // A multi-statement code block hoists its statements
-                    // directly into the body, one operation per call, rather
-                    // than nesting them in a Sequence.
-                    Some(Operation::Sequence(inner)) => ops.extend(inner),
-                    Some(op) => ops.push(op),
-                    None => {}
-                }
+        let language::Paragraph(descriptives, _) = title;
+        for descriptive in descriptives {
+            match self.executable_from_descriptive(descriptive) {
+                // A multi-statement code block hoists its statements directly,
+                // one operation per call, rather than nesting in a Sequence.
+                Some(Operation::Sequence(inner)) => ops.extend(inner),
+                Some(op) => ops.push(op),
+                None => {}
             }
         }
     }
 
-    // Like translate_descriptions() but for a step body.
+    // Translate a step's description paragraphs into its body operations,
+    // keeping prose as inert `Prose` so the body's last value honours source
+    // order: a value contributes the step's result only in tail position.
     fn translate_step_content(
         &mut self,
         ops: &mut Vec<Operation<'i>>,

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -328,7 +328,7 @@ impl<'i> Translator<'i> {
             } => {
                 let mut body_ops = Vec::new();
                 let mut responses = Vec::new();
-                self.translate_descriptions(&mut body_ops, description);
+                self.translate_step_content(&mut body_ops, description);
                 self.attach_subscopes(&mut body_ops, &mut responses, subscopes, attrs);
                 Operation::Step {
                     ordinal: Ordinal::Dependent(ordinal),
@@ -345,7 +345,7 @@ impl<'i> Translator<'i> {
             } => {
                 let mut body_ops = Vec::new();
                 let mut responses = Vec::new();
-                self.translate_descriptions(&mut body_ops, description);
+                self.translate_step_content(&mut body_ops, description);
                 self.attach_subscopes(&mut body_ops, &mut responses, subscopes, attrs);
                 Operation::Step {
                     ordinal: Ordinal::Parallel,
@@ -470,6 +470,28 @@ impl<'i> Translator<'i> {
                     // A multi-statement code block hoists its statements
                     // directly into the body, one operation per call, rather
                     // than nesting them in a Sequence.
+                    Some(Operation::Sequence(inner)) => ops.extend(inner),
+                    Some(op) => ops.push(op),
+                    None => {}
+                }
+            }
+        }
+    }
+
+    // Like translate_descriptions() but for a step body.
+    fn translate_step_content(
+        &mut self,
+        ops: &mut Vec<Operation<'i>>,
+        paragraphs: &'i [language::Paragraph<'i>],
+    ) {
+        for paragraph in paragraphs {
+            let language::Paragraph(descriptives, _) = paragraph;
+            for descriptive in descriptives {
+                if let language::Descriptive::Text(text) = descriptive {
+                    ops.push(Operation::Prose(text));
+                    continue;
+                }
+                match self.executable_from_descriptive(descriptive) {
                     Some(Operation::Sequence(inner)) => ops.extend(inner),
                     Some(op) => ops.push(op),
                     None => {}

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -204,7 +204,23 @@ impl<'i> Translator<'i> {
 
         let mut ops = Vec::new();
         let mut responses = Vec::new();
-        self.translate_descriptions(&mut ops, description);
+        // The description's executable content becomes an anonymous step-0
+        // scope, present only when the description carries instructions rather
+        // than prose alone.
+        let mut prologue = Vec::new();
+        self.translate_step_content(&mut prologue, description);
+        if prologue
+            .iter()
+            .any(|op| {
+                if let Operation::Prose(_) = op {
+                    false
+                } else {
+                    true
+                }
+            })
+        {
+            ops.push(Operation::Prologue(prologue));
+        }
         for element in &procedure.elements {
             match element {
                 language::Element::Steps(scopes, _) => {
@@ -456,8 +472,8 @@ impl<'i> Translator<'i> {
         }
     }
 
-    // Hoist executable Descriptives out of description paragraphs and
-    // append them to `ops` as an "anonymous step 0" prefix.
+    // Hoist the executable Descriptives out of a paragraph, dropping its
+    // prose. Used to scan a section title for any invocations it makes.
     fn translate_descriptions(
         &mut self,
         ops: &mut Vec<Operation<'i>>,

--- a/tests/runner/samples.rs
+++ b/tests/runner/samples.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 
 use technique::parsing;
-use technique::runner::{Appender, Environment, Headless, Library, Outcome, Runner};
+use technique::runner::{Appender, Context, Environment, Headless, Library, Outcome, Runner};
 use technique::translation;
 
 use crate::common::list_technique_documents;
@@ -80,7 +80,8 @@ fn ensure_run() {
             HashMap::new(),
             Headless::new(),
             library,
-        );
+        )
+        .with_context(Context::capture());
         let outcome = match runner.run(Environment::new()) {
             Ok(outcome) => outcome,
             Err(e) => {

--- a/tests/samples/runner/ExecutionInSteps.pfftt
+++ b/tests/samples/runner/ExecutionInSteps.pfftt
@@ -2,7 +2,7 @@
 2026-06-23T05:57:54.061Z 000088 /local_network: Begin
 2026-06-23T05:57:54.062Z 000088 /local_network:/0 Begin
 2026-06-23T05:57:54.062Z 000088 /local_network:/0 Execute exec()
-2026-06-23T05:57:55.457Z 000088 /local_network:/0 Return "afs\nbin\nboot\ndev\netc\nhome\nlib\nlib64\nlost+found\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar"
+2026-06-23T05:57:55.457Z 000088 /local_network:/0 Return "/usr"
 2026-06-23T05:57:55.457Z 000088 /local_network:/0 Done ()
 2026-06-23T05:57:55.457Z 000088 /local_network:/1 Begin
 2026-06-23T05:57:55.457Z 000088 /local_network:/1 Execute exec()

--- a/tests/samples/runner/ExecutionInSteps.pfftt
+++ b/tests/samples/runner/ExecutionInSteps.pfftt
@@ -1,0 +1,11 @@
+2026-06-23T05:57:54.061Z 000088 / Start file://tests/samples/runner/ExecutionInSteps.tq?library=system
+2026-06-23T05:57:54.061Z 000088 /local_network: Begin
+2026-06-23T05:57:54.062Z 000088 /local_network:/0 Begin
+2026-06-23T05:57:54.062Z 000088 /local_network:/0 Execute exec()
+2026-06-23T05:57:55.457Z 000088 /local_network:/0 Return "afs\nbin\nboot\ndev\netc\nhome\nlib\nlib64\nlost+found\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar"
+2026-06-23T05:57:55.457Z 000088 /local_network:/0 Done ()
+2026-06-23T05:57:55.457Z 000088 /local_network:/1 Begin
+2026-06-23T05:57:55.457Z 000088 /local_network:/1 Execute exec()
+2026-06-23T05:57:55.646Z 000088 /local_network:/1 Return "eth0 UP"
+2026-06-23T05:57:55.807Z 000088 /local_network:/1 Done ()
+2026-06-23T05:57:55.972Z 000088 /local_network: Done ()

--- a/tests/samples/runner/ExecutionInSteps.tq
+++ b/tests/samples/runner/ExecutionInSteps.tq
@@ -1,0 +1,12 @@
+local_network :
+
+# Local Network Connectivity
+
+Establish that the local network { exec("ls /") } environment is
+functioning.
+
+    1.  Check physical network interface { exec(
+        ```bash
+            echo "eth0 UP"
+        ```
+        ) } and look for eth0 being marked UP.

--- a/tests/samples/runner/ExecutionInSteps.tq
+++ b/tests/samples/runner/ExecutionInSteps.tq
@@ -2,7 +2,7 @@ local_network :
 
 # Local Network Connectivity
 
-Establish that the local network { exec("ls /") } environment is
+Establish that the local network { exec("ls -d /usr") } environment is
 functioning.
 
     1.  Check physical network interface { exec(


### PR DESCRIPTION
The output of exec() calls was already recorded in a `Return` line, but that value was being duplicated as the enclosing step's `Result`. That led to clarifying the place of code inlines in descriptive paragraphs, and realizing we could translate the prose as a no-op `Operation::Prose` variant so that if trailing prose is present then the result of the step is then correctly the `Unitus` value.

This extended into the anonymous "Step 0" created when consequential operations are present in a procedure description. This has been re-translated as `Operation::Prelude` and then if function calls are present then they are properly entered and recorded.

Cleanup noise from test output.