### PR TITLE
Refine procedure declaration checks 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "technique"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "technique"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "A domain specific language for procedures."
 authors = [ "Andrew Cowie" ]

--- a/examples/prototype/SurgicalSafetyChecklist.tq
+++ b/examples/prototype/SurgicalSafetyChecklist.tq
@@ -18,7 +18,7 @@ II. Before skin incision <before_incision>
 
 III. Before the patient leaves the operating room <before_leaving>
 
-before_anesthesia :
+before_anaesthesia :
 
 # Before induction of anaesthesia
 

--- a/src/parsing/checks/errors.rs
+++ b/src/parsing/checks/errors.rs
@@ -122,6 +122,25 @@ making_coffee Ingredients -> Coffee
     );
 }
 
+// A malformed declaration must end the procedure before it, rather than
+// being taken as description and swallowing the procedure that follows
+#[test]
+fn invalid_identifier_in_following_declaration() {
+    expect_error(
+        r#"
+making_coffee :
+
+    1.  Boil the water
+
+Prepare Gin :
+
+    1.  Pour it out
+            "#
+        .trim_ascii(),
+        ParsingError::InvalidIdentifier(Span::new(41, 7), "Prepare".to_string()),
+    );
+}
+
 #[test]
 fn invalid_identifier_in_parameters() {
     expect_error(
@@ -129,7 +148,7 @@ fn invalid_identifier_in_parameters() {
 making_coffee(BadParam) : Ingredients -> Coffee
             "#
         .trim_ascii(),
-        ParsingError::InvalidIdentifier(Span::new(0, 8), "BadParam".to_string()),
+        ParsingError::InvalidIdentifier(Span::new(14, 8), "BadParam".to_string()),
     );
 }
 

--- a/src/parsing/checks/errors.rs
+++ b/src/parsing/checks/errors.rs
@@ -122,6 +122,24 @@ making_coffee Ingredients -> Coffee
     );
 }
 
