### PR TITLE
Construction and validation of Cost literals

### DIFF
--- a/src/domain/engine.rs
+++ b/src/domain/engine.rs
@@ -300,6 +300,9 @@ fn render_expression(expr: &Expression) -> String {
         Expression::Within(inner, _) => {
             format!("within {}", render_expression(inner))
         }
+        Expression::Cost(inner, _) => {
+            format!("$({})", render_expression(inner))
+        }
         Expression::Foreach(ids, inner, _) => {
             let vars = if ids.len() == 1 {
                 ids[0]

--- a/src/editor/server.rs
+++ b/src/editor/server.rs
@@ -801,6 +801,10 @@ impl TechniqueLanguageServer {
                     "Invalid foreach expression".to_string(),
                     DiagnosticSeverity::ERROR,
                 ),
+                ParsingError::InvalidCost(_) => (
+                    "Invalid cost literal".to_string(),
+                    DiagnosticSeverity::ERROR,
+                ),
                 ParsingError::InvalidIntegral(_) => (
                     "Invalid integral number".to_string(),
                     DiagnosticSeverity::ERROR,

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -507,6 +507,16 @@ impl<'i> Formatter<'i> {
         }
     }
 
+    /// Render a naked `$(...)` cost with no surrounding braces — distinct
+    /// from `render_inline_code`, which always wraps in `{ }` because it
+    /// only ever renders an author-written `CodeInline`.
+    fn render_cost(&self, expr: &'i Expression) -> Vec<(Syntax, Cow<'i, str>)> {
+        let mut sub = self.subformatter();
+        sub.append_expression(expr);
+        sub.flush_current();
+        sub.fragments
+    }
+
     /// Render a `;`-separated code block inline: `{ a; b }`, with `;` for
     /// each of the separators.
     fn render_inline_block(&self, exprs: &'i [Expression]) -> Vec<(Syntax, Cow<'i, str>)> {
@@ -576,6 +586,9 @@ impl<'i> Formatter<'i> {
             }
             Descriptive::Application(invocation) => {
                 sub.append_application(invocation);
+            }
+            Descriptive::Cost(expr) => {
+                sub.append_expression(expr);
             }
             Descriptive::Binding(_, _) => {
                 sub.append_str("<<nested binding>>");
@@ -1015,6 +1028,15 @@ impl<'i> Formatter<'i> {
                     }
                     line.add_binding(inner_descriptive, variables);
                 }
+                Descriptive::Cost(expr) => {
+                    if !line
+                        .current
+                        .is_empty()
+                    {
+                        line.add_atomic(syntax, " ");
+                    }
+                    line.add_cost(expr);
+                }
             }
             after_construct = true;
         }
@@ -1326,6 +1348,11 @@ impl<'i> Formatter<'i> {
                 self.add_fragment_reference(Syntax::Keyword, "within");
                 self.add_fragment_reference(Syntax::Neutral, " ");
                 self.append_expression(expression);
+            }
+            Expression::Cost(expression, _) => {
+                self.add_fragment_reference(Syntax::Structure, "$(");
+                self.append_expression(expression);
+                self.add_fragment_reference(Syntax::Structure, ")");
             }
             Expression::Foreach(variables, expression, _) => {
                 self.add_fragment_reference(Syntax::Keyword, "foreach");
@@ -1720,6 +1747,15 @@ impl<'a, 'i> Line<'a, 'i> {
         let fragments = self
             .output
             .render_inline_code(expr);
+        for (syntax, content) in fragments {
+            self.add_no_wrap(syntax, content);
+        }
+    }
+
+    fn add_cost(&mut self, expr: &'i Expression) {
+        let fragments = self
+            .output
+            .render_cost(expr);
         for (syntax, content) in fragments {
             self.add_no_wrap(syntax, content);
         }

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -1351,7 +1351,11 @@ impl<'i> Formatter<'i> {
             }
             Expression::Cost(expression, _) => {
                 self.add_fragment_reference(Syntax::Structure, "$(");
-                self.append_expression(expression);
+                if let Expression::Number(numeric, _) = expression.as_ref() {
+                    self.append_numeric_as(numeric, Syntax::Cost);
+                } else {
+                    self.append_expression(expression);
+                }
                 self.add_fragment_reference(Syntax::Structure, ")");
             }
             Expression::Foreach(variables, expression, _) => {
@@ -1407,36 +1411,47 @@ impl<'i> Formatter<'i> {
     }
 
     pub fn append_numeric(&mut self, numeric: &'i Numeric) {
+        self.append_numeric_as(numeric, Syntax::Numeric);
+    }
+
+    /// `append_numeric`, but styled as `syntax` throughout instead of always
+    /// `Syntax::Numeric` — used to render the quantity inside a `$(...)` cost
+    /// literal in its own colour.
+    fn append_numeric_as(&mut self, numeric: &'i Numeric, syntax: Syntax) {
         match numeric {
-            Numeric::Integral(num) => self.add_fragment_string(Syntax::Numeric, num.to_string()),
-            Numeric::Scientific(quantity) => self.append_quantity(quantity),
+            Numeric::Integral(num) => self.add_fragment_string(syntax, num.to_string()),
+            Numeric::Scientific(quantity) => self.append_quantity_as(quantity, syntax),
         }
     }
 
     pub fn append_quantity(&mut self, quantity: &'i Quantity) {
+        self.append_quantity_as(quantity, Syntax::Numeric);
+    }
+
+    fn append_quantity_as(&mut self, quantity: &'i Quantity, syntax: Syntax) {
         // Format the mantissa
-        self.add_fragment_string(Syntax::Numeric, format!("{}", quantity.mantissa));
+        self.add_fragment_string(syntax, format!("{}", quantity.mantissa));
 
         // Add uncertainty if present
         if let Some(uncertainty) = &quantity.uncertainty {
             self.add_fragment_reference(Syntax::Neutral, " ");
-            self.add_fragment_reference(Syntax::Numeric, "±");
+            self.add_fragment_reference(syntax, "±");
             self.add_fragment_reference(Syntax::Neutral, " ");
-            self.add_fragment_string(Syntax::Numeric, format!("{}", uncertainty));
+            self.add_fragment_string(syntax, format!("{}", uncertainty));
         }
 
         // Add magnitude if present
         if let Some(magnitude) = &quantity.magnitude {
             self.add_fragment_reference(Syntax::Neutral, " ");
-            self.add_fragment_reference(Syntax::Numeric, "×");
+            self.add_fragment_reference(syntax, "×");
             self.add_fragment_reference(Syntax::Neutral, " ");
-            self.add_fragment_reference(Syntax::Numeric, "10");
-            self.add_fragment_string(Syntax::Numeric, to_superscript(*magnitude));
+            self.add_fragment_reference(syntax, "10");
+            self.add_fragment_string(syntax, to_superscript(*magnitude));
         }
 
         // Add unit symbol
         self.add_fragment_reference(Syntax::Neutral, " ");
-        self.add_fragment_reference(Syntax::Numeric, quantity.symbol);
+        self.add_fragment_reference(syntax, quantity.symbol);
     }
 
     pub fn append_application(&mut self, invocation: &'i Invocation) {

--- a/src/formatting/syntax.rs
+++ b/src/formatting/syntax.rs
@@ -18,6 +18,7 @@ pub enum Syntax {
     Section,
     String,
     Numeric,
+    Cost,
     Response,
     Invocation,
     Title,

--- a/src/highlighting/terminal.rs
+++ b/src/highlighting/terminal.rs
@@ -55,6 +55,10 @@ impl Render for Terminal {
                 .color(owo_colors::Rgb(0xad, 0x7f, 0xa8))
                 .bold()
                 .to_string(),
+            Syntax::Cost => content // number.technique.cost - #a40000 (dull red) bold
+                .color(owo_colors::Rgb(0xa4, 0x00, 0x00))
+                .bold()
+                .to_string(),
             Syntax::Response => content // string.quoted.single.technique
                 .color(owo_colors::Rgb(0xf5, 0x79, 0x00))
                 .bold()

--- a/src/highlighting/typst.rs
+++ b/src/highlighting/typst.rs
@@ -28,6 +28,7 @@ impl Render for Typst {
             Syntax::Section => markup("", &content),
             Syntax::String => markup("fill: rgb(0x4e, 0x9a, 0x06), weight: \"bold\"", &content),
             Syntax::Numeric => markup("fill: rgb(0xad, 0x7f, 0xa8), weight: \"bold\"", &content),
+            Syntax::Cost => markup("fill: rgb(0xa4, 0x00, 0x00), weight: \"bold\"", &content),
             Syntax::Response => markup("fill: rgb(0xf5, 0x79, 0x00), weight: \"bold\"", &content),
             Syntax::Invocation => markup("fill: rgb(0x3b, 0x5d, 0x7d), weight: \"bold\"", &content),
             Syntax::Title => markup("weight: \"bold\"", &content),

--- a/src/language/quantity.rs
+++ b/src/language/quantity.rs
@@ -37,6 +37,39 @@ pub struct Decimal {
     pub precision: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Resource<'i> {
+    Time(Quantity<'i>),
+    Currency(Quantity<'i>),
+    Amount(Quantity<'i>),
+}
+
+/// Classify a Quantity as a Time, Currency, or (fallback) Amount resource,
+/// wrapping it in the matching variant by its unit symbol.
+pub fn classify_resource(quantity: Quantity<'_>) -> Resource<'_> {
+    let symbol = quantity.symbol;
+    let singular = symbol
+        .strip_suffix('s')
+        .unwrap_or(symbol);
+
+    let time = ["year", "month", "week", "day", "hour", "minute", "second"];
+    if time.contains(&singular) {
+        return Resource::Time(quantity);
+    }
+
+    let currency = ["dollar", "pound", "euro", "yen"];
+    if currency.contains(&singular) {
+        return Resource::Currency(quantity);
+    }
+
+    let codes = ["CAD", "USD", "AUD", "SGD", "HKD", "GBP", "EUR", "JPY"];
+    if codes.contains(&symbol) {
+        return Resource::Currency(quantity);
+    }
+
+    Resource::Amount(quantity)
+}
+
 /// Parse a string as a Quantity if it matches the expected format
 pub fn parse_quantity(input: &str) -> Option<Quantity<'_>> {
     // Look for patterns that indicate a quantity:
@@ -372,6 +405,99 @@ mod check {
         assert!(parse_quantity("4 ± 1.5").is_none()); // No units after uncertainty
         assert!(parse_quantity("").is_none()); // Empty string
         assert!(parse_quantity("   ").is_none()); // Just whitespace
+    }
+
+    fn q(symbol: &str) -> Quantity<'_> {
+        Quantity {
+            mantissa: Decimal {
+                number: 1,
+                precision: 0,
+            },
+            uncertainty: None,
+            magnitude: None,
+            symbol,
+        }
+    }
+
+    #[test]
+    fn classify_time_units() {
+        assert_eq!(classify_resource(q("year")), Resource::Time(q("year")));
+        assert_eq!(classify_resource(q("years")), Resource::Time(q("years")));
+        assert_eq!(classify_resource(q("month")), Resource::Time(q("month")));
+        assert_eq!(classify_resource(q("months")), Resource::Time(q("months")));
+        assert_eq!(classify_resource(q("week")), Resource::Time(q("week")));
+        assert_eq!(classify_resource(q("weeks")), Resource::Time(q("weeks")));
+        assert_eq!(classify_resource(q("day")), Resource::Time(q("day")));
+        assert_eq!(classify_resource(q("days")), Resource::Time(q("days")));
+        assert_eq!(classify_resource(q("hour")), Resource::Time(q("hour")));
+        assert_eq!(classify_resource(q("hours")), Resource::Time(q("hours")));
+        assert_eq!(classify_resource(q("minute")), Resource::Time(q("minute")));
+        assert_eq!(
+            classify_resource(q("minutes")),
+            Resource::Time(q("minutes"))
+        );
+        assert_eq!(classify_resource(q("second")), Resource::Time(q("second")));
+        assert_eq!(
+            classify_resource(q("seconds")),
+            Resource::Time(q("seconds"))
+        );
+    }
+
+    #[test]
+    fn classify_currency_words() {
+        assert_eq!(
+            classify_resource(q("dollar")),
+            Resource::Currency(q("dollar"))
+        );
+        assert_eq!(
+            classify_resource(q("dollars")),
+            Resource::Currency(q("dollars"))
+        );
+        assert_eq!(
+            classify_resource(q("pound")),
+            Resource::Currency(q("pound"))
+        );
+        assert_eq!(
+            classify_resource(q("pounds")),
+            Resource::Currency(q("pounds"))
+        );
+        assert_eq!(classify_resource(q("euro")), Resource::Currency(q("euro")));
+        assert_eq!(
+            classify_resource(q("euros")),
+            Resource::Currency(q("euros"))
+        );
+        assert_eq!(classify_resource(q("yen")), Resource::Currency(q("yen")));
+    }
+
+    #[test]
+    fn classify_currency_codes_and_yen() {
+        assert_eq!(classify_resource(q("CAD")), Resource::Currency(q("CAD")));
+        assert_eq!(classify_resource(q("USD")), Resource::Currency(q("USD")));
+        assert_eq!(classify_resource(q("AUD")), Resource::Currency(q("AUD")));
+        assert_eq!(classify_resource(q("SGD")), Resource::Currency(q("SGD")));
+        assert_eq!(classify_resource(q("HKD")), Resource::Currency(q("HKD")));
+        assert_eq!(classify_resource(q("GBP")), Resource::Currency(q("GBP")));
+        assert_eq!(classify_resource(q("EUR")), Resource::Currency(q("EUR")));
+        assert_eq!(classify_resource(q("JPY")), Resource::Currency(q("JPY")));
+    }
+
+    #[test]
+    fn classify_pluralized_codes_are_amounts() {
+        assert_eq!(classify_resource(q("HKDs")), Resource::Amount(q("HKDs")));
+        assert_eq!(classify_resource(q("USDs")), Resource::Amount(q("USDs")));
+    }
+
+    #[test]
+    fn classify_everything_else_is_amount() {
+        assert_eq!(classify_resource(q("kg")), Resource::Amount(q("kg")));
+        assert_eq!(
+            classify_resource(q("breadsticks")),
+            Resource::Amount(q("breadsticks"))
+        );
+        assert_eq!(
+            classify_resource(q("widgets")),
+            Resource::Amount(q("widgets"))
+        );
     }
 
     #[test]

--- a/src/language/types.rs
+++ b/src/language/types.rs
@@ -253,6 +253,10 @@ pub enum Descriptive<'i> {
     CodeInline(Vec<Expression<'i>>),
     Application(Invocation<'i>),
     Binding(Box<Descriptive<'i>>, Vec<Identifier<'i>>),
+    // A naked `$(...)` cost, distinct from CodeInline so the formatter can
+    // tell it apart from an author-written `{ $(...) }` and preserve braces
+    // (or their absence) exactly as written.
+    Cost(Expression<'i>),
 }
 
 // types for Steps within procedures
@@ -443,6 +447,7 @@ pub enum Expression<'i> {
     Repeat(Box<Expression<'i>>, Span),
     Foreach(Vec<Identifier<'i>>, Box<Expression<'i>>, Span),
     Within(Box<Expression<'i>>, Span),
+    Cost(Box<Expression<'i>>, Span),
     Application(Invocation<'i>, Span),
     Execution(Function<'i>, Span),
     Binding(Box<Expression<'i>>, Vec<Identifier<'i>>, Span),
@@ -469,6 +474,7 @@ impl PartialEq for Expression<'_> {
                 a1 == b1 && a2 == b2
             }
             (Expression::Within(a, _), Expression::Within(b, _)) => a == b,
+            (Expression::Cost(a, _), Expression::Cost(b, _)) => a == b,
             (Expression::Application(a, _), Expression::Application(b, _)) => a == b,
             (Expression::Execution(a, _), Expression::Execution(b, _)) => a == b,
             (Expression::Binding(a1, a2, _), Expression::Binding(b1, b2, _)) => {

--- a/src/linking/checks/linker.rs
+++ b/src/linking/checks/linker.rs
@@ -12,8 +12,8 @@ use crate::translation::translate;
 
 fn first_execute<'a, 'i>(op: &'a Operation<'i>) -> Option<&'a Executable<'i>> {
     match op {
-        Operation::Execute(executable) => Some(executable),
-        Operation::Sequence(ops) => ops
+        Operation::Execute(executable, _) => Some(executable),
+        Operation::Sequence(ops, _) => ops
             .iter()
             .find_map(first_execute),
         Operation::Section { body, .. } => first_execute(body),
@@ -23,10 +23,10 @@ fn first_execute<'a, 'i>(op: &'a Operation<'i>) -> Option<&'a Executable<'i>> {
             .and_then(first_execute)
             .or_else(|| first_execute(body)),
         Operation::Bind { value, .. } => first_execute(value),
-        Operation::Tablet(entries) => entries
+        Operation::Tablet(entries, _) => entries
             .iter()
             .find_map(|entry| first_execute(&entry.value)),
-        Operation::List(items) => items
+        Operation::List(items, _) => items
             .iter()
             .find_map(first_execute),
         _ => None,

--- a/src/linking/linker.rs
+++ b/src/linking/linker.rs
@@ -50,7 +50,7 @@ fn link_operation<'i>(
     problems: &mut Vec<LinkingError<'i>>,
 ) {
     match op {
-        Operation::Execute(executable) => {
+        Operation::Execute(executable, _) => {
             if let ExecutableRef::Unresolved(id) = &executable.target {
                 match library.resolve(id.value) {
                     Some(exec_id) => {
@@ -75,12 +75,12 @@ fn link_operation<'i>(
                 link_operation(arg, library, problems);
             }
         }
-        Operation::Invoke(invocable) => {
+        Operation::Invoke(invocable, _) => {
             for arg in &mut invocable.arguments {
                 link_operation(arg, library, problems);
             }
         }
-        Operation::Sequence(ops) | Operation::Prologue(ops) => {
+        Operation::Sequence(ops, _) | Operation::Prologue(ops, _) => {
             for op in ops {
                 link_operation(op, library, problems);
             }
@@ -97,32 +97,32 @@ fn link_operation<'i>(
             link_operation(bound, library, problems);
             link_operation(body, library, problems);
         }
-        Operation::Cost(inner) => link_operation(inner, library, problems),
+        Operation::Cost(inner, _) => link_operation(inner, library, problems),
         Operation::Bind { value, .. } => link_operation(value, library, problems),
-        Operation::String(fragments) => {
+        Operation::String(fragments, _) => {
             for fragment in fragments {
                 if let Fragment::Interpolation(op) = fragment {
                     link_operation(op, library, problems);
                 }
             }
         }
-        Operation::Tablet(entries) => {
+        Operation::Tablet(entries, _) => {
             for entry in entries {
                 link_operation(&mut entry.value, library, problems);
             }
         }
-        Operation::List(items) | Operation::Tuple(items) => {
+        Operation::List(items, _) | Operation::Tuple(items, _) => {
             for item in items {
                 link_operation(item, library, problems);
             }
         }
-        Operation::Variable(_)
-        | Operation::Number(_)
-        | Operation::Response(_)
-        | Operation::Multiline(_, _)
-        | Operation::Prose(_)
-        | Operation::Hole
-        | Operation::Unit => {}
+        Operation::Variable(_, _)
+        | Operation::Number(_, _)
+        | Operation::Response(_, _)
+        | Operation::Multiline(_, _, _)
+        | Operation::Prose(_, _)
+        | Operation::Hole(_)
+        | Operation::Unit(_) => {}
     }
 }
 

--- a/src/linking/linker.rs
+++ b/src/linking/linker.rs
@@ -97,6 +97,7 @@ fn link_operation<'i>(
             link_operation(bound, library, problems);
             link_operation(body, library, problems);
         }
+        Operation::Cost(inner) => link_operation(inner, library, problems),
         Operation::Bind { value, .. } => link_operation(value, library, problems),
         Operation::String(fragments) => {
             for fragment in fragments {

--- a/src/parsing/checks/parser.rs
+++ b/src/parsing/checks/parser.rs
@@ -296,6 +296,69 @@ fn response_as_expression() {
 }
 
 #[test]
+fn cost_as_expression() {
+    // `$(<expression>)` is a cost literal usable wherever an expression is
+    // expected: bare in a code block, or as an invocation argument.
+    let mut input = Parser::new();
+    input.initialize("$(10 minutes)");
+    assert_eq!(
+        input.read_expression(),
+        Ok(Expression::Cost(
+            Box::new(Expression::Number(
+                Numeric::Scientific(Quantity {
+                    mantissa: Decimal {
+                        number: 10,
+                        precision: 0
+                    },
+                    uncertainty: None,
+                    magnitude: None,
+                    symbol: "minutes"
+                }),
+                Span::default()
+            )),
+            Span::default()
+        ))
+    );
+
+    // The argument is any expression, not just a literal quantity.
+    input.initialize("$(calculate())");
+    assert_eq!(
+        input.read_expression(),
+        Ok(Expression::Cost(
+            Box::new(Expression::Execution(
+                Function {
+                    target: Identifier::new("calculate"),
+                    parameters: vec![]
+                },
+                Span::default()
+            )),
+            Span::default()
+        ))
+    );
+}
+
+#[test]
+fn cost_in_code_block() {
+    // A cost is a single expression inside braces: `{ $(calculate()) }`.
+    let mut input = Parser::new();
+    input.initialize("{ $(calculate()) }");
+    let result = input.read_code_block();
+    assert_eq!(
+        result,
+        Ok(vec![Expression::Cost(
+            Box::new(Expression::Execution(
+                Function {
+                    target: Identifier::new("calculate"),
+                    parameters: vec![]
+                },
+                Span::default()
+            )),
+            Span::default()
+        )])
+    );
+}
+
+#[test]
 fn declaration_simple() {
     let mut input = Parser::new();
     input.initialize("making_coffee :");

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1533,6 +1533,8 @@ impl<'i> Parser<'i> {
             self.read_foreach_expression()
         } else if is_within_keyword(content) {
             self.read_within_expression()
+        } else if content.starts_with('$') {
+            self.read_cost_expression()
         } else if content.starts_with("foreach ") {
             // Malformed foreach expression
             return Err(ParsingError::InvalidForeach(Span::new(self.offset, 0)));
@@ -1759,6 +1761,17 @@ impl<'i> Parser<'i> {
 
         let span = self.span_since(start);
         Ok(Expression::Within(Box::new(expression), span))
+    }
+
+    fn read_cost_expression(&mut self) -> Result<Expression<'i>, ParsingError> {
+        // Parse "$(<expression>)"
+        let start = self.offset;
+        self.trim_whitespace();
+        self.advance(1); // consume '$'
+        let inner =
+            self.take_block_chars("a cost", '(', ')', true, |outer| outer.read_expression())?;
+        let span = self.span_since(start);
+        Ok(Expression::Cost(Box::new(inner), span))
     }
 
     fn read_binding_expression(&mut self) -> Result<Expression<'i>, ParsingError> {
@@ -2489,9 +2502,32 @@ impl<'i> Parser<'i> {
                                     } else {
                                         content.push(Descriptive::Application(invocation));
                                     }
+                                } else if c == '$'
+                                    && parser
+                                        .source
+                                        .starts_with("$(")
+                                {
+                                    let cost = parser.read_cost_expression()?;
+                                    parser.trim_whitespace();
+                                    if parser.peek_next_char() == Some('~') {
+                                        parser.advance(1);
+                                        parser.trim_whitespace();
+                                        let variables = parser.read_binding_identifiers()?;
+                                        content.push(Descriptive::Binding(
+                                            Box::new(Descriptive::Cost(cost)),
+                                            variables,
+                                        ));
+                                    } else {
+                                        content.push(Descriptive::Cost(cost));
+                                    }
+                                } else if c == '$' {
+                                    // A bare '$' not opening a cost is literal text.
+                                    parser.advance(1);
+                                    content.push(Descriptive::Text("$"));
                                 } else {
-                                    let text =
-                                        parser.take_until(&['{', '<', '~', '\n'], |inner| {
+                                    let text = parser.take_until(
+                                        &['{', '<', '$', '~', '\n'],
+                                        |inner| {
                                             let content = inner
                                                 .source
                                                 .trim_ascii();
@@ -2502,7 +2538,8 @@ impl<'i> Parser<'i> {
                                                 ));
                                             }
                                             Ok(content)
-                                        })?;
+                                        },
+                                    )?;
                                     if text.is_empty() {
                                         continue;
                                     } else if parser.peek_next_char() == Some('~') {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -54,6 +54,7 @@ pub enum ParsingError {
     InvalidResponse(Span),
     InvalidMultiline(Span),
     InvalidForeach(Span),
+    InvalidCost(Span),
     InvalidIntegral(Span),
     InvalidQuantity(Span),
     InvalidQuantityDecimal(Span),
@@ -90,6 +91,7 @@ impl ParsingError {
             | ParsingError::InvalidResponse(span)
             | ParsingError::InvalidMultiline(span)
             | ParsingError::InvalidForeach(span)
+            | ParsingError::InvalidCost(span)
             | ParsingError::InvalidIntegral(span)
             | ParsingError::InvalidQuantity(span)
             | ParsingError::InvalidQuantityDecimal(span)
@@ -1768,8 +1770,16 @@ impl<'i> Parser<'i> {
         let start = self.offset;
         self.trim_whitespace();
         self.advance(1); // consume '$'
-        let inner =
-            self.take_block_chars("a cost", '(', ')', true, |outer| outer.read_expression())?;
+        let inner = self.take_block_chars("a cost", '(', ')', true, |outer| {
+            outer.trim_whitespace();
+            if outer
+                .source
+                .is_empty()
+            {
+                return Err(ParsingError::InvalidCost(Span::new(outer.offset, 0)));
+            }
+            outer.read_expression()
+        })?;
         let span = self.span_since(start);
         Ok(Expression::Cost(Box::new(inner), span))
     }

--- a/src/problem/messages.rs
+++ b/src/problem/messages.rs
@@ -1214,7 +1214,7 @@ sequence), not a mix of the two.
 /// internal references and variable scoping are resolved.
 pub fn generate_resolution_error<'i>(
     error: &ResolutionError<'i>,
-    _renderer: &dyn Render,
+    renderer: &dyn Render,
 ) -> (String, String) {
     match error {
         ResolutionError::UnresolvedProcedure(Identifier { value: name, .. }) => (
@@ -1255,6 +1255,88 @@ result bound by a binding or loop within it.
             .trim_ascii()
             .to_string(),
         ),
+        ResolutionError::InvalidCostLiteral(_) => {
+            let examples = vec![
+                Expression::Cost(
+                    Box::new(Expression::Number(
+                        Numeric::Scientific(Quantity {
+                            mantissa: Decimal {
+                                number: 2,
+                                precision: 0,
+                            },
+                            uncertainty: None,
+                            magnitude: None,
+                            symbol: "minutes",
+                        }),
+                        Span::default(),
+                    )),
+                    Span::default(),
+                ),
+                Expression::Cost(
+                    Box::new(Expression::Number(
+                        Numeric::Scientific(Quantity {
+                            mantissa: Decimal {
+                                number: 5,
+                                precision: 0,
+                            },
+                            uncertainty: None,
+                            magnitude: None,
+                            symbol: "pounds",
+                        }),
+                        Span::default(),
+                    )),
+                    Span::default(),
+                ),
+                Expression::Cost(
+                    Box::new(Expression::Number(
+                        Numeric::Scientific(Quantity {
+                            mantissa: Decimal {
+                                number: 5,
+                                precision: 0,
+                            },
+                            uncertainty: None,
+                            magnitude: None,
+                            symbol: "GBP",
+                        }),
+                        Span::default(),
+                    )),
+                    Span::default(),
+                ),
+                Expression::Cost(
+                    Box::new(Expression::Number(
+                        Numeric::Scientific(Quantity {
+                            mantissa: Decimal {
+                                number: 6,
+                                precision: 0,
+                            },
+                            uncertainty: None,
+                            magnitude: None,
+                            symbol: "pints",
+                        }),
+                        Span::default(),
+                    )),
+                    Span::default(),
+                ),
+            ];
+
+            (
+                "Cost literal requires a Quantity".to_string(),
+                format!(
+                    r#"
+The $(...) syntax constructs a Cost value out of a Quantity, but the value
+supplied isn't one. You can specify a time, as in the {} demolition
+will take, a currency like {} or {} indicating the what you pay
+at the bar, or an amount, for example {} being reasonable at lunchtime.
+                    "#,
+                    examples[0].present(renderer),
+                    examples[1].present(renderer),
+                    examples[2].present(renderer),
+                    examples[3].present(renderer)
+                )
+                .trim_ascii()
+                .to_string(),
+            )
+        }
     }
 }
 

--- a/src/problem/messages.rs
+++ b/src/problem/messages.rs
@@ -809,6 +809,70 @@ a list of tuples.
                 .to_string(),
             )
         }
+        ParsingError::InvalidCost(_) => {
+            let examples = vec![
+                Expression::Cost(
+                    Box::new(Expression::Number(
+                        Numeric::Scientific(Quantity {
+                            mantissa: Decimal {
+                                number: 2,
+                                precision: 0,
+                            },
+                            uncertainty: None,
+                            magnitude: None,
+                            symbol: "minutes",
+                        }),
+                        Span::default(),
+                    )),
+                    Span::default(),
+                ),
+                Expression::Cost(
+                    Box::new(Expression::Number(
+                        Numeric::Scientific(Quantity {
+                            mantissa: Decimal {
+                                number: 5,
+                                precision: 0,
+                            },
+                            uncertainty: None,
+                            magnitude: None,
+                            symbol: "GBP",
+                        }),
+                        Span::default(),
+                    )),
+                    Span::default(),
+                ),
+                Expression::Cost(
+                    Box::new(Expression::Execution(
+                        Function {
+                            target: Identifier::new("expected_duration"),
+                            parameters: vec![Expression::Variable(
+                                Identifier::new("demolition"),
+                                Span::default(),
+                            )],
+                        },
+                        Span::default(),
+                    )),
+                    Span::default(),
+                ),
+            ];
+
+            (
+                "Incomplete cost literal".to_string(),
+                format!(
+                    r#"
+The $(...) syntax constructs a cost. It must either be a literal such
+as {} or {}, or contain an expression that evaluates
+to a cost (or to a quantity which can be interpreted as a cost).
+Something like {} would be reasonable.
+                    "#,
+                    examples[0].present(renderer),
+                    examples[1].present(renderer),
+                    examples[2].present(renderer)
+                )
+                .trim_ascii()
+                .to_string(),
+            )
+        }
         ParsingError::InvalidResponse(_) => {
             let examples = vec![
                 vec![
@@ -1392,6 +1456,15 @@ to use the values from a tablet convert them into a list first with the
 values() function. There is also a labels() function to get each of the
 tablet's labels, and pairs() to get a sequence of tuples of labels and values
 you can iterate over.
+            "#
+            .trim_ascii()
+            .to_string(),
+        ),
+        RunnerError::InvalidCost => (
+            "Cost literal syntax requires a Quantity".to_string(),
+            r#"
+The $(...) syntax constructs a Cost value out of a Quantity, but the
+expression inside these parentheses evaluated to something else.
             "#
             .trim_ascii()
             .to_string(),

--- a/src/program/types.rs
+++ b/src/program/types.rs
@@ -164,6 +164,9 @@ pub enum Operation<'i> {
         body: Box<Operation<'i>>,
         responses: Vec<&'i language::Response<'i>>,
     },
+    /// A `$(...)` cost evaluates its inner expression, then constructs a
+    /// Resource-typed value (e.g. `Intratempse`) from the result.
+    Cost(Box<Operation<'i>>),
     Bind {
         names: &'i [language::Identifier<'i>],
         value: Box<Operation<'i>>,

--- a/src/program/types.rs
+++ b/src/program/types.rs
@@ -11,6 +11,7 @@
 // own the data.
 
 use crate::language;
+use crate::language::Span;
 
 /// Top-level Technique translated to a runnable program.
 #[derive(Debug, Eq, PartialEq, Default)]
@@ -71,7 +72,7 @@ impl<'i> Subroutine<'i> {
             description: &[],
             parameters: None,
             signature: None,
-            body: Operation::Sequence(Vec::new()),
+            body: Operation::Sequence(Vec::new(), Span::default()),
             responses: Vec::new(),
             locale: Vec::new(),
         }
@@ -100,7 +101,7 @@ impl<'i> Subroutine<'i> {
             description: &[],
             parameters: None,
             signature: None,
-            body: Operation::Sequence(Vec::new()),
+            body: Operation::Sequence(Vec::new(), Span::default()),
             responses: Vec::new(),
             locale: Vec::new(),
         }
@@ -119,30 +120,31 @@ impl<'i> Subroutine<'i> {
 /// the `runner::Environment`.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Operation<'i> {
-    Variable(language::Identifier<'i>),
-    Number(language::Numeric<'i>),
-    String(Vec<Fragment<'i>>),
-    Response(&'i str),
-    Multiline(Option<&'i str>, Vec<&'i str>),
-    Tablet(Vec<Entry<'i>>),
-    List(Vec<Operation<'i>>),
-    Tuple(Vec<Operation<'i>>),
-    Invoke(Invocable<'i>),
-    Execute(Executable<'i>),
-    Hole,
-    Unit,
-    Prose(&'i str),
-    Sequence(Vec<Operation<'i>>),
+    Variable(language::Identifier<'i>, Span),
+    Number(language::Numeric<'i>, Span),
+    String(Vec<Fragment<'i>>, Span),
+    Response(&'i str, Span),
+    Multiline(Option<&'i str>, Vec<&'i str>, Span),
+    Tablet(Vec<Entry<'i>>, Span),
+    List(Vec<Operation<'i>>, Span),
+    Tuple(Vec<Operation<'i>>, Span),
+    Invoke(Invocable<'i>, Span),
+    Execute(Executable<'i>, Span),
+    Hole(Span),
+    Unit(Span),
+    Prose(&'i str, Span),
+    Sequence(Vec<Operation<'i>>, Span),
     /// The executable work hoisted from a procedure's description is an
     /// anonymous "step 0". Present only when the description carries
     /// instructions, not for prose alone. Its outcome folds into the
     /// procedure's own sign-off rather than prompting itself.
-    Prologue(Vec<Operation<'i>>),
+    Prologue(Vec<Operation<'i>>, Span),
     Section {
         numeral: &'i str,
         title: Option<Box<Operation<'i>>>,
         body: Box<Operation<'i>>,
         responses: Vec<&'i language::Response<'i>>,
+        span: Span,
     },
     Step {
         ordinal: Ordinal<'i>,
@@ -150,12 +152,14 @@ pub enum Operation<'i> {
         source: &'i language::Scope<'i>,
         body: Box<Operation<'i>>,
         responses: Vec<&'i language::Response<'i>>,
+        span: Span,
     },
     Loop {
         names: &'i [language::Identifier<'i>],
         over: Option<Box<Operation<'i>>>,
         body: Box<Operation<'i>>,
         responses: Vec<&'i language::Response<'i>>,
+        span: Span,
     },
     /// A `within` block is _not_ generative like `Loop`, but a predicate
     /// governing a run-once body.
@@ -163,17 +167,47 @@ pub enum Operation<'i> {
         bound: Box<Operation<'i>>,
         body: Box<Operation<'i>>,
         responses: Vec<&'i language::Response<'i>>,
+        span: Span,
     },
     /// A `$(...)` cost evaluates its inner expression, then constructs a
     /// Resource-typed value (e.g. `Intratempse`) from the result.
-    Cost(Box<Operation<'i>>),
+    Cost(Box<Operation<'i>>, Span),
     Bind {
         names: &'i [language::Identifier<'i>],
         value: Box<Operation<'i>>,
         /// Inferred shape of the bound value, set in resolution: a wildcard
         /// list `[*]` when the name is iterated by a `foreach`, else `None`.
         inferred: Option<language::Genus<'i>>,
+        span: Span,
     },
+}
+
+impl<'i> Operation<'i> {
+    pub fn span(&self) -> Span {
+        match self {
+            Operation::Variable(_, span)
+            | Operation::Number(_, span)
+            | Operation::String(_, span)
+            | Operation::Response(_, span)
+            | Operation::Multiline(_, _, span)
+            | Operation::Tablet(_, span)
+            | Operation::List(_, span)
+            | Operation::Tuple(_, span)
+            | Operation::Invoke(_, span)
+            | Operation::Execute(_, span)
+            | Operation::Hole(span)
+            | Operation::Unit(span)
+            | Operation::Prose(_, span)
+            | Operation::Sequence(_, span)
+            | Operation::Prologue(_, span)
+            | Operation::Section { span, .. }
+            | Operation::Step { span, .. }
+            | Operation::Loop { span, .. }
+            | Operation::Within { span, .. }
+            | Operation::Cost(_, span)
+            | Operation::Bind { span, .. } => *span,
+        }
+    }
 }
 
 /// A step's lexical kind. `Dependent` carries the verbatim ordinal string as

--- a/src/resolution/checks/resolver.rs
+++ b/src/resolution/checks/resolver.rs
@@ -176,10 +176,10 @@ helper : X -> Y
         })
         .expect("helper present");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Invoke(invocable) = &ops[0] else {
+    let Operation::Invoke(invocable, _) = &ops[0] else {
         panic!("expected Invoke");
     };
     let SubroutineRef::Resolved(SubroutineId(idx)) = invocable.target else {
@@ -219,10 +219,10 @@ main(x) :
         })
         .expect("main present");
 
-    let Operation::Sequence(ops) = &program.subroutines[main_idx].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[main_idx].body else {
         panic!("expected Sequence");
     };
-    let Operation::Invoke(invocable) = &ops[0] else {
+    let Operation::Invoke(invocable, _) = &ops[0] else {
         panic!("expected Invoke");
     };
     let SubroutineRef::Resolved(_) = invocable.target else {
@@ -251,10 +251,10 @@ run :
     let mut program = translate(&document).expect("translate");
     resolve(&mut program).expect("resolve");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Execute(executable) = &ops[0] else {
+    let Operation::Execute(executable, _) = &ops[0] else {
         panic!("expected Execute, got {:?}", ops[0]);
     };
     let ExecutableRef::Unresolved(target) = &executable.target else {
@@ -372,7 +372,7 @@ fn inferred_for<'a>(op: &'a Operation<'a>, name: &str) -> Option<&'a Option<lang
         Operation::Bind { value, .. } | Operation::Step { body: value, .. } => {
             inferred_for(value, name)
         }
-        Operation::Sequence(ops) | Operation::List(ops) => ops
+        Operation::Sequence(ops, _) | Operation::List(ops, _) => ops
             .iter()
             .find_map(|op| inferred_for(op, name)),
         Operation::Loop { over, body, .. } => over

--- a/src/resolution/checks/resolver.rs
+++ b/src/resolution/checks/resolver.rs
@@ -451,3 +451,51 @@ split :
     // The tuple bind is skipped, so no single-name `regions` bind exists to mark.
     assert!(inferred_for(&program.subroutines[0].body, "regions").is_none());
 }
+
+#[test]
+fn cost_literal_string_is_invalid() {
+    // $(...) wrapping a literal that plainly isn't a quantity is a static
+    // resolution error — the string can never become a Quantity.
+    let source = r#"
+% technique v1
+
+bad_cost :
+
+1.  Do a thing $("not a quantity")
+        "#
+    .trim_ascii();
+    let path = Path::new("Test.tq");
+    let document = parsing::parse(path, source).expect("parse");
+    let mut program = translate(&document).expect("translate");
+    let errors = resolve(&mut program).expect_err("resolve should fail");
+
+    assert_eq!(errors.len(), 1);
+    let ResolutionError::InvalidCostLiteral(span) = &errors[0] else {
+        panic!("expected InvalidCostLiteral, got {:?}", errors[0]);
+    };
+    assert_eq!(
+        span.offset,
+        source
+            .find("$(")
+            .expect("$( in source"),
+        "span points at the cost literal"
+    );
+}
+
+#[test]
+fn cost_call_is_not_checked_statically() {
+    // A call's return shape isn't known until it runs, so $(...) wrapping one
+    // resolves cleanly even though it can't be verified as a quantity yet.
+    let source = r#"
+% technique v1
+
+good_cost :
+
+1.  Do a thing $(duration())
+        "#
+    .trim_ascii();
+    let path = Path::new("Test.tq");
+    let document = parsing::parse(path, source).expect("parse");
+    let mut program = translate(&document).expect("translate");
+    resolve(&mut program).expect("resolve");
+}

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -77,7 +77,7 @@ fn resolve_operation<'i>(
     problems: &mut Vec<ResolutionError<'i>>,
 ) {
     match op {
-        Operation::Invoke(invocable) => {
+        Operation::Invoke(invocable, _) => {
             if let SubroutineRef::Unresolved(id) = &invocable.target {
                 match known.get(id.value) {
                     Some(sub_id) => {
@@ -105,10 +105,10 @@ fn resolve_operation<'i>(
                 resolve_operation(arg, known, arities, problems);
             }
         }
-        Operation::Sequence(ops)
-        | Operation::List(ops)
-        | Operation::Tuple(ops)
-        | Operation::Prologue(ops) => {
+        Operation::Sequence(ops, _)
+        | Operation::List(ops, _)
+        | Operation::Tuple(ops, _)
+        | Operation::Prologue(ops, _) => {
             for op in ops {
                 resolve_operation(op, known, arities, problems);
             }
@@ -130,32 +130,32 @@ fn resolve_operation<'i>(
             resolve_operation(bound, known, arities, problems);
             resolve_operation(body, known, arities, problems);
         }
-        Operation::Cost(inner) => resolve_operation(inner, known, arities, problems),
+        Operation::Cost(inner, _) => resolve_operation(inner, known, arities, problems),
         Operation::Bind { value, .. } => resolve_operation(value, known, arities, problems),
-        Operation::Execute(executable) => {
+        Operation::Execute(executable, _) => {
             for arg in &mut executable.arguments {
                 resolve_operation(arg, known, arities, problems);
             }
         }
-        Operation::String(fragments) => {
+        Operation::String(fragments, _) => {
             for fragment in fragments {
                 if let Fragment::Interpolation(op) = fragment {
                     resolve_operation(op, known, arities, problems);
                 }
             }
         }
-        Operation::Tablet(entries) => {
+        Operation::Tablet(entries, _) => {
             for entry in entries {
                 resolve_operation(&mut entry.value, known, arities, problems);
             }
         }
-        Operation::Variable(_)
-        | Operation::Number(_)
-        | Operation::Response(_)
-        | Operation::Multiline(_, _)
-        | Operation::Prose(_)
-        | Operation::Hole
-        | Operation::Unit => {}
+        Operation::Variable(_, _)
+        | Operation::Number(_, _)
+        | Operation::Response(_, _)
+        | Operation::Multiline(_, _, _)
+        | Operation::Prose(_, _)
+        | Operation::Hole(_)
+        | Operation::Unit(_) => {}
     }
 }
 
@@ -175,7 +175,7 @@ fn gather_iterated<'i>(op: &Operation<'i>, iterated: &mut HashSet<&'i str>) {
     match op {
         Operation::Loop { over, body, .. } => {
             if let Some(over) = over {
-                if let Operation::Variable(id) = over.as_ref() {
+                if let Operation::Variable(id, _) = over.as_ref() {
                     iterated.insert(id.value);
                 }
                 gather_iterated(over, iterated);
@@ -187,11 +187,11 @@ fn gather_iterated<'i>(op: &Operation<'i>, iterated: &mut HashSet<&'i str>) {
             gather_iterated(body, iterated);
         }
         Operation::Bind { value, .. } => gather_iterated(value, iterated),
-        Operation::Cost(inner) => gather_iterated(inner, iterated),
-        Operation::Sequence(ops)
-        | Operation::List(ops)
-        | Operation::Tuple(ops)
-        | Operation::Prologue(ops) => {
+        Operation::Cost(inner, _) => gather_iterated(inner, iterated),
+        Operation::Sequence(ops, _)
+        | Operation::List(ops, _)
+        | Operation::Tuple(ops, _)
+        | Operation::Prologue(ops, _) => {
             for op in ops {
                 gather_iterated(op, iterated);
             }
@@ -203,35 +203,35 @@ fn gather_iterated<'i>(op: &Operation<'i>, iterated: &mut HashSet<&'i str>) {
             gather_iterated(body, iterated);
         }
         Operation::Step { body, .. } => gather_iterated(body, iterated),
-        Operation::Invoke(invocable) => {
+        Operation::Invoke(invocable, _) => {
             for arg in &invocable.arguments {
                 gather_iterated(arg, iterated);
             }
         }
-        Operation::Execute(executable) => {
+        Operation::Execute(executable, _) => {
             for arg in &executable.arguments {
                 gather_iterated(arg, iterated);
             }
         }
-        Operation::String(fragments) => {
+        Operation::String(fragments, _) => {
             for fragment in fragments {
                 if let Fragment::Interpolation(op) = fragment {
                     gather_iterated(op, iterated);
                 }
             }
         }
-        Operation::Tablet(entries) => {
+        Operation::Tablet(entries, _) => {
             for entry in entries {
                 gather_iterated(&entry.value, iterated);
             }
         }
-        Operation::Variable(_)
-        | Operation::Number(_)
-        | Operation::Response(_)
-        | Operation::Multiline(_, _)
-        | Operation::Prose(_)
-        | Operation::Hole
-        | Operation::Unit => {}
+        Operation::Variable(_, _)
+        | Operation::Number(_, _)
+        | Operation::Response(_, _)
+        | Operation::Multiline(_, _, _)
+        | Operation::Prose(_, _)
+        | Operation::Hole(_)
+        | Operation::Unit(_) => {}
     }
 }
 
@@ -241,6 +241,7 @@ fn mark_iterated<'i>(op: &mut Operation<'i>, iterated: &HashSet<&str>) {
             names,
             value,
             inferred,
+            ..
         } => {
             if names.len() == 1 && iterated.contains(names[0].value) {
                 *inferred = Some(language::Genus::List(language::Forma::new("*")));
@@ -257,11 +258,11 @@ fn mark_iterated<'i>(op: &mut Operation<'i>, iterated: &HashSet<&str>) {
             mark_iterated(bound, iterated);
             mark_iterated(body, iterated);
         }
-        Operation::Cost(inner) => mark_iterated(inner, iterated),
-        Operation::Sequence(ops)
-        | Operation::List(ops)
-        | Operation::Tuple(ops)
-        | Operation::Prologue(ops) => {
+        Operation::Cost(inner, _) => mark_iterated(inner, iterated),
+        Operation::Sequence(ops, _)
+        | Operation::List(ops, _)
+        | Operation::Tuple(ops, _)
+        | Operation::Prologue(ops, _) => {
             for op in ops {
                 mark_iterated(op, iterated);
             }
@@ -273,35 +274,35 @@ fn mark_iterated<'i>(op: &mut Operation<'i>, iterated: &HashSet<&str>) {
             mark_iterated(body, iterated);
         }
         Operation::Step { body, .. } => mark_iterated(body, iterated),
-        Operation::Invoke(invocable) => {
+        Operation::Invoke(invocable, _) => {
             for arg in &mut invocable.arguments {
                 mark_iterated(arg, iterated);
             }
         }
-        Operation::Execute(executable) => {
+        Operation::Execute(executable, _) => {
             for arg in &mut executable.arguments {
                 mark_iterated(arg, iterated);
             }
         }
-        Operation::String(fragments) => {
+        Operation::String(fragments, _) => {
             for fragment in fragments {
                 if let Fragment::Interpolation(op) = fragment {
                     mark_iterated(op, iterated);
                 }
             }
         }
-        Operation::Tablet(entries) => {
+        Operation::Tablet(entries, _) => {
             for entry in entries {
                 mark_iterated(&mut entry.value, iterated);
             }
         }
-        Operation::Variable(_)
-        | Operation::Number(_)
-        | Operation::Response(_)
-        | Operation::Multiline(_, _)
-        | Operation::Prose(_)
-        | Operation::Hole
-        | Operation::Unit => {}
+        Operation::Variable(_, _)
+        | Operation::Number(_, _)
+        | Operation::Response(_, _)
+        | Operation::Multiline(_, _, _)
+        | Operation::Prose(_, _)
+        | Operation::Hole(_)
+        | Operation::Unit(_) => {}
     }
 }
 
@@ -328,7 +329,7 @@ fn check_scope<'i>(
     problems: &mut Vec<ResolutionError<'i>>,
 ) {
     match op {
-        Operation::Variable(id) => {
+        Operation::Variable(id, _) => {
             if !scope.contains(id.value) {
                 problems.push(ResolutionError::UnboundVariable { variable: *id });
             }
@@ -359,11 +360,11 @@ fn check_scope<'i>(
             check_scope(bound, scope, problems);
             check_scope(body, scope, problems);
         }
-        Operation::Cost(inner) => check_scope(inner, scope, problems),
-        Operation::Sequence(ops)
-        | Operation::List(ops)
-        | Operation::Tuple(ops)
-        | Operation::Prologue(ops) => {
+        Operation::Cost(inner, _) => check_scope(inner, scope, problems),
+        Operation::Sequence(ops, _)
+        | Operation::List(ops, _)
+        | Operation::Tuple(ops, _)
+        | Operation::Prologue(ops, _) => {
             for op in ops {
                 check_scope(op, scope, problems);
             }
@@ -375,34 +376,34 @@ fn check_scope<'i>(
             check_scope(body, scope, problems);
         }
         Operation::Step { body, .. } => check_scope(body, scope, problems),
-        Operation::Invoke(invocable) => {
+        Operation::Invoke(invocable, _) => {
             for arg in &invocable.arguments {
                 check_scope(arg, scope, problems);
             }
         }
-        Operation::Execute(executable) => {
+        Operation::Execute(executable, _) => {
             for arg in &executable.arguments {
                 check_scope(arg, scope, problems);
             }
         }
-        Operation::String(fragments) => {
+        Operation::String(fragments, _) => {
             for fragment in fragments {
                 if let Fragment::Interpolation(op) = fragment {
                     check_scope(op, scope, problems);
                 }
             }
         }
-        Operation::Tablet(entries) => {
+        Operation::Tablet(entries, _) => {
             for entry in entries {
                 check_scope(&entry.value, scope, problems);
             }
         }
-        Operation::Number(_)
-        | Operation::Response(_)
-        | Operation::Multiline(_, _)
-        | Operation::Prose(_)
-        | Operation::Hole
-        | Operation::Unit => {}
+        Operation::Number(_, _)
+        | Operation::Response(_, _)
+        | Operation::Multiline(_, _, _)
+        | Operation::Prose(_, _)
+        | Operation::Hole(_)
+        | Operation::Unit(_) => {}
     }
 }
 

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -130,6 +130,7 @@ fn resolve_operation<'i>(
             resolve_operation(bound, known, arities, problems);
             resolve_operation(body, known, arities, problems);
         }
+        Operation::Cost(inner) => resolve_operation(inner, known, arities, problems),
         Operation::Bind { value, .. } => resolve_operation(value, known, arities, problems),
         Operation::Execute(executable) => {
             for arg in &mut executable.arguments {
@@ -186,6 +187,7 @@ fn gather_iterated<'i>(op: &Operation<'i>, iterated: &mut HashSet<&'i str>) {
             gather_iterated(body, iterated);
         }
         Operation::Bind { value, .. } => gather_iterated(value, iterated),
+        Operation::Cost(inner) => gather_iterated(inner, iterated),
         Operation::Sequence(ops)
         | Operation::List(ops)
         | Operation::Tuple(ops)
@@ -255,6 +257,7 @@ fn mark_iterated<'i>(op: &mut Operation<'i>, iterated: &HashSet<&str>) {
             mark_iterated(bound, iterated);
             mark_iterated(body, iterated);
         }
+        Operation::Cost(inner) => mark_iterated(inner, iterated),
         Operation::Sequence(ops)
         | Operation::List(ops)
         | Operation::Tuple(ops)
@@ -356,6 +359,7 @@ fn check_scope<'i>(
             check_scope(bound, scope, problems);
             check_scope(body, scope, problems);
         }
+        Operation::Cost(inner) => check_scope(inner, scope, problems),
         Operation::Sequence(ops)
         | Operation::List(ops)
         | Operation::Tuple(ops)

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -18,6 +18,11 @@ pub enum ResolutionError<'i> {
     /// A read that doesn't match any variable in scope (neither a parameter
     /// of the procedure nor a name bound by a binding or loop within it).
     UnboundVariable { variable: language::Identifier<'i> },
+    /// A `$(...)` cost whose inner expression is a literal that plainly isn't
+    /// a quantity`. If an expression is here its return value isn't known
+    /// until runtime, so that case is left to the runtime
+    /// `RunnerError::InvalidCost` check instead.
+    InvalidCostLiteral(Span),
 }
 
 impl<'i> ResolutionError<'i> {
@@ -26,6 +31,7 @@ impl<'i> ResolutionError<'i> {
             ResolutionError::UnresolvedProcedure(id) => id.span,
             ResolutionError::ProcedureArityMismatch { procedure, .. } => procedure.span,
             ResolutionError::UnboundVariable { variable } => variable.span,
+            ResolutionError::InvalidCostLiteral(span) => *span,
         }
     }
 }
@@ -62,6 +68,7 @@ pub fn resolve<'i>(program: &mut Program<'i>) -> Result<(), Vec<ResolutionError<
     }
     for subroutine in &program.subroutines {
         check_bindings(subroutine, &mut problems);
+        check_costs(&subroutine.body, &mut problems);
     }
     if problems.is_empty() {
         Ok(())
@@ -404,6 +411,92 @@ fn check_scope<'i>(
         | Operation::Prose(_, _)
         | Operation::Hole(_)
         | Operation::Unit(_) => {}
+    }
+}
+
+// Flag a $(...) cost whose inner expression is a literal that plainly isn't a
+// quantity. A call, invocation, variable read, or bind has no statically
+// known result, so those are left unchecked here — a bad value from one of
+// those surfaces at runtime as RunnerError::InvalidCost instead.
+fn check_costs<'i>(op: &Operation<'i>, problems: &mut Vec<ResolutionError<'i>>) {
+    match op {
+        Operation::Cost(inner, span) => {
+            if literal_not_a_quantity(inner) {
+                problems.push(ResolutionError::InvalidCostLiteral(*span));
+            }
+            check_costs(inner, problems);
+        }
+        Operation::Sequence(ops, _)
+        | Operation::List(ops, _)
+        | Operation::Tuple(ops, _)
+        | Operation::Prologue(ops, _) => {
+            for op in ops {
+                check_costs(op, problems);
+            }
+        }
+        Operation::Section { title, body, .. } => {
+            if let Some(title) = title {
+                check_costs(title, problems);
+            }
+            check_costs(body, problems);
+        }
+        Operation::Step { body, .. } => check_costs(body, problems),
+        Operation::Loop { over, body, .. } => {
+            if let Some(over) = over {
+                check_costs(over, problems);
+            }
+            check_costs(body, problems);
+        }
+        Operation::Within { bound, body, .. } => {
+            check_costs(bound, problems);
+            check_costs(body, problems);
+        }
+        Operation::Bind { value, .. } => check_costs(value, problems),
+        Operation::Invoke(invocable, _) => {
+            for arg in &invocable.arguments {
+                check_costs(arg, problems);
+            }
+        }
+        Operation::Execute(executable, _) => {
+            for arg in &executable.arguments {
+                check_costs(arg, problems);
+            }
+        }
+        Operation::String(fragments, _) => {
+            for fragment in fragments {
+                if let Fragment::Interpolation(op) = fragment {
+                    check_costs(op, problems);
+                }
+            }
+        }
+        Operation::Tablet(entries, _) => {
+            for entry in entries {
+                check_costs(&entry.value, problems);
+            }
+        }
+        Operation::Variable(_, _)
+        | Operation::Number(_, _)
+        | Operation::Response(_, _)
+        | Operation::Multiline(_, _, _)
+        | Operation::Prose(_, _)
+        | Operation::Hole(_)
+        | Operation::Unit(_) => {}
+    }
+}
+
+// Whether `op` is a literal — not a call — known without evaluation to not be
+// a quantity.
+fn literal_not_a_quantity(op: &Operation) -> bool {
+    match op {
+        Operation::String(_, _)
+        | Operation::Response(_, _)
+        | Operation::Multiline(_, _, _)
+        | Operation::Tablet(_, _)
+        | Operation::List(_, _)
+        | Operation::Tuple(_, _)
+        | Operation::Unit(_)
+        | Operation::Hole(_) => true,
+        _ => false,
     }
 }
 

--- a/src/runner/checks/evaluator.rs
+++ b/src/runner/checks/evaluator.rs
@@ -1,4 +1,4 @@
-use crate::language::{Identifier, Numeric as LangNumeric};
+use crate::language::{Identifier, Numeric as LangNumeric, Span};
 use crate::program::{Entry, Executable, ExecutableRef, Fragment, Operation};
 use crate::runner::context::Context;
 use crate::runner::evaluator::{Environment, coerce_to_list, combine, evaluate};
@@ -10,7 +10,7 @@ use crate::value;
 fn variable_lookup() {
     let library = Library::core();
     let context = Context::native(false);
-    let op = Operation::Variable(Identifier::new("missing"));
+    let op = Operation::Variable(Identifier::new("missing"), Span::default());
     let mut env = Environment::new();
     match evaluate(&library, &context, &mut env, &op) {
         Err(RunnerError::UnboundVariable(name)) => assert_eq!(name, "missing"),
@@ -22,7 +22,7 @@ fn variable_lookup() {
         "name".to_string(),
         value::Value::Literali("World".to_string()),
     );
-    let op = Operation::Variable(Identifier::new("name"));
+    let op = Operation::Variable(Identifier::new("name"), Span::default());
     let v = evaluate(&library, &context, &mut env, &op).expect("evaluated");
     assert_eq!(v, value::Value::Literali("World".to_string()));
 }
@@ -31,7 +31,7 @@ fn variable_lookup() {
 fn number_evaluates_to_quanticle() {
     let library = Library::core();
     let context = Context::native(false);
-    let op = Operation::Number(LangNumeric::Integral(42));
+    let op = Operation::Number(LangNumeric::Integral(42), Span::default());
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &op).expect("evaluated");
     assert_eq!(v, value::Value::Quanticle(value::Numeric::Integral(42)));
@@ -46,18 +46,30 @@ fn string_interpolation() {
         "name".to_string(),
         value::Value::Literali("World".to_string()),
     );
-    let op = Operation::String(vec![
-        Fragment::Text("Hello, "),
-        Fragment::Interpolation(Operation::Variable(Identifier::new("name"))),
-        Fragment::Text("!"),
-    ]);
+    let op = Operation::String(
+        vec![
+            Fragment::Text("Hello, "),
+            Fragment::Interpolation(Operation::Variable(
+                Identifier::new("name"),
+                Span::default(),
+            )),
+            Fragment::Text("!"),
+        ],
+        Span::default(),
+    );
     let v = evaluate(&library, &context, &mut env, &op).expect("evaluated");
     assert_eq!(v, value::Value::Literali("Hello, World!".to_string()));
 
-    let op = Operation::String(vec![
-        Fragment::Text("hi "),
-        Fragment::Interpolation(Operation::Variable(Identifier::new("nope"))),
-    ]);
+    let op = Operation::String(
+        vec![
+            Fragment::Text("hi "),
+            Fragment::Interpolation(Operation::Variable(
+                Identifier::new("nope"),
+                Span::default(),
+            )),
+        ],
+        Span::default(),
+    );
     let mut env = Environment::new();
     match evaluate(&library, &context, &mut env, &op) {
         Err(RunnerError::UnboundVariable(name)) => assert_eq!(name, "nope"),
@@ -69,7 +81,7 @@ fn string_interpolation() {
 fn multiline_joins_with_newlines() {
     let library = Library::core();
     let context = Context::native(false);
-    let op = Operation::Multiline(None, vec!["foo", "bar", "baz"]);
+    let op = Operation::Multiline(None, vec!["foo", "bar", "baz"], Span::default());
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &op).expect("evaluated");
     assert_eq!(v, value::Value::Literali("foo\nbar\nbaz".to_string()));
@@ -79,16 +91,19 @@ fn multiline_joins_with_newlines() {
 fn tablet_entries_evaluate() {
     let library = Library::core();
     let context = Context::native(false);
-    let op = Operation::Tablet(vec![
-        Entry {
-            label: "name",
-            value: Operation::String(vec![Fragment::Text("Kowalski")]),
-        },
-        Entry {
-            label: "count",
-            value: Operation::Number(LangNumeric::Integral(7)),
-        },
-    ]);
+    let op = Operation::Tablet(
+        vec![
+            Entry {
+                label: "name",
+                value: Operation::String(vec![Fragment::Text("Kowalski")], Span::default()),
+            },
+            Entry {
+                label: "count",
+                value: Operation::Number(LangNumeric::Integral(7), Span::default()),
+            },
+        ],
+        Span::default(),
+    );
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &op).expect("evaluated");
     assert_eq!(
@@ -110,11 +125,14 @@ fn tablet_entries_evaluate() {
 fn list_elements_evaluate() {
     let library = Library::core();
     let context = Context::native(false);
-    let op = Operation::List(vec![
-        Operation::Number(LangNumeric::Integral(1)),
-        Operation::Number(LangNumeric::Integral(4)),
-        Operation::Number(LangNumeric::Integral(9)),
-    ]);
+    let op = Operation::List(
+        vec![
+            Operation::Number(LangNumeric::Integral(1), Span::default()),
+            Operation::Number(LangNumeric::Integral(4), Span::default()),
+            Operation::Number(LangNumeric::Integral(9), Span::default()),
+        ],
+        Span::default(),
+    );
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &op).expect("evaluated");
     assert_eq!(
@@ -134,11 +152,15 @@ fn bind_extends_env_for_subsequent_lookup() {
     let names = [Identifier::new("greeting")];
     let bind = Operation::Bind {
         names: &names,
-        value: Box::new(Operation::String(vec![Fragment::Text("Hello")])),
+        value: Box::new(Operation::String(
+            vec![Fragment::Text("Hello")],
+            Span::default(),
+        )),
         inferred: None,
+        span: Span::default(),
     };
-    let lookup = Operation::Variable(Identifier::new("greeting"));
-    let seq = Operation::Sequence(vec![bind, lookup]);
+    let lookup = Operation::Variable(Identifier::new("greeting"), Span::default());
+    let seq = Operation::Sequence(vec![bind, lookup], Span::default());
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &seq).expect("evaluated");
     assert_eq!(v, value::Value::Literali("Hello".to_string()));
@@ -151,16 +173,19 @@ fn bind_extends_env_for_subsequent_lookup() {
 fn sequence_evaluation() {
     let library = Library::core();
     let context = Context::native(false);
-    let seq = Operation::Sequence(vec![
-        Operation::Number(LangNumeric::Integral(1)),
-        Operation::Number(LangNumeric::Integral(2)),
-        Operation::Number(LangNumeric::Integral(3)),
-    ]);
+    let seq = Operation::Sequence(
+        vec![
+            Operation::Number(LangNumeric::Integral(1), Span::default()),
+            Operation::Number(LangNumeric::Integral(2), Span::default()),
+            Operation::Number(LangNumeric::Integral(3), Span::default()),
+        ],
+        Span::default(),
+    );
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &seq).expect("evaluated");
     assert_eq!(v, value::Value::Quanticle(value::Numeric::Integral(3)));
 
-    let seq = Operation::Sequence(vec![]);
+    let seq = Operation::Sequence(vec![], Span::default());
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &seq).expect("evaluated");
     assert_eq!(v, value::Value::Unitus);
@@ -171,10 +196,13 @@ fn tuple_literal_evaluates_to_parametriq() {
     let library = Library::core();
     let context = Context::native(false);
     let mut env = Environment::new();
-    let tuple = Operation::Tuple(vec![
-        Operation::Number(LangNumeric::Integral(2)),
-        Operation::String(vec![Fragment::Text("mice")]),
-    ]);
+    let tuple = Operation::Tuple(
+        vec![
+            Operation::Number(LangNumeric::Integral(2), Span::default()),
+            Operation::String(vec![Fragment::Text("mice")], Span::default()),
+        ],
+        Span::default(),
+    );
     let v = evaluate(&library, &context, &mut env, &tuple).expect("evaluated");
     assert_eq!(
         v,
@@ -194,11 +222,15 @@ fn tuple_literal_binds_directly() {
     let names = [Identifier::new("count"), Identifier::new("kind")];
     let bind = Operation::Bind {
         names: &names,
-        value: Box::new(Operation::Tuple(vec![
-            Operation::Number(LangNumeric::Integral(2)),
-            Operation::String(vec![Fragment::Text("mice")]),
-        ])),
+        value: Box::new(Operation::Tuple(
+            vec![
+                Operation::Number(LangNumeric::Integral(2), Span::default()),
+                Operation::String(vec![Fragment::Text("mice")], Span::default()),
+            ],
+            Span::default(),
+        )),
         inferred: None,
+        span: Span::default(),
     };
     let result = evaluate(&library, &context, &mut env, &bind).expect("evaluated");
     assert_eq!(result, value::Value::Unitus);
@@ -232,8 +264,12 @@ fn multi_name_bind_destructures_parametriq() {
     ];
     let bind = Operation::Bind {
         names: &names,
-        value: Box::new(Operation::Variable(Identifier::new("triple"))),
+        value: Box::new(Operation::Variable(
+            Identifier::new("triple"),
+            Span::default(),
+        )),
         inferred: None,
+        span: Span::default(),
     };
     let result = evaluate(&library, &context, &mut env, &bind).expect("evaluated");
     assert_eq!(result, value::Value::Unitus);
@@ -270,8 +306,12 @@ fn multi_name_bind_wrong_arity_errors() {
     ];
     let bind = Operation::Bind {
         names: &names,
-        value: Box::new(Operation::Variable(Identifier::new("pair"))),
+        value: Box::new(Operation::Variable(
+            Identifier::new("pair"),
+            Span::default(),
+        )),
         inferred: None,
+        span: Span::default(),
     };
     match evaluate(&library, &context, &mut env, &bind) {
         Err(RunnerError::BindArityMismatch { expected, actual }) => {
@@ -294,8 +334,12 @@ fn multi_name_bind_against_scalar_errors_as_not_tuple() {
     let names = [Identifier::new("a"), Identifier::new("b")];
     let bind = Operation::Bind {
         names: &names,
-        value: Box::new(Operation::Variable(Identifier::new("scalar"))),
+        value: Box::new(Operation::Variable(
+            Identifier::new("scalar"),
+            Span::default(),
+        )),
         inferred: None,
+        span: Span::default(),
     };
     match evaluate(&library, &context, &mut env, &bind) {
         Err(RunnerError::BindNotTuple { expected }) => {
@@ -312,13 +356,16 @@ fn execute_dispatches_resolved_builtin() {
     let id = library
         .resolve("seq")
         .expect("seq registered");
-    let op = Operation::Execute(Executable {
-        target: ExecutableRef::Resolved(id),
-        arguments: vec![
-            Operation::Number(LangNumeric::Integral(1)),
-            Operation::Number(LangNumeric::Integral(3)),
-        ],
-    });
+    let op = Operation::Execute(
+        Executable {
+            target: ExecutableRef::Resolved(id),
+            arguments: vec![
+                Operation::Number(LangNumeric::Integral(1), Span::default()),
+                Operation::Number(LangNumeric::Integral(3), Span::default()),
+            ],
+        },
+        Span::default(),
+    );
     let mut env = Environment::new();
     let v = evaluate(&library, &context, &mut env, &op).expect("evaluated");
     assert_eq!(
@@ -335,10 +382,13 @@ fn execute_dispatches_resolved_builtin() {
 fn execute_unresolved_function_errors() {
     let library = Library::core();
     let context = Context::native(false);
-    let op = Operation::Execute(Executable {
-        target: ExecutableRef::Unresolved(Identifier::new("click")),
-        arguments: Vec::new(),
-    });
+    let op = Operation::Execute(
+        Executable {
+            target: ExecutableRef::Unresolved(Identifier::new("click")),
+            arguments: Vec::new(),
+        },
+        Span::default(),
+    );
     let mut env = Environment::new();
     let Err(RunnerError::UnknownFunction(name)) = evaluate(&library, &context, &mut env, &op)
     else {

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -2016,6 +2016,34 @@ fn foreach_over_non_list_errors_unbound_is_empty() {
 }
 
 #[test]
+fn cost_of_non_quantity_value_errors_invalid_cost() {
+    // $(...) constructs an Intratempse from its inner expression's value; a
+    // bare string is not a quantity, so it cannot become a cost.
+    let cost_op = Operation::Cost(Box::new(Operation::String(vec![Fragment::Text(
+        "not a quantity",
+    )])));
+    let mut sub = Subroutine::anonymous();
+    sub.body = cost_op;
+    let mut program = Program::new();
+    program
+        .subroutines
+        .push(sub);
+
+    let mut fixture = StoreFixture::new("cost-non-quantity");
+    let mut runner = Runner::new(
+        &program,
+        fixture.take_appender(),
+        HashMap::new(),
+        Mock::new(),
+        Library::stub(),
+    );
+    match runner.run(Environment::new()) {
+        Err(RunnerError::InvalidCost) => {}
+        other => panic!("expected InvalidCost, got {:?}", other),
+    }
+}
+
+#[test]
 fn bind_parameters_arity_and_errors() {
     // Procedure with two parameters and matching arity: the returned
     // Environment contains both parameter bindings in `Value::Literali`

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -109,6 +109,7 @@ fn step(ordinal: Ordinal<'static>, body: Operation<'static>) -> Operation<'stati
         source: scope_for(ordinal),
         body: Box::new(body),
         responses: Vec::new(),
+        span: language::Span::default(),
     }
 }
 
@@ -125,10 +126,13 @@ fn anonymous_with_body(body: Operation<'static>) -> Program<'static> {
 #[test]
 fn step_outcomes_recorded() {
     let mut fixture = StoreFixture::new("step-done");
-    let body = Operation::Sequence(vec![step(
-        Ordinal::Dependent("1"),
-        Operation::Sequence(vec![]),
-    )]);
+    let body = Operation::Sequence(
+        vec![step(
+            Ordinal::Dependent("1"),
+            Operation::Sequence(vec![], language::Span::default()),
+        )],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
     let prompt = Mock::with_answers([UserInput::Done(Value::Unitus)]);
     let mut runner = Runner::new(
@@ -168,10 +172,13 @@ fn step_outcomes_recorded() {
     };
 
     let mut fixture = StoreFixture::new("step-skip");
-    let body = Operation::Sequence(vec![step(
-        Ordinal::Dependent("1"),
-        Operation::Sequence(vec![]),
-    )]);
+    let body = Operation::Sequence(
+        vec![step(
+            Ordinal::Dependent("1"),
+            Operation::Sequence(vec![], language::Span::default()),
+        )],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
     let prompt = Mock::with_answers([UserInput::Skip]);
     let mut runner = Runner::new(
@@ -199,10 +206,13 @@ fn step_outcomes_recorded() {
     assert_eq!(record.state, State::Skip);
 
     let mut fixture = StoreFixture::new("step-fail");
-    let body = Operation::Sequence(vec![step(
-        Ordinal::Dependent("1"),
-        Operation::Sequence(vec![]),
-    )]);
+    let body = Operation::Sequence(
+        vec![step(
+            Ordinal::Dependent("1"),
+            Operation::Sequence(vec![], language::Span::default()),
+        )],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
     let prompt = Mock::with_answers([UserInput::Fail("cable unplugged".to_string())]);
     let mut runner = Runner::new(
@@ -241,10 +251,13 @@ fn empty_fail_reason_records_none() {
     // Failing a step without giving a reason records Fail with no reason at
     // all, not an empty-string reason tablet.
     let mut fixture = StoreFixture::new("fail-no-reason");
-    let body = Operation::Sequence(vec![step(
-        Ordinal::Dependent("1"),
-        Operation::Sequence(vec![]),
-    )]);
+    let body = Operation::Sequence(
+        vec![step(
+            Ordinal::Dependent("1"),
+            Operation::Sequence(vec![], language::Span::default()),
+        )],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
     let prompt = Mock::with_answers([UserInput::Fail(String::new())]);
     let mut runner = Runner::new(
@@ -320,10 +333,19 @@ helper :
 #[test]
 fn two_steps_prompted_in_source_order() {
     let mut fixture = StoreFixture::new("two-steps");
-    let body = Operation::Sequence(vec![
-        step(Ordinal::Dependent("1"), Operation::Sequence(vec![])),
-        step(Ordinal::Dependent("2"), Operation::Sequence(vec![])),
-    ]);
+    let body = Operation::Sequence(
+        vec![
+            step(
+                Ordinal::Dependent("1"),
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+            step(
+                Ordinal::Dependent("2"),
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+        ],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
 
     let prompt = Mock::with_answers([
@@ -360,10 +382,19 @@ fn two_steps_prompted_in_source_order() {
 #[test]
 fn pre_completed_step_short_circuits() {
     let mut fixture = StoreFixture::new("short-circuit");
-    let body = Operation::Sequence(vec![
-        step(Ordinal::Dependent("1"), Operation::Sequence(vec![])),
-        step(Ordinal::Dependent("2"), Operation::Sequence(vec![])),
-    ]);
+    let body = Operation::Sequence(
+        vec![
+            step(
+                Ordinal::Dependent("1"),
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+            step(
+                Ordinal::Dependent("2"),
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+        ],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
 
     // Pre-mark step 1 completed; the walker should skip its prompt
@@ -402,10 +433,19 @@ fn pre_completed_step_short_circuits() {
 #[test]
 fn quit_propagates_and_stops_walking() {
     let mut fixture = StoreFixture::new("quit-propagates");
-    let body = Operation::Sequence(vec![
-        step(Ordinal::Dependent("1"), Operation::Sequence(vec![])),
-        step(Ordinal::Dependent("2"), Operation::Sequence(vec![])),
-    ]);
+    let body = Operation::Sequence(
+        vec![
+            step(
+                Ordinal::Dependent("1"),
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+            step(
+                Ordinal::Dependent("2"),
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+        ],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
 
     let prompt = Mock::with_answers([UserInput::Quit]);
@@ -460,13 +500,20 @@ fn section_walking() {
     use crate::program::Fragment;
 
     let mut fixture = StoreFixture::new("section-no-title");
-    let inner = step(Ordinal::Dependent("1"), Operation::Sequence(vec![]));
-    let body = Operation::Sequence(vec![Operation::Section {
-        numeral: "I",
-        title: None,
-        body: Box::new(Operation::Sequence(vec![inner])),
-        responses: Vec::new(),
-    }]);
+    let inner = step(
+        Ordinal::Dependent("1"),
+        Operation::Sequence(vec![], language::Span::default()),
+    );
+    let body = Operation::Sequence(
+        vec![Operation::Section {
+            numeral: "I",
+            title: None,
+            body: Box::new(Operation::Sequence(vec![inner], language::Span::default())),
+            responses: Vec::new(),
+            span: language::Span::default(),
+        }],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
     let prompt = Mock::with_answers([UserInput::Done(Value::Unitus)]);
     let mut runner = Runner::new(
@@ -519,14 +566,21 @@ fn section_walking() {
     assert_eq!(step_fqns, vec!["/I/1"]);
 
     let mut fixture = StoreFixture::new("section-with-title");
-    let title = Operation::String(vec![Fragment::Text("Setup")]);
-    let inner = step(Ordinal::Dependent("1"), Operation::Sequence(vec![]));
-    let body = Operation::Sequence(vec![Operation::Section {
-        numeral: "I",
-        title: Some(Box::new(title)),
-        body: Box::new(Operation::Sequence(vec![inner])),
-        responses: Vec::new(),
-    }]);
+    let title = Operation::String(vec![Fragment::Text("Setup")], language::Span::default());
+    let inner = step(
+        Ordinal::Dependent("1"),
+        Operation::Sequence(vec![], language::Span::default()),
+    );
+    let body = Operation::Sequence(
+        vec![Operation::Section {
+            numeral: "I",
+            title: Some(Box::new(title)),
+            body: Box::new(Operation::Sequence(vec![inner], language::Span::default())),
+            responses: Vec::new(),
+            span: language::Span::default(),
+        }],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
     let prompt = Mock::with_answers([UserInput::Done(Value::Unitus)]);
     let mut runner = Runner::new(
@@ -558,10 +612,19 @@ fn section_walking() {
 #[test]
 fn parallel_step_index_starts_at_one() {
     let mut fixture = StoreFixture::new("parallel-index");
-    let body = Operation::Sequence(vec![
-        step(Ordinal::Parallel, Operation::Sequence(vec![])),
-        step(Ordinal::Parallel, Operation::Sequence(vec![])),
-    ]);
+    let body = Operation::Sequence(
+        vec![
+            step(
+                Ordinal::Parallel,
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+            step(
+                Ordinal::Parallel,
+                Operation::Sequence(vec![], language::Span::default()),
+            ),
+        ],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
 
     let prompt = Mock::with_answers([
@@ -1456,9 +1519,13 @@ fn loop_inside_step_produces_one_result() {
     // enclosing Step records exactly one Result.
     let loop_op = Operation::Loop {
         names: &[],
-        over: Some(Box::new(Operation::Variable(Identifier::new("empty")))),
-        body: Box::new(Operation::Sequence(vec![])),
+        over: Some(Box::new(Operation::Variable(
+            Identifier::new("empty"),
+            language::Span::default(),
+        ))),
+        body: Box::new(Operation::Sequence(vec![], language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let the_step = Operation::Step {
         ordinal: Ordinal::Dependent("1"),
@@ -1466,8 +1533,9 @@ fn loop_inside_step_produces_one_result() {
         source: scope_for(Ordinal::Dependent("1")),
         body: Box::new(loop_op),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
-    let body = Operation::Sequence(vec![the_step]);
+    let body = Operation::Sequence(vec![the_step], language::Span::default());
     let program = anonymous_with_body(body);
 
     let mut env = Environment::new();
@@ -1513,14 +1581,16 @@ fn repeat_loops_until_quit() {
         ordinal: Ordinal::Dependent("1"),
         attributes: Vec::new(),
         source: scope_for(Ordinal::Dependent("1")),
-        body: Box::new(Operation::Sequence(Vec::new())),
+        body: Box::new(Operation::Sequence(Vec::new(), language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let loop_op = Operation::Loop {
         names: &[],
         over: None,
-        body: Box::new(Operation::Sequence(vec![inner])),
+        body: Box::new(Operation::Sequence(vec![inner], language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let program = anonymous_with_body(loop_op);
 
@@ -1569,16 +1639,24 @@ fn foreach_walks_body_once_per_list_element() {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
-        body: Box::new(Operation::Sequence(Vec::new())),
+        body: Box::new(Operation::Sequence(Vec::new(), language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     // `names` borrows from the IR, so the array must outlive the program.
     let names = [Identifier::new("item")];
     let loop_op = Operation::Loop {
         names: &names,
-        over: Some(Box::new(Operation::Variable(Identifier::new("items")))),
-        body: Box::new(Operation::Sequence(vec![substep])),
+        over: Some(Box::new(Operation::Variable(
+            Identifier::new("items"),
+            language::Span::default(),
+        ))),
+        body: Box::new(Operation::Sequence(
+            vec![substep],
+            language::Span::default(),
+        )),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let mut sub = Subroutine::anonymous();
     sub.body = loop_op;
@@ -1667,22 +1745,30 @@ fn foreach_over_seq_builtin_runs() {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
-        body: Box::new(Operation::Sequence(Vec::new())),
+        body: Box::new(Operation::Sequence(Vec::new(), language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let names = [Identifier::new("n")];
-    let over = Operation::Execute(Executable {
-        target: ExecutableRef::Resolved(seq),
-        arguments: vec![
-            Operation::Number(LangNumeric::Integral(1)),
-            Operation::Number(LangNumeric::Integral(3)),
-        ],
-    });
+    let over = Operation::Execute(
+        Executable {
+            target: ExecutableRef::Resolved(seq),
+            arguments: vec![
+                Operation::Number(LangNumeric::Integral(1), language::Span::default()),
+                Operation::Number(LangNumeric::Integral(3), language::Span::default()),
+            ],
+        },
+        language::Span::default(),
+    );
     let loop_op = Operation::Loop {
         names: &names,
         over: Some(Box::new(over)),
-        body: Box::new(Operation::Sequence(vec![substep])),
+        body: Box::new(Operation::Sequence(
+            vec![substep],
+            language::Span::default(),
+        )),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let mut sub = Subroutine::anonymous();
     sub.body = loop_op;
@@ -1753,16 +1839,24 @@ fn foreach_destructures_tuple_elements() {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
-        body: Box::new(Operation::Sequence(Vec::new())),
+        body: Box::new(Operation::Sequence(Vec::new(), language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     // `names` borrows from the IR, so the array must outlive the program.
     let names = [Identifier::new("first"), Identifier::new("second")];
     let loop_op = Operation::Loop {
         names: &names,
-        over: Some(Box::new(Operation::Variable(Identifier::new("pairs")))),
-        body: Box::new(Operation::Sequence(vec![substep])),
+        over: Some(Box::new(Operation::Variable(
+            Identifier::new("pairs"),
+            language::Span::default(),
+        ))),
+        body: Box::new(Operation::Sequence(
+            vec![substep],
+            language::Span::default(),
+        )),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let mut sub = Subroutine::anonymous();
     sub.body = loop_op;
@@ -1829,15 +1923,23 @@ fn foreach_widens_primitive_to_singleton() {
         ordinal: Ordinal::Dependent("a"),
         attributes: Vec::new(),
         source: scope_with(Ordinal::Dependent("a"), source_paragraphs),
-        body: Box::new(Operation::Sequence(Vec::new())),
+        body: Box::new(Operation::Sequence(Vec::new(), language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let names = [Identifier::new("item")];
     let loop_op = Operation::Loop {
         names: &names,
-        over: Some(Box::new(Operation::Variable(Identifier::new("source")))),
-        body: Box::new(Operation::Sequence(vec![substep])),
+        over: Some(Box::new(Operation::Variable(
+            Identifier::new("source"),
+            language::Span::default(),
+        ))),
+        body: Box::new(Operation::Sequence(
+            vec![substep],
+            language::Span::default(),
+        )),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let mut sub = Subroutine::anonymous();
     sub.body = loop_op;
@@ -1882,12 +1984,22 @@ fn foreach_over_unit_iterates_nothing() {
     // sequence or a pure-prose step). Unit is the absence of a value, so the
     // loop iterates over nothing: the body never runs and the run completes.
     let names = [Identifier::new("item")];
-    let substep = step(Ordinal::Dependent("a"), Operation::Sequence(Vec::new()));
+    let substep = step(
+        Ordinal::Dependent("a"),
+        Operation::Sequence(Vec::new(), language::Span::default()),
+    );
     let loop_op = Operation::Loop {
         names: &names,
-        over: Some(Box::new(Operation::Variable(Identifier::new("source")))),
-        body: Box::new(Operation::Sequence(vec![substep])),
+        over: Some(Box::new(Operation::Variable(
+            Identifier::new("source"),
+            language::Span::default(),
+        ))),
+        body: Box::new(Operation::Sequence(
+            vec![substep],
+            language::Span::default(),
+        )),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let mut sub = Subroutine::anonymous();
     sub.body = loop_op;
@@ -1934,9 +2046,13 @@ fn foreach_over_non_list_errors_unbound_is_empty() {
     let names = [Identifier::new("item")];
     let loop_op = Operation::Loop {
         names: &names,
-        over: Some(Box::new(Operation::Variable(Identifier::new("source")))),
-        body: Box::new(Operation::Sequence(Vec::new())),
+        over: Some(Box::new(Operation::Variable(
+            Identifier::new("source"),
+            language::Span::default(),
+        ))),
+        body: Box::new(Operation::Sequence(Vec::new(), language::Span::default())),
         responses: Vec::new(),
+        span: language::Span::default(),
     };
     let mut sub = Subroutine::anonymous();
     sub.body = loop_op;
@@ -2019,9 +2135,13 @@ fn foreach_over_non_list_errors_unbound_is_empty() {
 fn cost_of_non_quantity_value_errors_invalid_cost() {
     // $(...) constructs an Intratempse from its inner expression's value; a
     // bare string is not a quantity, so it cannot become a cost.
-    let cost_op = Operation::Cost(Box::new(Operation::String(vec![Fragment::Text(
-        "not a quantity",
-    )])));
+    let cost_op = Operation::Cost(
+        Box::new(Operation::String(
+            vec![Fragment::Text("not a quantity")],
+            language::Span::default(),
+        )),
+        language::Span::default(),
+    );
     let mut sub = Subroutine::anonymous();
     sub.body = cost_op;
     let mut program = Program::new();
@@ -2381,10 +2501,10 @@ test :
 fn automatic_records_done_for_computable_step_skip_for_prose() {
     fn record_of(label: &str, body: Operation<'static>) -> (Conclusion, State) {
         let mut fixture = StoreFixture::new(label);
-        let program = anonymous_with_body(Operation::Sequence(vec![step(
-            Ordinal::Dependent("1"),
-            body,
-        )]));
+        let program = anonymous_with_body(Operation::Sequence(
+            vec![step(Ordinal::Dependent("1"), body)],
+            language::Span::default(),
+        ));
         let mut runner = Runner::new(
             &program,
             fixture.take_appender(),
@@ -2413,7 +2533,10 @@ fn automatic_records_done_for_computable_step_skip_for_prose() {
     // A single-line value computes and records Done with the literal.
     let (outcome, state) = record_of(
         "automatic-records-value",
-        Operation::String(vec![Fragment::Text("probe output")]),
+        Operation::String(
+            vec![Fragment::Text("probe output")],
+            language::Span::default(),
+        ),
     );
     assert_eq!(
         outcome,
@@ -2428,7 +2551,10 @@ fn automatic_records_done_for_computable_step_skip_for_prose() {
     // escapes the newlines so the value stays on one record line.
     let (outcome, state) = record_of(
         "multiline-records-value",
-        Operation::String(vec![Fragment::Text("1: lo\n2: eth0\n3: wlan0")]),
+        Operation::String(
+            vec![Fragment::Text("1: lo\n2: eth0\n3: wlan0")],
+            language::Span::default(),
+        ),
     );
     assert_eq!(
         outcome,
@@ -2444,7 +2570,10 @@ fn automatic_records_done_for_computable_step_skip_for_prose() {
     );
 
     // A pure-prose step (empty body) has nothing to compute and records Skip.
-    let (_, state) = record_of("automatic-empty-body", Operation::Sequence(vec![]));
+    let (_, state) = record_of(
+        "automatic-empty-body",
+        Operation::Sequence(vec![], language::Span::default()),
+    );
     assert_eq!(state, State::Skip);
 }
 
@@ -2452,16 +2581,19 @@ fn automatic_records_done_for_computable_step_skip_for_prose() {
 fn sequence_value_is_last_member() {
     // A body sequence takes the last member's value, not the first or a fold.
     let mut fixture = StoreFixture::new("sequence-last-member");
-    let body = Operation::Sequence(vec![
-        step(
-            Ordinal::Dependent("1"),
-            Operation::String(vec![Fragment::Text("first")]),
-        ),
-        step(
-            Ordinal::Dependent("2"),
-            Operation::String(vec![Fragment::Text("second")]),
-        ),
-    ]);
+    let body = Operation::Sequence(
+        vec![
+            step(
+                Ordinal::Dependent("1"),
+                Operation::String(vec![Fragment::Text("first")], language::Span::default()),
+            ),
+            step(
+                Ordinal::Dependent("2"),
+                Operation::String(vec![Fragment::Text("second")], language::Span::default()),
+            ),
+        ],
+        language::Span::default(),
+    );
     let program = anonymous_with_body(body);
     let mut runner = Runner::new(
         &program,
@@ -2505,12 +2637,15 @@ fn deferred_invoke_is_prompted_and_recorded() {
             value: "https://example.com/probe",
             span: language::Span::default(),
         };
-        let invoke = Operation::Invoke(Invocable {
-            target: SubroutineRef::Deferred(external),
-            arguments: Vec::new(),
-            elided: true,
-        });
-        anonymous_with_body(Operation::Sequence(vec![invoke]))
+        let invoke = Operation::Invoke(
+            Invocable {
+                target: SubroutineRef::Deferred(external),
+                arguments: Vec::new(),
+                elided: true,
+            },
+            language::Span::default(),
+        );
+        anonymous_with_body(Operation::Sequence(vec![invoke], language::Span::default()))
     }
 
     // The user confirms the departure, then marks the external procedure

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -139,7 +139,7 @@ pub fn evaluate<'i>(
     op: &Operation<'i>,
 ) -> Result<Value, RunnerError> {
     match op {
-        Operation::Variable(id) => env
+        Operation::Variable(id, _) => env
             .lookup(id.value)
             .cloned()
             .ok_or_else(|| {
@@ -148,9 +148,9 @@ pub fn evaluate<'i>(
                         .to_string(),
                 )
             }),
-        Operation::Number(n) => Ok(Value::Quanticle(Numeric::from(n))),
-        Operation::Response(value) => Ok(Value::Enumerati(value.to_string())),
-        Operation::String(fragments) => {
+        Operation::Number(n, _) => Ok(Value::Quanticle(Numeric::from(n))),
+        Operation::Response(value, _) => Ok(Value::Enumerati(value.to_string())),
+        Operation::String(fragments, _) => {
             let mut text = String::new();
             for fragment in fragments {
                 match fragment {
@@ -165,8 +165,8 @@ pub fn evaluate<'i>(
             }
             Ok(Value::Literali(text))
         }
-        Operation::Multiline(_, lines) => Ok(Value::Literali(lines.join("\n"))),
-        Operation::Tablet(entries) => {
+        Operation::Multiline(_, lines, _) => Ok(Value::Literali(lines.join("\n"))),
+        Operation::Tablet(entries, _) => {
             let mut pairs = Vec::with_capacity(entries.len());
             for entry in entries {
                 let v = evaluate(library, context, env, &entry.value)?;
@@ -179,14 +179,14 @@ pub fn evaluate<'i>(
             }
             Ok(Value::Tabularum(pairs))
         }
-        Operation::List(items) => {
+        Operation::List(items, _) => {
             let mut values = Vec::with_capacity(items.len());
             for item in items {
                 values.push(evaluate(library, context, env, item)?);
             }
             Ok(Value::Arraeum(values))
         }
-        Operation::Tuple(items) => {
+        Operation::Tuple(items, _) => {
             let mut values = Vec::with_capacity(items.len());
             for item in items {
                 values.push(evaluate(library, context, env, item)?);
@@ -198,26 +198,26 @@ pub fn evaluate<'i>(
             bind_names(env, names, v)?;
             Ok(Value::Unitus)
         }
-        Operation::Sequence(ops) => {
+        Operation::Sequence(ops, _) => {
             let mut last = Value::Unitus;
             for child in ops {
                 last = evaluate(library, context, env, child)?;
             }
             Ok(last)
         }
-        Operation::Execute(executable) => dispatch(library, context, env, executable, None),
+        Operation::Execute(executable, _) => dispatch(library, context, env, executable, None),
         // A `?` reached outside a procedure invocation has no parameter name
         // to defer against; it stands for an as-yet-unsupplied value.
-        Operation::Hole => Ok(Value::Futurae(String::new())),
-        Operation::Unit => Ok(Value::Unitus),
-        Operation::Prose(_)
-        | Operation::Prologue(_)
+        Operation::Hole(_) => Ok(Value::Futurae(String::new())),
+        Operation::Unit(_) => Ok(Value::Unitus),
+        Operation::Prose(_, _)
+        | Operation::Prologue(_, _)
         | Operation::Section { .. }
         | Operation::Step { .. }
         | Operation::Loop { .. }
         | Operation::Within { .. }
-        | Operation::Cost(_)
-        | Operation::Invoke(_) => Ok(Value::Unitus),
+        | Operation::Cost(_, _)
+        | Operation::Invoke(_, _) => Ok(Value::Unitus),
     }
 }
 

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -115,6 +115,7 @@ fn kind(value: &Value) -> &'static str {
         Value::Literali(_) => "string",
         Value::Enumerati(_) => "response",
         Value::Quanticle(_) => "quantity",
+        Value::Intratempse(_) => "resource",
         Value::Tabularum(_) => "tablet",
         Value::Arraeum(_) => "list",
         Value::Parametriq(_) => "tuple",

--- a/src/runner/evaluator.rs
+++ b/src/runner/evaluator.rs
@@ -215,6 +215,7 @@ pub fn evaluate<'i>(
         | Operation::Step { .. }
         | Operation::Loop { .. }
         | Operation::Within { .. }
+        | Operation::Cost(_)
         | Operation::Invoke(_) => Ok(Value::Unitus),
     }
 }

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -316,8 +316,8 @@ impl<'i, D: Driver> Runner<'i, D> {
         op: &'i Operation<'i>,
     ) -> Result<Conclusion, RunnerError> {
         match op {
-            Operation::Sequence(ops) => self.walk_sequence(env, ops),
-            Operation::Prologue(ops) => {
+            Operation::Sequence(ops, _) => self.walk_sequence(env, ops),
+            Operation::Prologue(ops, _) => {
                 self.path
                     .push(PathSegment::Prologue);
                 let qualified = self
@@ -347,15 +347,15 @@ impl<'i, D: Driver> Runner<'i, D> {
             Operation::Within { bound, body, .. } => self.walk_within(env, bound, body),
             // Walk the inner expression (so a `$(<call>)` runs), then
             // construct the Cost value from its result.
-            Operation::Cost(inner) => match self.walk(env, inner)? {
+            Operation::Cost(inner, _) => match self.walk(env, inner)? {
                 Conclusion::Completed(Outcome::Done(Value::Quanticle(numeric))) => Ok(
                     Conclusion::Completed(Outcome::Done(Value::Intratempse(numeric))),
                 ),
                 Conclusion::Completed(Outcome::Done(_)) => Err(RunnerError::InvalidCost),
                 other => Ok(other),
             },
-            Operation::Invoke(invocable) => self.walk_invoke(env, invocable),
-            Operation::Execute(executable) => {
+            Operation::Invoke(invocable, _) => self.walk_invoke(env, invocable),
+            Operation::Execute(executable, _) => {
                 let function = self.executable_name(&executable.target);
                 let qualified = self
                     .path
@@ -497,18 +497,19 @@ impl<'i, D: Driver> Runner<'i, D> {
                 names,
                 value,
                 inferred,
+                ..
             } => self.walk_bind(env, names, value, inferred.as_ref()),
-            Operation::Variable(_)
-            | Operation::Number(_)
-            | Operation::Response(_)
-            | Operation::String(_)
-            | Operation::Multiline(_, _)
-            | Operation::Tablet(_)
-            | Operation::List(_)
-            | Operation::Tuple(_)
-            | Operation::Prose(_)
-            | Operation::Hole
-            | Operation::Unit => {
+            Operation::Variable(_, _)
+            | Operation::Number(_, _)
+            | Operation::Response(_, _)
+            | Operation::String(_, _)
+            | Operation::Multiline(_, _, _)
+            | Operation::Tablet(_, _)
+            | Operation::List(_, _)
+            | Operation::Tuple(_, _)
+            | Operation::Prose(_, _)
+            | Operation::Hole(_)
+            | Operation::Unit(_) => {
                 let value = super::evaluator::evaluate(&self.library, &self.context, env, op)?;
                 Ok(Conclusion::Completed(Outcome::Done(value)))
             }
@@ -565,7 +566,7 @@ impl<'i, D: Driver> Runner<'i, D> {
         let mut parts = Vec::new();
         for arg in arguments {
             let value = super::evaluator::evaluate(&self.library, &self.context, env, arg)?;
-            let part = if let Operation::Variable(id) = arg {
+            let part = if let Operation::Variable(id, _) = arg {
                 format!("{} ~ {}", value, id.value)
             } else {
                 value.to_string()
@@ -730,7 +731,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                             let bind = params
                                 .get(i)
                                 .map(|p| p.value);
-                            if let Operation::Hole = arg {
+                            if let Operation::Hole(_) = arg {
                                 let value = match recorded
                                     .as_ref()
                                     .and_then(|r| r.get(taken))
@@ -928,7 +929,7 @@ impl<'i, D: Driver> Runner<'i, D> {
         value: &'i Operation<'i>,
         inferred: Option<&'i language::Genus<'i>>,
     ) -> Result<Conclusion, RunnerError> {
-        let descriptive = if let Operation::Sequence(ops) = value {
+        let descriptive = if let Operation::Sequence(ops, _) = value {
             ops.is_empty()
         } else {
             false
@@ -1040,7 +1041,7 @@ impl<'i, D: Driver> Runner<'i, D> {
                 // iterates nothing rather than aborting the run. The name is
                 // statically in scope (resolution guarantees it); it simply has
                 // no value yet at runtime.
-                if let Operation::Variable(id) = expr {
+                if let Operation::Variable(id, _) = expr {
                     if env
                         .lookup(id.value)
                         .is_none()
@@ -1152,7 +1153,7 @@ impl<'i, D: Driver> Runner<'i, D> {
             };
             // A prose child contributes its value but no verdict, so it cannot
             // make an otherwise-skipped sequence roll up as Done.
-            if let Operation::Prose(_) = op {
+            if let Operation::Prose(_, _) = op {
                 if let Conclusion::Completed(Outcome::Done(value)) = outcome {
                     rollup.observe(value);
                 }
@@ -1793,12 +1794,12 @@ impl<'i, D: Driver> Runner<'i, D> {
         match op {
             Operation::Step { responses, .. } if !responses.is_empty() => Kind::Choice,
             Operation::Step { body, .. } => self.kind_of_step(body),
-            Operation::Sequence(ops) | Operation::Prologue(ops) => match ops.last() {
+            Operation::Sequence(ops, _) | Operation::Prologue(ops, _) => match ops.last() {
                 Some(last) => self.kind_of_step(last),
                 None => Kind::Prose,
             },
-            Operation::Execute(exec) => self.execute_kind(exec),
-            Operation::Prose(_) => Kind::Prose,
+            Operation::Execute(exec, _) => self.execute_kind(exec),
+            Operation::Prose(_, _) => Kind::Prose,
             _ => Kind::Computable,
         }
     }
@@ -1807,7 +1808,7 @@ impl<'i, D: Driver> Runner<'i, D> {
     /// pure-prose scope is `Prose`, so an unattended run skips its close.
     fn kind_of_scope(&self, op: &Operation) -> Kind {
         match op {
-            Operation::Sequence(ops) | Operation::Prologue(ops) => {
+            Operation::Sequence(ops, _) | Operation::Prologue(ops, _) => {
                 if ops
                     .iter()
                     .any(|op| self.kind_of_scope(op) == Kind::Computable)
@@ -1820,7 +1821,7 @@ impl<'i, D: Driver> Runner<'i, D> {
             Operation::Step { body, .. } | Operation::Section { body, .. } => {
                 self.kind_of_scope(body)
             }
-            Operation::Prose(_) => Kind::Prose,
+            Operation::Prose(_, _) => Kind::Prose,
             _ => Kind::Computable,
         }
     }
@@ -1949,7 +1950,7 @@ fn record_state(conclusion: &Conclusion) -> State {
 fn binding_names<'i>(op: &Operation<'i>) -> Option<&'i [language::Identifier<'i>]> {
     match op {
         Operation::Bind { names, .. } => Some(names),
-        Operation::Sequence(ops) => ops
+        Operation::Sequence(ops, _) => ops
             .iter()
             .find_map(binding_names),
         _ => None,
@@ -1964,16 +1965,16 @@ fn binding_names<'i>(op: &Operation<'i>) -> Option<&'i [language::Identifier<'i>
 fn binds_descriptively(op: &Operation) -> bool {
     match op {
         Operation::Bind { value, .. } => {
-            if let Operation::Sequence(ops) = value.as_ref() {
+            if let Operation::Sequence(ops, _) = value.as_ref() {
                 ops.is_empty()
             } else {
                 false
             }
         }
-        Operation::Sequence(ops) => {
+        Operation::Sequence(ops, _) => {
             let mut bound = false;
             for op in ops {
-                if let Operation::Prose(_) = op {
+                if let Operation::Prose(_, _) = op {
                     continue;
                 }
                 if binds_descriptively(op) {
@@ -1995,7 +1996,7 @@ fn binds_descriptively(op: &Operation) -> bool {
 fn nests_work(op: &Operation) -> bool {
     match op {
         Operation::Loop { .. } | Operation::Step { .. } => true,
-        Operation::Sequence(ops) => ops
+        Operation::Sequence(ops, _) => ops
             .iter()
             .any(nests_work),
         _ => false,

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -344,6 +344,11 @@ impl<'i, D: Driver> Runner<'i, D> {
                 names, over, body, ..
             } => self.walk_loop(env, names, over.as_deref(), body),
             Operation::Within { bound, body, .. } => self.walk_within(env, bound, body),
+            // Walk the inner expression (so a `$(<call>)` runs); its resulting
+            // value becomes the step's own value, same as any other operation
+            // — a Cost is not special at runtime, only a marker in the IR for
+            // a future static analysis over declared costs.
+            Operation::Cost(inner) => self.walk(env, inner),
             Operation::Invoke(invocable) => self.walk_invoke(env, invocable),
             Operation::Execute(executable) => {
                 let function = self.executable_name(&executable.target);

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -72,6 +72,7 @@ pub enum RunnerError {
         expected: usize,
     },
     NotIterable,
+    InvalidCost,
     InvalidArgument {
         function: &'static str,
         expected: &'static str,
@@ -344,11 +345,15 @@ impl<'i, D: Driver> Runner<'i, D> {
                 names, over, body, ..
             } => self.walk_loop(env, names, over.as_deref(), body),
             Operation::Within { bound, body, .. } => self.walk_within(env, bound, body),
-            // Walk the inner expression (so a `$(<call>)` runs); its resulting
-            // value becomes the step's own value, same as any other operation
-            // — a Cost is not special at runtime, only a marker in the IR for
-            // a future static analysis over declared costs.
-            Operation::Cost(inner) => self.walk(env, inner),
+            // Walk the inner expression (so a `$(<call>)` runs), then
+            // construct the Cost value from its result.
+            Operation::Cost(inner) => match self.walk(env, inner)? {
+                Conclusion::Completed(Outcome::Done(Value::Quanticle(numeric))) => Ok(
+                    Conclusion::Completed(Outcome::Done(Value::Intratempse(numeric))),
+                ),
+                Conclusion::Completed(Outcome::Done(_)) => Err(RunnerError::InvalidCost),
+                other => Ok(other),
+            },
             Operation::Invoke(invocable) => self.walk_invoke(env, invocable),
             Operation::Execute(executable) => {
                 let function = self.executable_name(&executable.target);

--- a/src/runner/state.rs
+++ b/src/runner/state.rs
@@ -749,6 +749,7 @@ fn parse_optional_value(rest: Option<&str>) -> Result<Option<value::Value>, Reco
 //   Literali(s)       -> "<escaped>"
 //   Enumerati(s)      -> '<value>'
 //   Quanticle(n)      -> canonical numeric text (via formatting::render_numeric)
+//   Intratempse(n)    -> $(<canonical numeric text>), mirroring source syntax
 //   Arraeum(items)    -> [item, item]       (empty: [])
 //   Tabularum(pairs)  -> ["label" = value]  (empty: [=], unambiguous vs [])
 //   Parametriq(vals)  -> (val, val)
@@ -773,6 +774,11 @@ fn write_value(out: &mut String, value: &value::Value) {
             out.push('\'');
         }
         value::Value::Quanticle(numeric) => out.push_str(&render_value_numeric(numeric)),
+        value::Value::Intratempse(numeric) => {
+            out.push_str("$(");
+            out.push_str(&render_value_numeric(numeric));
+            out.push(')');
+        }
         value::Value::Futurae(name) => {
             out.push('{');
             out.push_str(name);
@@ -934,6 +940,14 @@ pub(crate) fn deserialize_value(text: &str) -> Result<value::Value, RecordError>
                 }
                 Ok(value::Value::Arraeum(items))
             }
+        }
+        '$' => {
+            if !text.starts_with("$(") || !text.ends_with(')') {
+                return Err(RecordError::MalformedState);
+            }
+            let inner = &text[2..text.len() - 1];
+            let n = crate::parsing::parse_numeric(inner).ok_or(RecordError::MalformedState)?;
+            Ok(value::Value::Intratempse(value::Numeric::from(&n)))
         }
         _ => {
             let n = crate::parsing::parse_numeric(text).ok_or(RecordError::MalformedState)?;

--- a/src/translation/checks/translate.rs
+++ b/src/translation/checks/translate.rs
@@ -198,7 +198,7 @@ I. First section
     let program = translate(&document).expect("translate");
 
     let body = &program.subroutines[0].body;
-    let Operation::Sequence(ops) = body else {
+    let Operation::Sequence(ops, _) = body else {
         panic!("expected Sequence, got {:?}", body);
     };
     assert_eq!(ops.len(), 1);
@@ -213,7 +213,7 @@ I. First section
     };
     assert_eq!(*numeral, "I");
     assert!(title.is_some());
-    let Operation::Sequence(inner) = section_body.as_ref() else {
+    let Operation::Sequence(inner, _) = section_body.as_ref() else {
         panic!("expected inner Sequence");
     };
     assert!(inner.is_empty());
@@ -248,7 +248,7 @@ inner : () -> ()
         .collect();
     assert_eq!(names, vec![Some("outer"), Some("inner")]);
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     assert_eq!(ops.len(), 1);
@@ -258,12 +258,12 @@ inner : () -> ()
     else {
         panic!("expected Section");
     };
-    let Operation::Sequence(inner) = section_body.as_ref() else {
+    let Operation::Sequence(inner, _) = section_body.as_ref() else {
         panic!("expected inner Sequence");
     };
     // A procedures-bodied section descends into its first procedure.
     assert_eq!(inner.len(), 1);
-    let Operation::Invoke(invocable) = &inner[0] else {
+    let Operation::Invoke(invocable, _) = &inner[0] else {
         panic!("expected Invoke, got {:?}", inner[0]);
     };
     assert_eq!(invocable.target, SubroutineRef::Resolved(SubroutineId(1)));
@@ -285,7 +285,7 @@ II. Second
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     assert_eq!(ops.len(), 2);
@@ -315,7 +315,7 @@ make_coffee :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     assert_eq!(ops.len(), 2);
@@ -348,7 +348,7 @@ make_coffee :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     assert_eq!(ops.len(), 2);
@@ -381,7 +381,7 @@ make_coffee :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     assert_eq!(ops.len(), 1);
@@ -395,7 +395,7 @@ make_coffee :
     };
     assert_eq!(*outer, "1");
 
-    let Operation::Sequence(inner) = outer_body.as_ref() else {
+    let Operation::Sequence(inner, _) = outer_body.as_ref() else {
         panic!("expected inner Sequence");
     };
     let inner_ordinals: Vec<&str> = inner
@@ -424,7 +424,7 @@ fn top_level_steps_populate_anonymous_wrapper_body() {
     let program = translate(&document).expect("translate");
 
     assert_eq!(program.subroutines[0].name, None);
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     assert_eq!(ops.len(), 2);
@@ -445,7 +445,7 @@ make_coffee :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     // AttributeBlock disappears: only the Step appears at this level.
@@ -476,7 +476,7 @@ make_coffee :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { attributes, .. } = &ops[0] else {
@@ -500,7 +500,7 @@ make_coffee :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { attributes, .. } = &ops[0] else {
@@ -528,7 +528,7 @@ make_coffee :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step {
@@ -541,7 +541,7 @@ make_coffee :
     };
     assert!(outer_attrs.is_empty(), "outer step has no attributes");
 
-    let Operation::Sequence(inner) = outer_body.as_ref() else {
+    let Operation::Sequence(inner, _) = outer_body.as_ref() else {
         panic!("expected inner Sequence");
     };
     // inner[0] is the outer step's own prose; the substep follows.
@@ -575,10 +575,10 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Variable(id) = &ops[0] else {
+    let Operation::Variable(id, _) = &ops[0] else {
         panic!("expected Variable, got {:?}", ops[0]);
     };
     assert_eq!(id.value, "x");
@@ -600,10 +600,10 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Number(numeric) = &ops[0] else {
+    let Operation::Number(numeric, _) = &ops[0] else {
         panic!("expected Number, got {:?}", ops[0]);
     };
     let language::Numeric::Integral(n) = numeric else {
@@ -629,10 +629,10 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Unit = &ops[0] else {
+    let Operation::Unit(_) = &ops[0] else {
         panic!("expected Unit, got {:?}", ops[0]);
     };
 }
@@ -654,13 +654,13 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Execute(executable) = &ops[0] else {
+    let Operation::Execute(executable, _) = &ops[0] else {
         panic!("expected Execute");
     };
-    let Operation::String(fragments) = &executable.arguments[0] else {
+    let Operation::String(fragments, _) = &executable.arguments[0] else {
         panic!("expected String");
     };
     assert_eq!(fragments.len(), 1);
@@ -689,13 +689,13 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Execute(executable) = &ops[0] else {
+    let Operation::Execute(executable, _) = &ops[0] else {
         panic!("expected Execute");
     };
-    let Operation::String(fragments) = &executable.arguments[0] else {
+    let Operation::String(fragments, _) = &executable.arguments[0] else {
         panic!("expected String");
     };
     assert_eq!(fragments.len(), 3);
@@ -706,7 +706,7 @@ run :
     let Fragment::Interpolation(inner) = &fragments[1] else {
         panic!("expected Interpolation fragment, got {:?}", fragments[1]);
     };
-    let Operation::Variable(id) = inner else {
+    let Operation::Variable(id, _) = inner else {
         panic!("expected Variable inside interpolation");
     };
     assert_eq!(id.value, "name");
@@ -732,10 +732,10 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Execute(executable) = &ops[0] else {
+    let Operation::Execute(executable, _) = &ops[0] else {
         panic!("expected Execute, got {:?}", ops[0]);
     };
     let ExecutableRef::Unresolved(target) = &executable.target else {
@@ -768,10 +768,10 @@ other : X -> Y
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Invoke(invocable) = &ops[0] else {
+    let Operation::Invoke(invocable, _) = &ops[0] else {
         panic!("expected Invoke, got {:?}", ops[0]);
     };
     assert_eq!(
@@ -802,13 +802,13 @@ other : X -> Y
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Invoke(invocable) = &ops[0] else {
+    let Operation::Invoke(invocable, _) = &ops[0] else {
         panic!("expected Invoke, got {:?}", ops[0]);
     };
-    let [Operation::Hole] = invocable
+    let [Operation::Hole(_)] = invocable
         .arguments
         .as_slice()
     else {
@@ -839,10 +839,10 @@ other : X -> Y
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Invoke(invocable) = &ops[0] else {
+    let Operation::Invoke(invocable, _) = &ops[0] else {
         panic!("expected Invoke, got {:?}", ops[0]);
     };
     assert!(invocable.elided, "a bare call is elided");
@@ -869,7 +869,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Bind { names, value, .. } = &ops[0] else {
@@ -877,7 +877,7 @@ run :
     };
     assert_eq!(names.len(), 1);
     assert_eq!(names[0].value, "answer");
-    let Operation::Number(_) = value.as_ref() else {
+    let Operation::Number(_, _) = value.as_ref() else {
         panic!("expected Number value");
     };
 }
@@ -901,10 +901,10 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Tablet(entries) = &ops[0] else {
+    let Operation::Tablet(entries, _) = &ops[0] else {
         panic!("expected Tablet, got {:?}", ops[0]);
     };
     assert_eq!(entries.len(), 2);
@@ -928,15 +928,15 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::List(items) = &ops[0] else {
+    let Operation::List(items, _) = &ops[0] else {
         panic!("expected List, got {:?}", ops[0]);
     };
     assert_eq!(items.len(), 3);
     for item in items {
-        let Operation::Number(_) = item else {
+        let Operation::Number(_, _) = item else {
             panic!("expected Number element, got {:?}", item);
         };
     }
@@ -959,7 +959,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Loop {
@@ -972,7 +972,7 @@ run :
     assert_eq!(names[0].value, "node");
     assert!(over.is_some(), "foreach has a source");
 
-    let Operation::Sequence(inner) = body.as_ref() else {
+    let Operation::Sequence(inner, _) = body.as_ref() else {
         panic!("expected inner Sequence");
     };
     assert_eq!(inner.len(), 2);
@@ -996,14 +996,14 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Loop { names, body, .. } = &ops[0] else {
         panic!("expected Loop, got {:?}", ops[0]);
     };
     assert_eq!(names[0].value, "node");
-    let Operation::Sequence(inner) = body.as_ref() else {
+    let Operation::Sequence(inner, _) = body.as_ref() else {
         panic!("expected inner Sequence");
     };
     assert_eq!(inner.len(), 2);
@@ -1025,7 +1025,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Loop { names, .. } = &ops[0] else {
@@ -1053,13 +1053,13 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body, .. } = &ops[0] else {
         panic!("expected Step");
     };
-    let Operation::Sequence(body_ops) = body.as_ref() else {
+    let Operation::Sequence(body_ops, _) = body.as_ref() else {
         panic!("expected Sequence");
     };
     assert_eq!(body_ops.len(), 1);
@@ -1068,7 +1068,7 @@ run :
     };
     assert_eq!(names.len(), 1);
     assert_eq!(names[0].value, "situation");
-    let Operation::Sequence(inner) = value.as_ref() else {
+    let Operation::Sequence(inner, _) = value.as_ref() else {
         panic!("expected empty Sequence as binding value");
     };
     assert!(inner.is_empty());
@@ -1091,13 +1091,13 @@ helper : () -> Result
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body, .. } = &ops[0] else {
         panic!("expected Step");
     };
-    let Operation::Sequence(body_ops) = body.as_ref() else {
+    let Operation::Sequence(body_ops, _) = body.as_ref() else {
         panic!("expected Sequence");
     };
     assert_eq!(body_ops.len(), 2);
@@ -1105,7 +1105,7 @@ helper : () -> Result
         panic!("expected Bind");
     };
     assert_eq!(names[0].value, "outcome");
-    let Operation::Invoke(_) = value.as_ref() else {
+    let Operation::Invoke(_, _) = value.as_ref() else {
         panic!("expected Invoke as binding value");
     };
 }
@@ -1128,18 +1128,18 @@ helper : () -> Result
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body, .. } = &ops[0] else {
         panic!("expected Step");
     };
-    let Operation::Sequence(body_ops) = body.as_ref() else {
+    let Operation::Sequence(body_ops, _) = body.as_ref() else {
         panic!("expected Sequence");
     };
     // [Prose("Do"), Invoke, Prose("first.")] — the invoke sits between prose.
     assert_eq!(body_ops.len(), 3);
-    let Operation::Invoke(_) = &body_ops[1] else {
+    let Operation::Invoke(_, _) = &body_ops[1] else {
         panic!("expected Invoke, got {:?}", body_ops[1]);
     };
 }
@@ -1160,17 +1160,17 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body, .. } = &ops[0] else {
         panic!("expected Step");
     };
-    let Operation::Sequence(body_ops) = body.as_ref() else {
+    let Operation::Sequence(body_ops, _) = body.as_ref() else {
         panic!("expected Sequence");
     };
     assert_eq!(body_ops.len(), 1);
-    let Operation::Prose(text) = &body_ops[0] else {
+    let Operation::Prose(text, _) = &body_ops[0] else {
         panic!("expected Prose, got {:?}", body_ops[0]);
     };
     assert_eq!(*text, "Just a plain step with no executable bits.");
@@ -1192,17 +1192,17 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body, .. } = &ops[0] else {
         panic!("expected Step");
     };
-    let Operation::Sequence(body_ops) = body.as_ref() else {
+    let Operation::Sequence(body_ops, _) = body.as_ref() else {
         panic!("expected Sequence");
     };
     assert_eq!(body_ops.len(), 2);
-    let Operation::Execute(_) = &body_ops[1] else {
+    let Operation::Execute(_, _) = &body_ops[1] else {
         panic!("expected Execute, got {:?}", body_ops[1]);
     };
 }
@@ -1224,17 +1224,17 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body, .. } = &ops[0] else {
         panic!("expected Step");
     };
-    let Operation::Sequence(body_ops) = body.as_ref() else {
+    let Operation::Sequence(body_ops, _) = body.as_ref() else {
         panic!("expected Sequence");
     };
     assert_eq!(body_ops.len(), 2);
-    let Operation::Variable(id) = &body_ops[1] else {
+    let Operation::Variable(id, _) = &body_ops[1] else {
         panic!("expected Variable, got {:?}", body_ops[1]);
     };
     assert_eq!(id.value, "x");
@@ -1260,18 +1260,18 @@ init : () -> ()
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     // Prologue from the description, then the explicit Step.
     assert_eq!(ops.len(), 2);
-    let Operation::Prologue(prologue) = &ops[0] else {
+    let Operation::Prologue(prologue, _) = &ops[0] else {
         panic!("expected Prologue, got {:?}", ops[0]);
     };
     let invokes = prologue
         .iter()
         .filter(|op| {
-            if let Operation::Invoke(_) = op {
+            if let Operation::Invoke(_, _) = op {
                 true
             } else {
                 false
@@ -1299,7 +1299,7 @@ check :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { responses, .. } = &ops[0] else {
@@ -1324,7 +1324,7 @@ check :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { responses, .. } = &ops[0] else {
@@ -1352,7 +1352,7 @@ check :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { responses, .. } = &ops[0] else {
@@ -1381,7 +1381,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step {
@@ -1397,7 +1397,7 @@ run :
         "responses do not lift onto the enclosing Step"
     );
 
-    let Operation::Sequence(step_body) = body.as_ref() else {
+    let Operation::Sequence(step_body, _) = body.as_ref() else {
         panic!("expected Sequence");
     };
     let Operation::Loop {
@@ -1432,13 +1432,13 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
-    let Operation::Execute(executable) = &ops[0] else {
+    let Operation::Execute(executable, _) = &ops[0] else {
         panic!("expected Execute");
     };
-    let Operation::Multiline(lang, lines) = &executable.arguments[0] else {
+    let Operation::Multiline(lang, lines, _) = &executable.arguments[0] else {
         panic!("expected Multiline, got {:?}", executable.arguments[0]);
     };
     assert_eq!(*lang, Some("bash"));
@@ -1465,7 +1465,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Loop {
@@ -1473,6 +1473,7 @@ run :
         over,
         body,
         responses,
+        ..
     } = &ops[0]
     else {
         panic!("expected Loop, got {:?}", ops[0]);
@@ -1480,10 +1481,10 @@ run :
     assert!(names.is_empty());
     assert!(over.is_none(), "repeat has no `over` source");
     assert!(responses.is_empty());
-    let Operation::Sequence(inner) = body.as_ref() else {
+    let Operation::Sequence(inner, _) = body.as_ref() else {
         panic!("expected Sequence body");
     };
-    let [Operation::Number(_)] = inner.as_slice() else {
+    let [Operation::Number(_, _)] = inner.as_slice() else {
         panic!(
             "expected the repeated expression in the body, got {:?}",
             inner
@@ -1511,7 +1512,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Loop {
@@ -1525,11 +1526,11 @@ run :
     let Some(over) = over else {
         panic!("foreach has an `over` source");
     };
-    let Operation::Variable(id) = over.as_ref() else {
+    let Operation::Variable(id, _) = over.as_ref() else {
         panic!("expected Variable as `over`");
     };
     assert_eq!(id.value, "xs");
-    let Operation::Sequence(inner) = body.as_ref() else {
+    let Operation::Sequence(inner, _) = body.as_ref() else {
         panic!("expected empty Sequence body");
     };
     assert!(inner.is_empty());
@@ -1558,13 +1559,13 @@ delete_rds_instance :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body, .. } = &ops[0] else {
         panic!("expected Step");
     };
-    let Operation::Sequence(step_body) = body.as_ref() else {
+    let Operation::Sequence(step_body, _) = body.as_ref() else {
         panic!("expected Step body Sequence");
     };
     // A plain code block is inline: its expressions hoist directly into the
@@ -1572,7 +1573,7 @@ delete_rds_instance :
     let names: Vec<&str> = step_body
         .iter()
         .filter_map(|op| match op {
-            Operation::Execute(executable) => {
+            Operation::Execute(executable, _) => {
                 let ExecutableRef::Unresolved(target) = &executable.target else {
                     panic!("expected Unresolved, got {:?}", executable.target);
                 };
@@ -1606,19 +1607,19 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { body: outer, .. } = &ops[0] else {
         panic!("expected outer Step");
     };
-    let Operation::Sequence(outer_ops) = outer.as_ref() else {
+    let Operation::Sequence(outer_ops, _) = outer.as_ref() else {
         panic!("expected Sequence");
     };
     let Operation::Step { body: substep, .. } = &outer_ops[1] else {
         panic!("expected substep");
     };
-    let Operation::Sequence(sub_ops) = substep.as_ref() else {
+    let Operation::Sequence(sub_ops, _) = substep.as_ref() else {
         panic!("expected Sequence");
     };
     let ordinals: Vec<&str> = sub_ops
@@ -1650,7 +1651,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { responses, .. } = &ops[0] else {
@@ -1687,7 +1688,7 @@ run :
     let document = parsing::parse(path, source).expect("parse");
     let program = translate(&document).expect("translate");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Step { responses, .. } = &ops[0] else {
@@ -1762,13 +1763,13 @@ init : () -> ()
         })
         .expect("init declared");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Section { body, .. } = &ops[0] else {
         panic!("expected Section");
     };
-    let Operation::Sequence(section_body) = body.as_ref() else {
+    let Operation::Sequence(section_body, _) = body.as_ref() else {
         panic!("expected Section body Sequence");
     };
     // The title's hoisted `<init>` Application is the section's single entry:
@@ -1779,7 +1780,7 @@ init : () -> ()
         1,
         "title's Application is the sole entry"
     );
-    let Operation::Invoke(invocable) = &section_body[0] else {
+    let Operation::Invoke(invocable, _) = &section_body[0] else {
         panic!("expected Invoke, got {:?}", section_body[0]);
     };
     let SubroutineRef::Resolved(SubroutineId(idx)) = invocable.target else {
@@ -1806,18 +1807,18 @@ init : () -> ()
     let mut program = translate(&document).expect("translate");
     resolve(&mut program).expect("resolve");
 
-    let Operation::Sequence(ops) = &program.subroutines[0].body else {
+    let Operation::Sequence(ops, _) = &program.subroutines[0].body else {
         panic!("expected Sequence");
     };
     let Operation::Section { body, .. } = &ops[0] else {
         panic!("expected Section");
     };
-    let Operation::Sequence(section_body) = body.as_ref() else {
+    let Operation::Sequence(section_body, _) = body.as_ref() else {
         panic!("expected Section body Sequence");
     };
     // The title's value-read, then the descent into `init`.
     assert_eq!(section_body.len(), 2);
-    let Operation::Invoke(invocable) = &section_body[1] else {
+    let Operation::Invoke(invocable, _) = &section_body[1] else {
         panic!("expected Invoke, got {:?}", section_body[1]);
     };
     assert_eq!(invocable.target, SubroutineRef::Resolved(SubroutineId(1)));

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -29,7 +29,7 @@ pub fn translate<'i>(document: &'i Document<'i>) -> Result<Program<'i>, Vec<Tran
             for scope in scopes {
                 translator.append_attributes(&mut ops, &mut responses, scope, &[]);
             }
-            wrapper.body = Operation::Sequence(ops);
+            wrapper.body = Operation::Sequence(ops, Span::default());
             wrapper.responses = responses;
             translator
                 .program
@@ -212,14 +212,14 @@ impl<'i> Translator<'i> {
         if prologue
             .iter()
             .any(|op| {
-                if let Operation::Prose(_) = op {
+                if let Operation::Prose(_, _) = op {
                     false
                 } else {
                     true
                 }
             })
         {
-            ops.push(Operation::Prologue(prologue));
+            ops.push(Operation::Prologue(prologue, procedure.span));
         }
         for element in &procedure.elements {
             match element {
@@ -244,7 +244,7 @@ impl<'i> Translator<'i> {
                 _ => {}
             }
         }
-        let body = Operation::Sequence(ops);
+        let body = Operation::Sequence(ops, procedure.span);
 
         let entry = &mut self
             .program
@@ -286,7 +286,7 @@ impl<'i> Translator<'i> {
                 numeral,
                 title,
                 body,
-                ..
+                span,
             } => {
                 let mut body_ops = Vec::new();
                 let mut responses = Vec::new();
@@ -307,7 +307,7 @@ impl<'i> Translator<'i> {
                             let invoked = body_ops
                                 .iter()
                                 .any(|op| {
-                                    if let Operation::Invoke(invocable) = op {
+                                    if let Operation::Invoke(invocable, _) = op {
                                         invocable.target
                                             == SubroutineRef::Unresolved(procedure.name)
                                     } else {
@@ -315,11 +315,14 @@ impl<'i> Translator<'i> {
                                     }
                                 });
                             if !invoked {
-                                body_ops.push(Operation::Invoke(Invocable {
-                                    target: SubroutineRef::Unresolved(procedure.name),
-                                    arguments: Vec::new(),
-                                    elided: true,
-                                }));
+                                body_ops.push(Operation::Invoke(
+                                    Invocable {
+                                        target: SubroutineRef::Unresolved(procedure.name),
+                                        arguments: Vec::new(),
+                                        elided: true,
+                                    },
+                                    *span,
+                                ));
                             }
                         }
                     }
@@ -331,15 +334,16 @@ impl<'i> Translator<'i> {
                 Operation::Section {
                     numeral,
                     title: title_op,
-                    body: Box::new(Operation::Sequence(body_ops)),
+                    body: Box::new(Operation::Sequence(body_ops, *span)),
                     responses,
+                    span: *span,
                 }
             }
             language::Scope::DependentBlock {
                 ordinal,
                 description,
                 subscopes,
-                ..
+                span,
             } => {
                 let mut body_ops = Vec::new();
                 let mut responses = Vec::new();
@@ -349,13 +353,15 @@ impl<'i> Translator<'i> {
                     ordinal: Ordinal::Dependent(ordinal),
                     attributes: attrs.to_vec(),
                     source: scope,
-                    body: Box::new(Operation::Sequence(body_ops)),
+                    body: Box::new(Operation::Sequence(body_ops, *span)),
                     responses,
+                    span: *span,
                 }
             }
             language::Scope::ParallelBlock {
                 description,
                 subscopes,
+                span,
                 ..
             } => {
                 let mut body_ops = Vec::new();
@@ -366,8 +372,9 @@ impl<'i> Translator<'i> {
                     ordinal: Ordinal::Parallel,
                     attributes: attrs.to_vec(),
                     source: scope,
-                    body: Box::new(Operation::Sequence(body_ops)),
+                    body: Box::new(Operation::Sequence(body_ops, *span)),
                     responses,
+                    span: *span,
                 }
             }
             // AttributeBlock and ResponseBlock are intercepted by
@@ -378,7 +385,7 @@ impl<'i> Translator<'i> {
             language::Scope::CodeBlock {
                 expressions,
                 subscopes,
-                ..
+                span,
             } => match self.translate_control_block(expressions, subscopes, attrs) {
                 Some(control_op) => control_op,
                 None => {
@@ -390,7 +397,7 @@ impl<'i> Translator<'i> {
                     for sub in subscopes {
                         self.append_attributes(&mut ops, &mut responses, sub, attrs);
                     }
-                    Operation::Sequence(ops)
+                    Operation::Sequence(ops, *span)
                 }
             },
         }
@@ -410,7 +417,7 @@ impl<'i> Translator<'i> {
             return None;
         }
         match &expressions[0] {
-            language::Expression::Foreach(names, source, _) => {
+            language::Expression::Foreach(names, source, span) => {
                 let mut body_ops = Vec::new();
                 let mut responses = Vec::new();
                 for sub in subscopes {
@@ -419,11 +426,12 @@ impl<'i> Translator<'i> {
                 Some(Operation::Loop {
                     names,
                     over: Some(Box::new(self.translate_expression(source))),
-                    body: Box::new(Operation::Sequence(body_ops)),
+                    body: Box::new(Operation::Sequence(body_ops, *span)),
                     responses,
+                    span: *span,
                 })
             }
-            language::Expression::Repeat(inner, _) => {
+            language::Expression::Repeat(inner, span) => {
                 // `repeat <thing>` does `<thing>` over and over: the inline
                 // expression is the loop body. Any subscopes follow it.
                 let mut body_ops = vec![self.translate_expression(inner)];
@@ -434,11 +442,12 @@ impl<'i> Translator<'i> {
                 Some(Operation::Loop {
                     names: &[],
                     over: None,
-                    body: Box::new(Operation::Sequence(body_ops)),
+                    body: Box::new(Operation::Sequence(body_ops, *span)),
                     responses,
+                    span: *span,
                 })
             }
-            language::Expression::Within(inner, _) => {
+            language::Expression::Within(inner, span) => {
                 // `within <budget>` governs the subscopes beneath it, the way
                 // `foreach`'s source does: the budget is a separate field,
                 // not part of the body.
@@ -449,8 +458,9 @@ impl<'i> Translator<'i> {
                 }
                 Some(Operation::Within {
                     bound: Box::new(self.translate_expression(inner)),
-                    body: Box::new(Operation::Sequence(body_ops)),
+                    body: Box::new(Operation::Sequence(body_ops, *span)),
                     responses,
+                    span: *span,
                 })
             }
             _ => None,
@@ -473,7 +483,7 @@ impl<'i> Translator<'i> {
             ..
         }) = body_ops.last_mut()
         {
-            if let Operation::Sequence(loop_body) = body.as_mut() {
+            if let Operation::Sequence(loop_body, _) = body.as_mut() {
                 if loop_body.is_empty() {
                     for sub in subscopes {
                         self.append_attributes(loop_body, loop_responses, sub, attrs);
@@ -495,12 +505,12 @@ impl<'i> Translator<'i> {
         ops: &mut Vec<Operation<'i>>,
         title: &'i language::Paragraph<'i>,
     ) {
-        let language::Paragraph(descriptives, _) = title;
+        let language::Paragraph(descriptives, span) = title;
         for descriptive in descriptives {
-            match self.executable_from_descriptive(descriptive) {
+            match self.executable_from_descriptive(descriptive, *span) {
                 // A multi-statement code block hoists its statements directly,
                 // one operation per call, rather than nesting in a Sequence.
-                Some(Operation::Sequence(inner)) => ops.extend(inner),
+                Some(Operation::Sequence(inner, _)) => ops.extend(inner),
                 Some(op) => ops.push(op),
                 None => {}
             }
@@ -516,14 +526,14 @@ impl<'i> Translator<'i> {
         paragraphs: &'i [language::Paragraph<'i>],
     ) {
         for paragraph in paragraphs {
-            let language::Paragraph(descriptives, _) = paragraph;
+            let language::Paragraph(descriptives, span) = paragraph;
             for descriptive in descriptives {
                 if let language::Descriptive::Text(text) = descriptive {
-                    ops.push(Operation::Prose(text));
+                    ops.push(Operation::Prose(text, *span));
                     continue;
                 }
-                match self.executable_from_descriptive(descriptive) {
-                    Some(Operation::Sequence(inner)) => ops.extend(inner),
+                match self.executable_from_descriptive(descriptive, *span) {
+                    Some(Operation::Sequence(inner, _)) => ops.extend(inner),
                     Some(op) => ops.push(op),
                     None => {}
                 }
@@ -539,7 +549,7 @@ impl<'i> Translator<'i> {
     // string literals translated elsewhere preserve whitespace verbatim and
     // are not affected by this rule.
     fn translate_paragraph(&mut self, paragraph: &'i language::Paragraph<'i>) -> Operation<'i> {
-        let language::Paragraph(descriptives, _) = paragraph;
+        let language::Paragraph(descriptives, span) = paragraph;
         let mut fragments = Vec::with_capacity(
             descriptives
                 .len()
@@ -553,7 +563,7 @@ impl<'i> Translator<'i> {
                 fragments.push(fragment);
             }
         }
-        Operation::String(fragments)
+        Operation::String(fragments, *span)
     }
 
     // The display fragment for a descriptive, or `None` when it renders no
@@ -593,10 +603,14 @@ impl<'i> Translator<'i> {
     /// value before the description can be rendered, just as much as an
     /// Application does); Binding captures a result. The description
     /// Paragraph stays borrowed on the enclosing Step for the renderer to
-    /// fill the CodeInline holes from these Operations' results.
+    /// fill the CodeInline holes from these Operations' results. `span` is
+    /// the enclosing Paragraph's span, used for constructs (Application,
+    /// Binding, a multi-statement CodeInline) with no finer-grained span of
+    /// their own.
     fn executable_from_descriptive(
         &mut self,
         descriptive: &'i language::Descriptive<'i>,
+        span: Span,
     ) -> Option<Operation<'i>> {
         match descriptive {
             language::Descriptive::Text(_) => None,
@@ -616,21 +630,23 @@ impl<'i> Translator<'i> {
                 match ops.len() {
                     0 => None,
                     1 => ops.pop(),
-                    _ => Some(Operation::Sequence(ops)),
+                    _ => Some(Operation::Sequence(ops, span)),
                 }
             }
-            language::Descriptive::Application(invocation) => {
-                Some(Operation::Invoke(self.translate_invocation(invocation)))
-            }
+            language::Descriptive::Application(invocation) => Some(Operation::Invoke(
+                self.translate_invocation(invocation),
+                span,
+            )),
             // Naked binding `text ~ var` or `<call> ~ var`.
             language::Descriptive::Binding(inner, names) => {
                 let value = self
-                    .executable_from_descriptive(inner)
-                    .unwrap_or_else(|| Operation::Sequence(Vec::new()));
+                    .executable_from_descriptive(inner, span)
+                    .unwrap_or_else(|| Operation::Sequence(Vec::new(), span));
                 Some(Operation::Bind {
                     names: names.as_slice(),
                     value: Box::new(value),
                     inferred: None,
+                    span,
                 })
             }
             language::Descriptive::Cost(expr) => Some(self.translate_expression(expr)),
@@ -736,9 +752,9 @@ impl<'i> Translator<'i> {
 
     fn translate_expression(&mut self, expression: &'i language::Expression<'i>) -> Operation<'i> {
         match expression {
-            language::Expression::Variable(id, _) => Operation::Variable(*id),
-            language::Expression::Number(numeric, _) => Operation::Number(*numeric),
-            language::Expression::String(pieces, _) => {
+            language::Expression::Variable(id, span) => Operation::Variable(*id, *span),
+            language::Expression::Number(numeric, span) => Operation::Number(*numeric, *span),
+            language::Expression::String(pieces, span) => {
                 let fragments = pieces
                     .iter()
                     .map(|piece| match piece {
@@ -748,20 +764,23 @@ impl<'i> Translator<'i> {
                         }
                     })
                     .collect();
-                Operation::String(fragments)
+                Operation::String(fragments, *span)
             }
-            language::Expression::Response(value, _) => Operation::Response(value),
-            language::Expression::Multiline(lang, lines, _) => {
-                Operation::Multiline(*lang, lines.clone())
+            language::Expression::Response(value, span) => Operation::Response(value, *span),
+            language::Expression::Multiline(lang, lines, span) => {
+                Operation::Multiline(*lang, lines.clone(), *span)
             }
-            language::Expression::Pair(pair, _) => {
+            language::Expression::Pair(pair, span) => {
                 // A standalone labelled value widens to a single-entry
                 // tablet, mirroring the way a bare value widens to a
                 // single-element list.
-                Operation::Tablet(vec![Entry {
-                    label: pair.label,
-                    value: self.translate_expression(&pair.value),
-                }])
+                Operation::Tablet(
+                    vec![Entry {
+                        label: pair.label,
+                        value: self.translate_expression(&pair.value),
+                    }],
+                    *span,
+                )
             }
             language::Expression::List(elements, span) => {
                 let labelled = elements
@@ -804,58 +823,64 @@ impl<'i> Translator<'i> {
                             }
                         })
                         .collect();
-                    Operation::Tablet(entries)
+                    Operation::Tablet(entries, *span)
                 } else {
                     let items = elements
                         .iter()
                         .map(|element| self.translate_expression(element))
                         .collect();
-                    Operation::List(items)
+                    Operation::List(items, *span)
                 }
             }
-            language::Expression::Tuple(elements, _) => {
+            language::Expression::Tuple(elements, span) => {
                 let items = elements
                     .iter()
                     .map(|element| self.translate_expression(element))
                     .collect();
-                Operation::Tuple(items)
+                Operation::Tuple(items, *span)
             }
-            language::Expression::Application(invocation, _) => {
-                Operation::Invoke(self.translate_invocation(invocation))
+            language::Expression::Application(invocation, span) => {
+                Operation::Invoke(self.translate_invocation(invocation), *span)
             }
-            language::Expression::Execution(function, _) => Operation::Execute(Executable {
-                target: ExecutableRef::Unresolved(function.target),
-                arguments: function
-                    .parameters
-                    .iter()
-                    .map(|expr| self.translate_expression(expr))
-                    .collect(),
-            }),
-            language::Expression::Repeat(body, _) => Operation::Loop {
+            language::Expression::Execution(function, span) => Operation::Execute(
+                Executable {
+                    target: ExecutableRef::Unresolved(function.target),
+                    arguments: function
+                        .parameters
+                        .iter()
+                        .map(|expr| self.translate_expression(expr))
+                        .collect(),
+                },
+                *span,
+            ),
+            language::Expression::Repeat(body, span) => Operation::Loop {
                 names: &[],
                 over: None,
                 body: Box::new(self.translate_expression(body)),
                 responses: Vec::new(),
+                span: *span,
             },
             // Standalone Foreach has no body in the AST; the body is supplied
             // by the enclosing CodeBlock's subscopes when one is present (see
             // CodeBlock translation). As a bare expression we emit a Loop
             // with an empty Sequence body.
-            language::Expression::Foreach(names, source, _) => Operation::Loop {
+            language::Expression::Foreach(names, source, span) => Operation::Loop {
                 names,
                 over: Some(Box::new(self.translate_expression(source))),
-                body: Box::new(Operation::Sequence(Vec::new())),
+                body: Box::new(Operation::Sequence(Vec::new(), *span)),
                 responses: Vec::new(),
+                span: *span,
             },
             // Standalone Within, likewise: the body is supplied by the
             // enclosing CodeBlock's subscopes when one is present.
-            language::Expression::Within(bound, _) => Operation::Within {
+            language::Expression::Within(bound, span) => Operation::Within {
                 bound: Box::new(self.translate_expression(bound)),
-                body: Box::new(Operation::Sequence(Vec::new())),
+                body: Box::new(Operation::Sequence(Vec::new(), *span)),
                 responses: Vec::new(),
+                span: *span,
             },
-            language::Expression::Cost(inner, _) => {
-                Operation::Cost(Box::new(self.translate_expression(inner)))
+            language::Expression::Cost(inner, span) => {
+                Operation::Cost(Box::new(self.translate_expression(inner)), *span)
             }
             language::Expression::Binding(value, names, span) => {
                 if let language::Expression::Repeat(_, _) = value.as_ref() {
@@ -866,11 +891,12 @@ impl<'i> Translator<'i> {
                     names,
                     value: Box::new(self.translate_expression(value)),
                     inferred: None,
+                    span: *span,
                 }
             }
-            language::Expression::Hole(_) => Operation::Hole,
-            language::Expression::Unit(_) => Operation::Unit,
-            language::Expression::Separator => Operation::Sequence(Vec::new()),
+            language::Expression::Hole(span) => Operation::Hole(*span),
+            language::Expression::Unit(span) => Operation::Unit(*span),
+            language::Expression::Separator => Operation::Sequence(Vec::new(), Span::default()),
         }
     }
 

--- a/src/translation/translator.rs
+++ b/src/translation/translator.rs
@@ -583,6 +583,7 @@ impl<'i> Translator<'i> {
             },
             language::Descriptive::Application(_) => None,
             language::Descriptive::Binding(inner, _) => self.fragment_from_descriptive(inner),
+            language::Descriptive::Cost(_) => None,
         }
     }
 
@@ -632,6 +633,7 @@ impl<'i> Translator<'i> {
                     inferred: None,
                 })
             }
+            language::Descriptive::Cost(expr) => Some(self.translate_expression(expr)),
         }
     }
 
@@ -852,6 +854,9 @@ impl<'i> Translator<'i> {
                 body: Box::new(Operation::Sequence(Vec::new())),
                 responses: Vec::new(),
             },
+            language::Expression::Cost(inner, _) => {
+                Operation::Cost(Box::new(self.translate_expression(inner)))
+            }
             language::Expression::Binding(value, names, span) => {
                 if let language::Expression::Repeat(_, _) = value.as_ref() {
                     self.problems

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -21,6 +21,7 @@ pub enum Value {
     Literali(String),
     Enumerati(String),
     Quanticle(Numeric),
+    Intratempse(Numeric),
     Tabularum(Vec<(String, Value)>),
     Arraeum(Vec<Value>),
     Parametriq(Vec<Value>),
@@ -78,6 +79,7 @@ impl Display for Value {
             Value::Literali(text) => write!(f, "\"{}\"", text),
             Value::Enumerati(text) => write!(f, "'{}'", text),
             Value::Quanticle(numeric) => write!(f, "{}", numeric),
+            Value::Intratempse(numeric) => write!(f, "$({})", numeric),
             Value::Tabularum(pairs) => {
                 f.write_str("[")?;
                 for (i, (label, value)) in pairs

--- a/tests/broken/constraints/TimeBudgetExceeded.tq
+++ b/tests/broken/constraints/TimeBudgetExceeded.tq
@@ -1,4 +1,4 @@
-roast_turkey(i) : Ingredients -> Turkey
+roast_turkey :
 
 # Roast Turkey
 
@@ -6,4 +6,4 @@ roast_turkey(i) : Ingredients -> Turkey
         { within 30 minutes }
             1.  Set oven temperature $(10 minutes)
             2.  Place bacon strips onto bird
-            3.  Put bird into oven
+            3.  Put bird into oven $(2 hours)

--- a/tests/broken/resolution/InvalidCostLiteral.tq
+++ b/tests/broken/resolution/InvalidCostLiteral.tq
@@ -1,0 +1,1 @@
+1.  Do a thing $("not a quantity")


### PR DESCRIPTION
Introduce cost literals to the Technique language, taking the form 

```technique
    3.  Roast turkey $(2 hours)
```

allowing the author to express how long a step is expected to take, its price, or an amount of a resource that will be consumed by it.
