### PR TITLE
Guard Posix API usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ crossterm = "0.29"
 ignore = "0.4"
 lsp-server = "0.8.0"
 lsp-types = "0.97"
-nix = { version = "0.31", features = ["poll"] }
 owo-colors = "4"
 regex = "1.11.1"
 serde = { version = "1.0.209", features = [ "derive" ] }
@@ -23,6 +22,9 @@ tinytemplate = "1.2.1"
 
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", features = ["poll"] }
 
 [build-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ as well as very detailed ones:
 </a>
 
 Detailed examples can be found in the _examples/_ and _tests/_ directories.
-Documents written in Technique have file extension _\*.tq_.
+Documents written in Technique have file extension _\*.tq_. The MIME type is
+`application/technique`.
 
 <!--
 See also:

--- a/src/runner/library.rs
+++ b/src/runner/library.rs
@@ -1,9 +1,14 @@
 //! The function table for the evaluator.
 
-use std::io::{self, Read};
+use std::io;
+#[cfg(unix)]
+use std::io::Read;
+#[cfg(unix)]
 use std::os::fd::AsFd;
+#[cfg(unix)]
 use std::process::{Command, Stdio};
 
+#[cfg(unix)]
 use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
 
 use super::context::{Context, Stream};
@@ -274,6 +279,7 @@ fn pairs(_context: &Context, args: &[Value]) -> Result<Value, RunnerError> {
 /// are decoded at the end, so a chunk split mid-UTF-8 is harmless; trailing
 /// newlines are trimmed (matching shell substitution). A non-zero exit is an
 /// error.
+#[cfg(unix)]
 fn exec(context: &Context, args: &[Value]) -> Result<Value, RunnerError> {
     let script = match &args[0] {
         Value::Literali(script) => script,
@@ -418,11 +424,20 @@ fn exec(context: &Context, args: &[Value]) -> Result<Value, RunnerError> {
     ))
 }
 
+#[cfg(not(unix))]
+fn exec(_context: &Context, _args: &[Value]) -> Result<Value, RunnerError> {
+    Err(RunnerError::ExecError(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "exec() is not supported on this platform",
+    )))
+}
+
 /// Tee a chunk to the user, recording it plain in `captured` and writing it
 /// through the Context. Only whole lines are written through; the trailing
 /// partial line waits in `pending` for its newline (or the stream's close), so
 /// a `Stream::Stderr` run never lands inside a `Stream::Stdout` line. A newline
 /// is always a UTF-8 boundary, so this never splits a character either.
+#[cfg(unix)]
 fn tee(
     bytes: &[u8],
     pending: &mut Vec<u8>,


### PR DESCRIPTION
In previous work we inadvertently introduced a hard dependency on Posix because of the use of `poll()` from the **nix** crate. This branch puts guards in place so that the build runs regardless of OS.

Work to support Windows can be contributed in the future; until then the `exec()` builtin will error if evaluated.