+// A multi-line string left open masks the rest of the input, so the closing
+// brace of the code block goes missing. Name the cause, not the symptom
+#[test]
+fn unterminated_multiline_in_code_block() {
+    expect_error(
+        r#"
+alpha :
+
+    1.  Do it { exec(
+        ```bash
+            ./stuff
+        ) }
+            "#
+        .trim_ascii(),
+        ParsingError::InvalidMultiline(Span::new(39, 0)),
+    );
+}
+
 // A paragraph of nothing but a name and a colon is a declaration whose colon
 // was not set apart from the name, not prose
 #[test]

--- a/src/parsing/checks/errors.rs
+++ b/src/parsing/checks/errors.rs
@@ -122,6 +122,47 @@ making_coffee Ingredients -> Coffee
     );
 }
 
+// A paragraph of nothing but a name and a colon is a declaration whose colon
+// was not set apart from the name, not prose
+#[test]
+fn declaration_without_space_before_colon() {
+    expect_error(
+        r#"
+making_coffee :
+
+    1.  Boil the water
+
+beta:
+
+    2.  Pour it out
+            "#
+        .trim_ascii(),
+        ParsingError::InvalidDeclaration(Span::new(41, 5)),
+    );
+}
+
+// ... whereas the last line of a wrapped sentence is prose, and the blank
+// line that would have set it apart as its own paragraph is absent
+#[test]
+fn colon_ending_wrapped_prose_is_not_a_declaration() {
+    let source = r#"
+making_coffee :
+
+The one you want is
+this one:
+
+    1.  Boil the water
+            "#
+    .trim_ascii();
+
+    let result = parse_with_recovery(Path::new("Test.tq"), source);
+    assert!(
+        result.is_ok(),
+        "Prose ending in a colon should parse, got: {:?}",
+        result.err()
+    );
+}
+
 // Content a section cannot hold is reported, not quietly dropped on the
 // floor as it makes its way past
 #[test]

--- a/src/parsing/checks/errors.rs
+++ b/src/parsing/checks/errors.rs
@@ -122,6 +122,27 @@ making_coffee Ingredients -> Coffee
     );
 }
 
+// Content a section cannot hold is reported, not quietly dropped on the
+// floor as it makes its way past
+#[test]
+fn unrecognized_content_in_section() {
+    expect_error(
+        r#"
+making_coffee :
+
+    1.  Boil the water
+
+I. Second Section
+
+    # Overview notes
+
+    1.  Pour it out
+            "#
+        .trim_ascii(),
+        ParsingError::Unrecognized(Span::new(64, 0)),
+    );
+}
+
 // A malformed declaration must end the procedure before it, rather than
 // being taken as description and swallowing the procedure that follows
 #[test]

--- a/src/parsing/checks/errors.rs
+++ b/src/parsing/checks/errors.rs
@@ -141,6 +141,24 @@ beta:
     );
 }
 
+// A signature after the colon settles it; no sentence is written that way
+#[test]
+fn declaration_without_space_but_with_signature() {
+    expect_error(
+        r#"
+making_coffee :
+
+    1.  Boil the water
+
+beta: Ingredients -> Coffee
+
+    2.  Pour it out
+            "#
+        .trim_ascii(),
+        ParsingError::InvalidDeclaration(Span::new(41, 27)),
+    );
+}
+
 // ... whereas the last line of a wrapped sentence is prose, and the blank
 // line that would have set it apart as its own paragraph is absent
 #[test]

--- a/src/parsing/checks/parser.rs
+++ b/src/parsing/checks/parser.rs
@@ -3183,6 +3183,71 @@ broken_proc2 : -> B
     };
 }
 
+// A procedure whose declaration is mistyped must be reported where it was
+// written. Both of these parsed as steps or were absorbed by the procedure
+// above, so the complaint used to arrive further down the file, pointing at
+// whatever construct finally broke.
+
+#[test]
+fn test_section_declaration_first() {
+    use std::path::Path;
+
+    let content = r#"
+mix_drink :
+
+I. Prepare the ingredients <prepare_gin>
+
+II. Serve it up <serve_drink>
+
+prepare gin :
+
+    1.  Remove cubes from the freezer
+
+serve_drink :
+
+    1.  Pour it out
+        "#;
+
+    let errors = parse_with_recovery(Path::new("Test.tq"), content)
+        .expect_err("mistyped declaration should be an error");
+
+    let expected = content
+        .find("prepare gin :")
+        .unwrap()
+        + "prepare ".len();
+
+    assert_eq!(errors[0].offset(), expected);
+}
+
+#[test]
+fn test_section_declaration_following() {
+    use std::path::Path;
+
+    let content = r#"
+mix_drink :
+
+I. Prepare the ingredients <prepare_gin>
+
+prepare_gin :
+
+    1.  Remove cubes from the freezer
+
+serve drink :
+
+    1.  Pour it out
+        "#;
+
+    let errors = parse_with_recovery(Path::new("Test.tq"), content)
+        .expect_err("mistyped declaration should be an error");
+
+    let expected = content
+        .find("serve drink :")
+        .unwrap()
+        + "serve ".len();
+
+    assert_eq!(errors[0].offset(), expected);
+}
+
 #[test]
 fn test_redundant_error_removal_needed() {
     use std::path::Path;

--- a/src/parsing/checks/parser.rs
+++ b/src/parsing/checks/parser.rs
@@ -476,7 +476,8 @@ fn declaration_full() {
 
     let content = r#"
     connectivity_check(e,s) : LocalEnvironment, TargetService -> NetworkHealth
-                "#;
+                "#
+    .trim_ascii();
 
     assert!(is_procedure_declaration(content));
 }
@@ -495,7 +496,8 @@ fn multiline_declaration() {
 
         1. Add the beans to the machine
         2. Pour in the milk
-                "#;
+                "#
+    .trim_ascii();
 
     assert!(is_procedure_declaration(content));
 }

--- a/src/parsing/checks/parser.rs
+++ b/src/parsing/checks/parser.rs
@@ -3328,6 +3328,40 @@ fn test_redundant_error_removal_unclosed_interpolation() {
     }
 }
 
+// A quote in descriptive text is punctuation the author wrote, here an inch
+// mark. It opens no literal, so it must not hide the code inline after it
+#[test]
+fn quote_in_descriptive_text() {
+    let mut input = Parser::new();
+
+    let source = r#"Measure the 6" pipe { record_it() } carefully."#;
+
+    input.initialize(source);
+    let result = input.read_descriptive();
+
+    let paragraphs = result.unwrap();
+    let descriptives = &paragraphs[0].0;
+
+    match &descriptives[0] {
+        Descriptive::Text(text) => assert_eq!(*text, "Measure the 6\" pipe"),
+        _ => panic!("First element should be text"),
+    }
+
+    match &descriptives[1] {
+        Descriptive::CodeInline(exprs) => {
+            let [Expression::Execution(func, _)] = exprs.as_slice() else {
+                panic!("Second element should be code inline with function execution");
+            };
+            assert_eq!(
+                func.target
+                    .value,
+                "record_it"
+            );
+        }
+        _ => panic!("Second element should be code inline"),
+    }
+}
+
 #[test]
 fn multiline_code_inline() {
     let mut input = Parser::new();

--- a/src/parsing/checks/parser.rs
+++ b/src/parsing/checks/parser.rs
@@ -1274,9 +1274,25 @@ fn test_potential_procedure_declaration_is_superset() {
     assert!(!is_procedure_declaration("123foo :")); // Starts with digit
     assert!(potential_procedure_declaration("123foo :"));
 
-    // Neither should match sentences with spaces
-    assert!(!is_procedure_declaration("Ask these questions :"));
-    assert!(!potential_procedure_declaration("Ask these questions :"));
+    assert!(!is_procedure_declaration("Prepare Gin :")); // Capital letter, and spaces
+    assert!(potential_procedure_declaration("Prepare Gin :"));
+
+    // Prose sets its colon against the preceding word, so neither matches
+    assert!(!is_procedure_declaration(
+        "Ask these questions: are you sure?"
+    ));
+    assert!(!potential_procedure_declaration(
+        "Ask these questions: are you sure?"
+    ));
+
+    // A line opening a title, section, attribute, or code block is none
+    // either, whatever colons it goes on to carry
+    assert!(!potential_procedure_declaration(
+        "# Making Tea : An Overview"
+    ));
+    assert!(!potential_procedure_declaration("I. Prepare it : now"));
+    assert!(!potential_procedure_declaration("@chef : the good one"));
+    assert!(!potential_procedure_declaration("{ exec(\"date : now\") }"));
 
     // Nor prose, code, titles, or responses that merely contain a colon. A
     // procedure name is a lowercase identifier, so none of these can be one.

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -12,6 +12,22 @@ mod scope;
 // Export the actual public API
 pub use parser::{Parser, ParsingError, parse_numeric, parse_with_recovery};
 
+/// Convert a document written on Windows to have Unix line endings, allowing
+/// the rest of the parser to only have to deal with \n characters. We check
+/// the first line ending for a \r as a sentinel.
+fn normalise(content: String) -> String {
+    let crlf = match content.find('\n') {
+        Some(i) => content[..i].ends_with('\r'),
+        None => false,
+    };
+
+    if crlf {
+        content.replace("\r\n", "\n")
+    } else {
+        content
+    }
+}
+
 /// Read a file and return an owned String. We pass that ownership back to the
 /// main function so that the Technique object created by parse() below can
 /// have the same lifetime.
@@ -19,7 +35,7 @@ pub fn load(filename: &Path) -> Result<String, LoadingError<'_>> {
     if filename.to_str() == Some("-") {
         let mut buffer = String::new();
         match std::io::stdin().read_to_string(&mut buffer) {
-            Ok(_) => return Ok(buffer),
+            Ok(_) => return Ok(normalise(buffer)),
             Err(error) => {
                 debug!(?error);
                 return Err(LoadingError {
@@ -32,7 +48,7 @@ pub fn load(filename: &Path) -> Result<String, LoadingError<'_>> {
     }
 
     match std::fs::read_to_string(filename) {
-        Ok(content) => Ok(content),
+        Ok(content) => Ok(normalise(content)),
         Err(error) => {
             debug!(?error);
             match error.kind() {
@@ -89,5 +105,20 @@ pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Result<Document<'i>, V
             debug!("errors: {}", errors.len());
             Err(errors)
         }
+    }
+}
+
+#[cfg(test)]
+mod check {
+    use super::*;
+
+    #[test]
+    fn carriage_returns_removed() {
+        let content = "% technique v1\r\n\r\nalpha :\r\n".to_string();
+        assert_eq!(normalise(content), "% technique v1\n\nalpha :\n");
+
+        // content already written with newlines is handed back untouched
+        let content = "% technique v1\n\nalpha :\n".to_string();
+        assert_eq!(normalise(content), "% technique v1\n\nalpha :\n");
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -3244,11 +3244,17 @@ where
 /// example it must not match " a. And now: do something" or "b. Proceed
 /// with:".
 ///
-/// The name must be an identifier and the colon must stand apart from it. The
+/// The name must be an identifier and the colon must stand apart from it, on
+/// the same line; a signature may then wrap onto the lines below. The
 /// signature is not validated here; `f : B` is a declaration whose signature is
 /// wrong, which read_signature() will address once we commit to reading it.
 fn is_procedure_declaration(content: &str) -> bool {
-    match content.split_once(':') {
+    let line = content
+        .lines()
+        .next()
+        .unwrap_or("");
+
+    match line.split_once(':') {
         Some((before, _after)) => {
             // a declaration is written `name : signature`, with the colon
             // standing apart from the name. Prose punctuates the other way, as

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2586,6 +2586,12 @@ impl<'i> Parser<'i> {
                             para_span,
                         ));
                     } else {
+                        if let Some(text) = potential_unspaced_declaration(outer.source) {
+                            outer
+                                .problems
+                                .push(ParsingError::InvalidDeclaration(outer.span_of(text)));
+                        }
+
                         // Paragraph container
                         let para_start = outer.offset;
                         let descriptives = outer.take_paragraph(|parser| {
@@ -3352,6 +3358,25 @@ fn potential_procedure_declaration(content: &str) -> bool {
         }
         None => false,
     }
+}
+
+/// A paragraph consisting solely of a token and a colon, as in
+///
+/// ```text
+/// beta:
+/// ```
+///
+/// Prose ending in a colon is a phrase introducing what follows, never a lone
+/// word, so this is a declaration whose colon was not set apart from the name.
+/// Being a whole paragraph, it cannot be the last line of a wrapped sentence.
+fn potential_unspaced_declaration(content: &str) -> Option<&str> {
+    let paragraph = &content[..content
+        .find("\n\n")
+        .unwrap_or(content.len())];
+    let line = paragraph.trim_ascii();
+
+    let re = regex!(r"^[^\s:]+:$");
+    if re.is_match(line) { Some(line) } else { None }
 }
 
 fn is_procedure_body(content: &str) -> bool {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -3360,23 +3360,37 @@ fn potential_procedure_declaration(content: &str) -> bool {
     }
 }
 
-/// A paragraph consisting solely of a token and a colon, as in
+/// A paragraph that is a declaration but for the space setting the colon
+/// apart from the name, as in
 ///
 /// ```text
 /// beta:
+/// beta(a, b):
+/// beta: Ingredients -> Coffee
 /// ```
 ///
 /// Prose ending in a colon is a phrase introducing what follows, never a lone
-/// word, so this is a declaration whose colon was not set apart from the name.
-/// Being a whole paragraph, it cannot be the last line of a wrapped sentence.
+/// name, and never carries a signature.
 fn potential_unspaced_declaration(content: &str) -> Option<&str> {
     let paragraph = &content[..content
         .find("\n\n")
         .unwrap_or(content.len())];
     let line = paragraph.trim_ascii();
 
-    let re = regex!(r"^[^\s:]+:$");
-    if re.is_match(line) { Some(line) } else { None }
+    // prose wraps, whereas a declaration is a single line; and one written
+    // correctly sets its colon apart, having been taken as a boundary long
+    // before reaching descriptive text
+    let (name, rest) = line.split_once(':')?;
+    if line.contains('\n') || name.ends_with([' ', '\t']) {
+        return None;
+    }
+
+    let spaced = format!("{} :{}", name, rest);
+    if begins_procedure_declaration(&spaced) {
+        Some(line)
+    } else {
+        None
+    }
 }
 
 fn is_procedure_body(content: &str) -> bool {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1114,11 +1114,13 @@ impl<'i> Parser<'i> {
 
     /// Parse a procedure with error recovery - collects multiple errors instead of stopping at the first one
     fn read_procedure(&mut self) -> Result<Procedure<'i>, ParsingError> {
-        // Find the procedure block boundaries
+        // Find the procedure block boundaries. The end is the next attempted
+        // declaration, malformed or not, so a mistake in one procedure's name
+        // does not silently absorb it into the procedure preceding it.
         let i = locate_block_lines(
             self.source,
-            is_procedure_declaration,
-            is_procedure_declaration,
+            potential_procedure_declaration,
+            potential_procedure_declaration,
         );
 
         // Extract the procedure block
@@ -1382,7 +1384,7 @@ impl<'i> Parser<'i> {
                     body: Technique::Empty,
                     span: Span::default(),
                 })
-            } else if is_procedure_declaration(outer.source) {
+            } else if potential_procedure_declaration(outer.source) {
                 // Section contains procedures
                 let mut procedures = Vec::new();
                 while !outer.is_finished() {
@@ -1390,13 +1392,12 @@ impl<'i> Parser<'i> {
                     if outer.is_finished() {
                         break;
                     }
-                    if is_procedure_declaration(outer.source) {
+                    if potential_procedure_declaration(outer.source) {
                         match outer.read_procedure() {
                             Ok(procedure) => procedures.push(procedure),
-                            Err(_err) => {
-                                // Error is already collected in outer.problems
-                                // Just skip adding this procedure and continue
-                            }
+                            Err(error) => outer
+                                .problems
+                                .push(error),
                         }
                     } else {
                         // Skip non-procedure content line by line

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1022,13 +1022,24 @@ impl<'i> Parser<'i> {
 
         let text = one.as_str();
         let (name, parameters) = if let Some((before, list)) = text.split_once('(') {
+            // As below, the name is the first word, so that a name which is
+            // not an identifier is reported on its own rather than together
+            // with whatever was mistakenly written after it
             let before = before.trim();
-            let name = validate_identifier(before, self.span_of(before)).ok_or(
-                ParsingError::InvalidIdentifier(
-                    Span::new(self.offset, before.len()),
-                    before.to_string(),
-                ),
+            let first = before
+                .split_whitespace()
+                .next()
+                .unwrap_or(before);
+
+            let name = validate_identifier(first, self.span_of(first)).ok_or(
+                ParsingError::InvalidIdentifier(self.span_of(first), first.to_string()),
             )?;
+
+            if first.len() < before.len() {
+                return Err(ParsingError::InvalidParameters(
+                    self.span_of(before[first.len()..].trim_ascii_start()),
+                ));
+            }
 
             // Extract parameters from parentheses
             if !list.ends_with(')') {
@@ -1043,10 +1054,7 @@ impl<'i> Parser<'i> {
                 for item in list.split(',') {
                     let trimmed = item.trim_ascii();
                     let param = validate_identifier(trimmed, self.span_of(trimmed)).ok_or(
-                        ParsingError::InvalidIdentifier(
-                            Span::new(self.offset, trimmed.len()),
-                            trimmed.to_string(),
-                        ),
+                        ParsingError::InvalidIdentifier(self.span_of(trimmed), trimmed.to_string()),
                     )?;
                     params.push(param);
                 }
@@ -1055,18 +1063,21 @@ impl<'i> Parser<'i> {
 
             (name, parameters)
         } else {
-            // Check if there are multiple words (procedure name + anything
-            // else) which would indicates parameters without parentheses
-            let words: Vec<&str> = text
-                .trim()
+            // The name is the first word. Validate it before considering
+            // what follows, so that a name which is not an identifier is
+            // reported as such rather than blamed on the words after it
+            let first = text
                 .split_whitespace()
-                .collect();
-            if words.len() > 1 {
-                // Calculate position of first mistaken parameter-ish thing
-                let first_space_pos = text
-                    .find(' ')
-                    .unwrap_or(0);
-                let first_param_pos = text[first_space_pos..]
+                .next()
+                .unwrap_or(text);
+
+            let name = validate_identifier(first, self.span_of(first)).ok_or(
+                ParsingError::InvalidIdentifier(self.span_of(first), first.to_string()),
+            )?;
+
+            // Anything further is an attempt at parameters without parentheses
+            if first.len() < text.len() {
+                let first_param_pos = text[first.len()..]
                     .trim_start()
                     .as_ptr() as isize
                     - text.as_ptr() as isize;
@@ -1078,12 +1089,6 @@ impl<'i> Parser<'i> {
                 )));
             }
 
-            let name = validate_identifier(text, self.span_of(text)).ok_or(
-                ParsingError::InvalidIdentifier(
-                    Span::new(self.offset, text.len()),
-                    text.to_string(),
-                ),
-            )?;
             (name, None)
         };
 
@@ -3294,35 +3299,25 @@ fn potential_procedure_declaration(content: &str) -> bool {
                     .is_empty();
             }
 
-            // If it's a step patterns then it's not a procedure declaration!
+            // A name is an identifier, so it never begins with one of the
+            // marker characters that open a step, section, title, attribute,
+            // response, or code block. Those lines carry colons of their own
             if is_step_dependent(line)
                 || is_step_parallel(line)
                 || is_substep_dependent(line)
                 || is_substep_parallel(line)
+                || is_subsubstep_dependent(line)
+                || is_section(line)
+                || is_procedure_title(line)
+                || is_attribute_pattern(line)
+                || is_enum_response(line)
+                || is_code_block(line)
             {
                 return false;
             }
 
-            // Has parentheses -> likely trying to be a procedure with parameters
-            if before.contains('(') {
-                return true;
-            }
-
-            // Check if it looks like prose vs an identifier attempt
-            // Prose typically: starts with capital, has multiple space-separated words
-            // Identifiers: lowercase, possibly with underscores
-            let first_char = before
-                .chars()
-                .next()
-                .unwrap();
-            let has_spaces = before.contains(' ');
-
-            // If it starts with uppercase AND has spaces, it's probably prose
-            if first_char.is_uppercase() && has_spaces {
-                return false;
-            }
-
-            // Otherwise, could be a procedure declaration attempt
+            // Anything else setting a colon apart from what precedes it is an
+            // attempt at a declaration, however malformed the name
             true
         }
         None => false,

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -3547,7 +3547,8 @@ impl Literals {
 
     fn in_literal(&self) -> bool {
         match self.within {
-            Within::Text => false,
+            // still inside a literal if partway through a ``` delimiter
+            Within::Text => self.delimiter > 0,
             _ => true,
         }
     }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -458,6 +458,7 @@ impl<'i> Parser<'i> {
     {
         let mut l = 0;
         let mut begun = false;
+        let mut unterminated = false;
 
         if start_char == end_char {
             // Simple case: same character for start and end (like X...X)
@@ -500,6 +501,8 @@ impl<'i> Parser<'i> {
                     }
                 }
             }
+
+            unterminated = literals.in_fence();
         }
 
         if !begun {
@@ -509,6 +512,18 @@ impl<'i> Parser<'i> {
             ));
         }
         if l == 0 {
+            // a multi-line string left open masks the rest of the input,
+            // taking the end character we were looking for with it
+            if unterminated {
+                let i = self
+                    .source
+                    .rfind("```")
+                    .unwrap_or(0);
+                return Err(ParsingError::InvalidMultiline(Span::new(
+                    self.offset + i,
+                    0,
+                )));
+            }
             return Err(ParsingError::ExpectedMatchingChar(
                 Span::new(self.offset, 0),
                 subject,
@@ -3550,6 +3565,15 @@ impl Literals {
             // still inside a literal if partway through a ``` delimiter
             Within::Text => self.delimiter > 0,
             _ => true,
+        }
+    }
+
+    // a fence is the only literal that carries across lines, so it is the only
+    // one that can still be open at the end of the input
+    fn in_fence(&self) -> bool {
+        match self.within {
+            Within::Fence => true,
+            _ => false,
         }
     }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -598,7 +598,33 @@ impl<'i> Parser<'i> {
             .map(|(i, _)| i)
             .unwrap_or(content.len());
 
-        let block = &content[..end_pos];
+        self.take_upto(end_pos, function)
+    }
+
+    /// As take_until(), but for descriptive text, which holds no literals. A
+    /// quote there is punctuation the author wrote, an old-fashioned mark for
+    /// the inch unit of measurement, or a quotation; none of which indicate a
+    /// run of text that needs to be masked.
+    fn take_text_until<A, F>(&mut self, pattern: &[char], function: F) -> Result<A, ParsingError>
+    where
+        F: Fn(&mut Parser<'i>) -> Result<A, ParsingError>,
+    {
+        let end_pos = self
+            .source
+            .find(pattern)
+            .unwrap_or(
+                self.source
+                    .len(),
+            );
+
+        self.take_upto(end_pos, function)
+    }
+
+    fn take_upto<A, F>(&mut self, end_pos: usize, function: F) -> Result<A, ParsingError>
+    where
+        F: Fn(&mut Parser<'i>) -> Result<A, ParsingError>,
+    {
+        let block = &self.source[..end_pos];
         let mut parser = self.subparser(0, block);
 
         // Pass to closure for processing
@@ -1405,7 +1431,9 @@ impl<'i> Parser<'i> {
                                 .push(error),
                         }
                     } else {
-                        // Skip non-procedure content line by line
+                        outer
+                            .problems
+                            .push(ParsingError::Unrecognized(Span::new(outer.offset, 0)));
                         outer.skip_to_next_line();
                     }
                 }
@@ -1444,7 +1472,9 @@ impl<'i> Parser<'i> {
                             line.len(),
                         )));
                     } else {
-                        // Skip unrecognized content line by line
+                        outer
+                            .problems
+                            .push(ParsingError::Unrecognized(Span::new(outer.offset, 0)));
                         outer.skip_to_next_line();
                     }
                 }
@@ -2628,7 +2658,7 @@ impl<'i> Parser<'i> {
                                     parser.advance(1);
                                     content.push(Descriptive::Text("$"));
                                 } else {
-                                    let text = parser.take_until(
+                                    let text = parser.take_text_until(
                                         &['{', '<', '$', '~', '\n'],
                                         |inner| {
                                             let content = inner

--- a/src/problem/messages.rs
+++ b/src/problem/messages.rs
@@ -389,8 +389,8 @@ this form.
                 "Invalid procedure declaration".to_string(),
                 format!(
                     r#"
-Procedures are declared by specifying an identifier as a name, followed by a
-colon:
+Procedures are declared by specifying an identifier as a name, followed by at
+least one space, then a colon:
 
     {}
     {}

--- a/tests/broken/parsing/DeclarationCapitalised.tq
+++ b/tests/broken/parsing/DeclarationCapitalised.tq
@@ -1,0 +1,14 @@
+mix_drink :
+
+# Mix Drink
+
+I. Prepare the ingredients <prepare_gin>
+
+Prepare Gin :
+
+    1.  Remove cubes from the freezer
+    2.  Drop them in the glass
+
+serve_drink :
+
+    1.  Pour it out

--- a/tests/broken/parsing/SectionDeclarationFirst.tq
+++ b/tests/broken/parsing/SectionDeclarationFirst.tq
@@ -1,0 +1,16 @@
+mix_drink :
+
+# Mix Drink
+
+I. Prepare the ingredients <prepare_gin>
+
+II. Serve it up <serve_drink>
+
+prepare gin :
+
+    1.  Remove cubes from the freezer
+    2.  Drop them in the glass
+
+serve_drink :
+
+    1.  Pour it out

--- a/tests/broken/parsing/SectionDeclarationFollowing.tq
+++ b/tests/broken/parsing/SectionDeclarationFollowing.tq
@@ -1,0 +1,14 @@
+mix_drink :
+
+# Mix Drink
+
+I. Prepare the ingredients <prepare_gin>
+
+prepare_gin :
+
+    1.  Remove cubes from the freezer
+    2.  Drop them in the glass
+
+serve drink :
+
+    1.  Pour it out


### PR DESCRIPTION
The switch to a permissive boundary check for detecting possible procedure declarations was right, but various heuristics from before were defeating the improvement, resulting in error spans being anchored to the wrong token. Add test coverage for these scenarios and then refine the order in which tests are applied.

Also fixes masking that was incorrectly happening if a `"` was encountered in descriptive prose. Such a character does not begin a literal as those only occur in expressions.

Finishes with a considerable number of defensive and correctness improvements to address corner cases encountered during review.