### PR TITLE
Embed commit in version string when developing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
         steps:
             - name: Clone project
               uses: actions/checkout@v6
+              with:
+                  fetch-tags: true
 
             - name: Validate toolchain
               shell: bash

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+
+/// Run git, returning its trimmed output, or None if it couldn't tell us.
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .ok()?;
+
+    if !output
+        .status
+        .success()
+    {
+        return None;
+    }
+
+    let text = String::from_utf8(output.stdout).ok()?;
+
+    Some(
+        text.trim()
+            .to_owned(),
+    )
+}
+
+fn main() {
+    // rerun on source changes so the dirty marker stays honest, and when git
+    // moves, the reflog (on commit and checkout) and the index (on staging)
+    println!("cargo::rerun-if-changed=src");
+    println!("cargo::rerun-if-changed=Cargo.toml");
+    println!("cargo::rerun-if-changed=.git/logs/HEAD");
+    println!("cargo::rerun-if-changed=.git/index");
+
+    const VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
+
+    // a release is the tag naming this version with nothing modified on top
+    let released = git(&["describe", "--tags", "--exact-match", "HEAD"])
+        .is_some_and(|tag| tag == VERSION)
+        && git(&["diff", "--quiet", "HEAD"]).is_some();
+
+    let suffix = match released {
+        true => None,
+        false => git(&[
+            "describe",
+            "--always",
+            "--abbrev=7",
+            "--dirty=.dev",
+            "--exclude=*",
+        ]),
+    };
+
+    match suffix {
+        Some(commit) => println!("cargo::rustc-env=TECHNIQUE_VERSION={}+{}", VERSION, commit),
+        None => println!("cargo::rustc-env=TECHNIQUE_VERSION={}", VERSION),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ fn select_libraries(matches: &clap::ArgMatches) -> Vec<Builtin> {
 }
 
 fn main() {
-    const VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
+    const VERSION: &str = env!("TECHNIQUE_VERSION");
 
     // Initialize the tracing subscriber. This respects the RUST_LOG
     // environment variable if present, or sets Level::ERROR as a fallback.


### PR DESCRIPTION
For non-release builds, embed the commit (and, if present, dirty status) in the version string. This allows a developer to know whether they are running a release, a build from a fully committed tree or, a local work-in-progress.

The result is that a release build will show a version of `v0.6.5` being the tag name. A build from a Git checkout with work done since the tag will be the Cargo package version and Git commit hash `v0.6.6+24824ba`, and a build from a checkout with locally uncommitted files will show as `v0.6.6+24824ba.dev`.

