### PR TITLE
Output log trace of a run to console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "technique"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "crossterm",
@@ -728,7 +737,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -750,6 +751,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "technique"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "A domain specific language for procedures."
 authors = [ "Andrew Cowie" ]
@@ -16,7 +16,7 @@ lsp-types = "0.97"
 owo-colors = "4"
 regex = "1.11.1"
 serde_json = "1.0"
-time = "0.3"
+time = { version = "0.3", features = [ "local-offset" ] }
 
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lsp-types = "0.97"
 owo-colors = "4"
 regex = "1.11.1"
 serde_json = "1.0"
-time = { version = "0.3", features = [ "local-offset" ] }
+time = { version = "0.3", features = [ "local-offset", "parsing" ] }
 
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/src/engraving/checks/record.rs
+++ b/src/engraving/checks/record.rs
@@ -1,9 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use crate::runner::runner::RunnerError;
-use crate::runner::state::{
-    InvokeTarget, Record, RecordError, RunId, State, Store, Supplied, fail_reason, format_record,
-    parse_record,
+use crate::engraving::{
+    InvokeTarget, Record, RecordError, RunId, State, Store, StoreError, Supplied, display_path,
+    fail_reason, format_record, parse_record,
 };
 use crate::value::Value;
 
@@ -43,7 +42,7 @@ fn run_id_parse() {
 fn run_id_parse_rejects_non_decimal() {
     for text in ["", "abc", "-1"] {
         match RunId::parse(text) {
-            Err(RunnerError::InvalidRunId(got)) => assert_eq!(got, text),
+            Err(StoreError::InvalidRunId(got)) => assert_eq!(got, text),
             other => panic!("expected InvalidRunId for {:?}, got {:?}", text, other),
         }
     }
@@ -281,7 +280,7 @@ fn open_missing_run_returns_no_such_run() {
             .clone(),
     );
     match store.open(RunId(42)) {
-        Err(RunnerError::NoSuchRun(run_id)) => assert_eq!(run_id, RunId(42)),
+        Err(StoreError::NoSuchRun(run_id)) => assert_eq!(run_id, RunId(42)),
         other => panic!("expected NoSuchRun, got {:?}", other),
     }
 }
@@ -710,7 +709,7 @@ fn open_missing_start_record() {
             .clone(),
     );
     match store.open(RunId(1)) {
-        Err(RunnerError::StartMissing(run_id)) => assert_eq!(run_id, RunId(1)),
+        Err(StoreError::StartMissing(run_id)) => assert_eq!(run_id, RunId(1)),
         other => panic!("expected StartMissing, got {:?}", other),
     }
 
@@ -726,7 +725,36 @@ fn open_missing_start_record() {
             .clone(),
     );
     match store.open(RunId(1)) {
-        Err(RunnerError::StartMissing(run_id)) => assert_eq!(run_id, RunId(1)),
+        Err(StoreError::StartMissing(run_id)) => assert_eq!(run_id, RunId(1)),
         other => panic!("expected StartMissing, got {:?}", other),
     }
+}
+
+#[test]
+fn display_trims_entry_head() {
+    // Within a section the entry head is dropped, the numeral anchors instead.
+    assert_eq!(
+        display_path("/connectivity_check:/VI/check_aws_health:/7"),
+        "VI/check_aws_health:/7"
+    );
+
+    // A flat entry with no section keeps its name; only the leading slash goes.
+    assert_eq!(
+        display_path("/connectivity_check:/1"),
+        "connectivity_check:/1"
+    );
+    assert_eq!(
+        display_path("/activate_crisis_management:/-1"),
+        "activate_crisis_management:/-1"
+    );
+
+    // An ` <invocation>` annotation on the numeral is kept; the head still drops.
+    assert_eq!(
+        display_path("/connectivity_check:/VII <service_endpoint>"),
+        "VII <service_endpoint>"
+    );
+
+    // An anonymous technique has no head to drop; the leading slash still goes.
+    assert_eq!(display_path("/I/1"), "I/1");
+    assert_eq!(display_path("/I"), "I");
 }

--- a/src/engraving/mod.rs
+++ b/src/engraving/mod.rs
@@ -1,0 +1,29 @@
+//! The PFFTT record format, and the local on-disk store these records are
+//! written to.
+
+use std::io;
+use std::path::PathBuf;
+
+mod record;
+mod store;
+
+/// Errors raised interacting with the store or PFFTT files therein.
+#[derive(Debug)]
+pub enum StoreError {
+    NoSuchRun(RunId),
+    StartMissing(RunId),
+    InvalidRunId(String),
+    MalformedRecord { run_id: RunId, error: RecordError },
+    Io { path: PathBuf, error: io::Error },
+}
+
+pub use record::{
+    InvokeTarget, Record, RecordError, RunId, State, Supplied, display_path, parse_records,
+};
+pub use store::{Appender, Store};
+
+pub(crate) use record::{fail_reason, format_record, format_supplied, serialize_value};
+pub(crate) use store::{construct_state_path, parse_run_uri};
+
+#[cfg(test)]
+pub(crate) use record::parse_record;

--- a/src/engraving/record.rs
+++ b/src/engraving/record.rs
@@ -1,11 +1,9 @@
-//! On-disk state store and run identifiers.
+//! The PFFTT record: the events a run writes, and the codec that puts
+//! them on a line and reads them back.
 
-use std::collections::HashMap;
-use std::io;
-use std::path::{Path, PathBuf};
-
-use super::runner::RunnerError;
 use crate::value;
+
+use super::StoreError;
 
 /// Monotonic identifier for a run. Conventionally rendered and stored as a
 /// six-digit zero-padded string.
@@ -15,10 +13,10 @@ pub struct RunId(pub u32);
 impl RunId {
     /// Parse a run identifier. Both unpadded (`7`) and zero-padded
     /// (`000007`) decimal forms are accepted.
-    pub fn parse(text: &str) -> Result<RunId, RunnerError> {
+    pub fn parse(text: &str) -> Result<RunId, StoreError> {
         text.parse::<u32>()
             .map(RunId)
-            .map_err(|_| RunnerError::InvalidRunId(text.to_string()))
+            .map_err(|_| StoreError::InvalidRunId(text.to_string()))
     }
 
     /// Render as a six-digit zero-padded decimal string.
@@ -94,353 +92,32 @@ pub enum InvokeTarget {
     Uri(String),
 }
 
-/// On-disk store of runs, rooted at some base directory (conventionally
-/// `.store/` relative to the user's current directory).
-#[allow(dead_code)]
-pub struct Store {
-    base: PathBuf,
+/// Trim a rendered PFFTT path to the live-prompt form: drop the leading `/`,
+/// and the entry procedure's `name:` head when a section immediately follows.
+pub fn display_path(qualified: &str) -> String {
+    let body = qualified
+        .strip_prefix('/')
+        .unwrap_or(qualified);
+    let mut parts: Vec<&str> = body
+        .split('/')
+        .collect();
+    if parts.len() >= 2 && parts[0].ends_with(':') && is_section_component(parts[1]) {
+        parts.remove(0);
+    }
+    parts.join("/")
 }
 
-// Cap the number of times the allocator retries when another process has
-// taken the identifier we just computed. The race window is small; a
-// handful of retries is more than enough in practice.
-#[allow(dead_code)]
-const ALLOCATE_RETRIES: usize = 4;
-
-#[allow(dead_code)]
-impl Store {
-    /// Build a handle to a store rooted at `base`. No I/O happens here; the
-    /// directory is created on the first call to `allocate`.
-    pub fn new(base: PathBuf) -> Self {
-        Store { base }
-    }
-
-    /// Allocate a new run identifier and create its directory. Returns the
-    /// identifier and the path of the new directory.
-    pub fn allocate(&self) -> Result<(RunId, PathBuf), RunnerError> {
-        // Make sure the store root exists before scanning for siblings.
-        if let Err(error) = std::fs::create_dir_all(&self.base) {
-            return Err(RunnerError::StoreError {
-                path: self
-                    .base
-                    .clone(),
-                error,
-            });
-        }
-
-        for _ in 0..ALLOCATE_RETRIES {
-            let next = self.next_identifier()?;
-            let path = self
-                .base
-                .join(next.render());
-            match std::fs::create_dir(&path) {
-                Ok(()) => return Ok((next, path)),
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-                Err(error) => return Err(RunnerError::StoreError { path, error }),
-            }
-        }
-
-        Err(RunnerError::StoreError {
-            path: self
-                .base
-                .clone(),
-            error: io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                "exhausted retries allocating a run identifier",
-            ),
-        })
-    }
-
-    /// Allocate a new run and write its opening `Start` record. The PFFTT
-    /// file is named after the source document's basename (e.g.
-    /// `NetworkProbe.pfftt`).
-    pub fn create(
-        &self,
-        document: &Path,
-        started: String,
-        libraries: &[String],
-    ) -> Result<(RunId, PathBuf), RunnerError> {
-        let absolute = std::path::absolute(document).map_err(|error| RunnerError::StoreError {
-            path: document.to_path_buf(),
-            error,
-        })?;
-        let (run_id, run_dir) = self.allocate()?;
-        let pfftt = construct_state_path(&run_dir, &absolute);
-        let mut uri = format!("file://{}", absolute.display());
-        if !libraries.is_empty() {
-            uri.push_str("?library=");
-            uri.push_str(&libraries.join(","));
-        }
-        let record = Record {
-            recorded: started,
-            run_id,
-            path: "/".to_string(),
-            state: State::Start { uri },
-        };
-        std::fs::write(&pfftt, format_record(&record))
-            .map_err(|error| RunnerError::StoreError { path: pfftt, error })?;
-        Ok((run_id, run_dir))
-    }
-
-    /// Open an existing run. Parses the leading `Start` record to recover the
-    /// source document and the libraries it was run with, then replays
-    /// records into a map of completed step paths to the value each recorded
-    /// (`Done` with its value, `Skip`/`Fail` mapping to `Unitus`), used to
-    /// rehydrate bindings on resume. `Stop` and `Resume` records are passed
-    /// over.
-    pub fn open(
-        &self,
-        run_id: RunId,
-    ) -> Result<
-        (
-            PathBuf,
-            Vec<String>,
-            HashMap<String, value::Value>,
-            HashMap<String, Vec<Supplied>>,
-            PathBuf,
-        ),
-        RunnerError,
-    > {
-        let run_dir = self
-            .base
-            .join(run_id.render());
-        if !run_dir.is_dir() {
-            return Err(RunnerError::NoSuchRun(run_id));
-        }
-        let pfftt = find_pfftt_file(&run_dir, run_id)?;
-        let content = std::fs::read_to_string(&pfftt).map_err(|error| RunnerError::StoreError {
-            path: pfftt.clone(),
-            error,
-        })?;
-
-        let mut lines = content
-            .lines()
-            .filter(|line| {
-                !line
-                    .trim()
-                    .is_empty()
-            });
-
-        let first = lines
-            .next()
-            .ok_or(RunnerError::StartMissing(run_id))?;
-        let head =
-            parse_record(first).map_err(|error| RunnerError::MalformedRecord { run_id, error })?;
-        let (document, libraries) = match head.state {
-            State::Start { uri, .. } => parse_run_uri(&uri),
-            _ => return Err(RunnerError::StartMissing(run_id)),
-        };
-
-        let mut completed = HashMap::new();
-        let mut inputs: HashMap<String, Vec<Supplied>> = HashMap::new();
-        for line in lines {
-            let record = parse_record(line)
-                .map_err(|error| RunnerError::MalformedRecord { run_id, error })?;
-            match record.state {
-                State::Done(value) => {
-                    completed.insert(record.path, value.unwrap_or(value::Value::Unitus));
-                }
-                State::Skip | State::Fail(_) => {
-                    completed.insert(record.path, value::Value::Unitus);
-                }
-                State::Input(supplied) => {
-                    inputs.insert(record.path, supplied);
-                }
-                State::Start { .. }
-                | State::Finish
-                | State::Stop
-                | State::Resume
-                | State::Invoke(_)
-                | State::Execute { .. }
-                | State::Return(_)
-                | State::Begin => {}
-            }
-        }
-        Ok((document, libraries, completed, inputs, run_dir))
-    }
-
-    // Scan the store for the highest existing run identifier and return
-    // one more. Entries whose names are not valid decimal integers are
-    // ignored, which keeps the allocator robust against editor scratch
-    // files left in `.store/`.
-    fn next_identifier(&self) -> Result<RunId, RunnerError> {
-        let mut max: u32 = 0;
-        let entries = std::fs::read_dir(&self.base).map_err(|error| RunnerError::StoreError {
-            path: self
-                .base
-                .clone(),
-            error,
-        })?;
-        for entry in entries {
-            let entry = entry.map_err(|error| RunnerError::StoreError {
-                path: self
-                    .base
-                    .clone(),
-                error,
-            })?;
-            if let Some(name) = entry
-                .file_name()
-                .to_str()
-            {
-                if let Ok(n) = name.parse::<u32>() {
-                    if n > max {
-                        max = n;
-                    }
-                }
-            }
-        }
-        Ok(RunId(max + 1))
-    }
-}
-
-// Recover the source document's file path and the libraries that were
-// selected from a Start URI of the form
-//
-// file://{path}?library=a,b
-
-// written by `create` records. The query string parameters are optional.
-fn parse_run_uri(uri: &str) -> (PathBuf, Vec<String>) {
-    let (location, query) = match uri.split_once('?') {
-        Some((location, query)) => (location, Some(query)),
-        None => (uri, None),
-    };
-    let path = location
-        .strip_prefix("file://")
-        .unwrap_or(location);
-    let libraries = query
-        .and_then(|query| query.strip_prefix("library="))
-        .map(|names| {
-            names
-                .split(',')
-                .map(str::to_string)
-                .collect()
-        })
-        .unwrap_or_default();
-    (PathBuf::from(path), libraries)
-}
-
-// Compute the on-disk PFFTT file path for a run, named using the source
-// document's stem.
-pub(crate) fn construct_state_path(run_dir: &Path, document: &Path) -> PathBuf {
-    let stem = document
-        .file_stem()
-        .map(|s| s.to_os_string())
-        .unwrap_or_default();
-    let mut name = PathBuf::from(stem);
-    name.set_extension("pfftt");
-    run_dir.join(name)
-}
-
-/// Where an `Appender` sends its records, normally an append-only PFFTT file
-/// in the store, or an in-memory sink for test runs that keep no persistent
-/// state.
-enum Target {
-    File { file: std::fs::File, path: PathBuf },
-    Memory(String),
-    Discard,
-}
-
-/// Append-only writer for a PFFTT file. Used by the runner to append a
-/// record for each step boundary and lifecycle event. Carries the
-/// `RunId` so callers can stamp it onto records.
-/// through every layer.
-#[allow(dead_code)]
-pub struct Appender {
-    target: Target,
-    run_id: RunId,
-}
-
-#[allow(dead_code)]
-impl Appender {
-    /// Open the PFFTT file for append. The file must already exist (the
-    /// runner writes the opening `Start` record first via `Store::create`).
-    pub fn open(path: PathBuf, run_id: RunId) -> Result<Self, RunnerError> {
-        let file = std::fs::OpenOptions::new()
-            .append(true)
-            .open(&path)
-            .map_err(|error| RunnerError::StoreError {
-                path: path.clone(),
-                error,
-            })?;
-        Ok(Appender {
-            target: Target::File { file, path },
-            run_id,
-        })
-    }
-
-    /// An Appender that discards every record for use in tests.
-    pub fn sink() -> Self {
-        Appender {
-            target: Target::Discard,
-            run_id: RunId(0),
-        }
-    }
-
-    /// An Appender that captures every record in memory for use in tests,
-    /// readable afterwards with `contents()`. Touches no filesystem.
-    pub fn memory() -> Self {
-        Appender {
-            target: Target::Memory(String::new()),
-            run_id: RunId(0),
-        }
-    }
-
-    /// The records captured by an in-memory Appender (`memory()`), as the raw
-    /// PFFTT text; empty for a file or discarding Appender.
-    pub fn contents(&self) -> &str {
-        match &self.target {
-            Target::Memory(buffer) => buffer,
-            _ => "",
-        }
-    }
-
-    /// The `RunId` this Appender is writing records for.
-    pub fn run_id(&self) -> RunId {
-        self.run_id
-    }
-
-    /// Append one record line. Flushes are left to the OS; on Quit the
-    /// runner drops the Appender, which closes the file.
-    pub fn append(&mut self, record: &Record) -> Result<(), RunnerError> {
-        use std::io::Write;
-        let text = format_record(record);
-        match &mut self.target {
-            Target::File { file, path } => file
-                .write_all(text.as_bytes())
-                .map_err(|error| RunnerError::StoreError {
-                    path: path.clone(),
-                    error,
-                }),
-            Target::Memory(buffer) => {
-                buffer.push_str(&text);
-                Ok(())
-            }
-            Target::Discard => Ok(()),
-        }
-    }
-}
-
-// Locate the single `*.pfftt` file in a run directory.
-fn find_pfftt_file(run_dir: &Path, run_id: RunId) -> Result<PathBuf, RunnerError> {
-    let entries = std::fs::read_dir(run_dir).map_err(|error| RunnerError::StoreError {
-        path: run_dir.to_path_buf(),
-        error,
-    })?;
-    for entry in entries {
-        let entry = entry.map_err(|error| RunnerError::StoreError {
-            path: run_dir.to_path_buf(),
-            error,
-        })?;
-        let path = entry.path();
-        if path
-            .extension()
-            .and_then(|s| s.to_str())
-            == Some("pfftt")
-        {
-            return Ok(path);
-        }
-    }
-    Err(RunnerError::StartMissing(run_id))
+/// Leading token, not the whole component: an acquire label can glue an
+/// ` <invocation>` annotation after the numeral.
+fn is_section_component(part: &str) -> bool {
+    let token = part
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    !token.is_empty()
+        && token
+            .bytes()
+            .all(|b| b"IVXLCDM".contains(&b))
 }
 
 // Serialize a Record in PFFTT line form. The format is:
@@ -520,7 +197,7 @@ fn format_state(out: &mut String, state: &State) {
 // Format a procedure's supplied inputs as `( value ~ name, value, … )`: each
 // value serialized by the value codec, a named parameter followed by `~ name`,
 // an unnamed one left bare.
-fn format_supplied(out: &mut String, supplied: &[Supplied]) {
+pub(crate) fn format_supplied(out: &mut String, supplied: &[Supplied]) {
     out.push('(');
     for (i, item) in supplied
         .iter()
@@ -617,6 +294,19 @@ pub(crate) fn fail_reason(reason: &str) -> value::Value {
         "reason".to_string(),
         value::Value::Literali(reason.to_string()),
     )])
+}
+
+/// Parse the lines of a PFFTT file into records, blank lines passed over.
+pub fn parse_records(content: &str) -> Result<Vec<Record>, RecordError> {
+    content
+        .lines()
+        .filter(|line| {
+            !line
+                .trim()
+                .is_empty()
+        })
+        .map(parse_record)
+        .collect()
 }
 
 // Parse a single PFFTT record line into a Record.
@@ -1095,7 +785,7 @@ fn split_once_top_level_tilde(text: &str) -> Option<(&str, &str)> {
 }
 
 #[cfg(test)]
-#[path = "checks/state.rs"]
+#[path = "checks/record.rs"]
 mod check;
 
 #[cfg(test)]

--- a/src/engraving/record.rs
+++ b/src/engraving/record.rs
@@ -34,7 +34,6 @@ pub enum RecordError {
 }
 
 /// One record line on disk.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Record {
     pub recorded: String,
@@ -56,7 +55,6 @@ pub struct Record {
 /// `Action`) with the value it returned; Pure builtins are not recorded.
 /// `Input` records the values supplied to a procedure so a resume can restore
 /// the state without re-prompting for information already entered.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum State {
     Start { uri: String },
@@ -76,7 +74,6 @@ pub enum State {
 /// One value supplied to a procedure's parameter: bound to a named parameter
 /// (recorded as `value ~ name`), or positional when the parameter is unnamed
 /// (recorded as a bare `value`).
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Supplied {
     pub value: value::Value,
@@ -85,7 +82,6 @@ pub struct Supplied {
 
 /// The target of an `Invoke`: either a named procedure (rendered as
 /// `name:`) or a URI to an external technique.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum InvokeTarget {
     Procedure(String),
@@ -122,7 +118,6 @@ fn is_section_component(part: &str) -> bool {
 
 // Serialize a Record in PFFTT line form. The format is:
 // Timestamp RunId Path (State Value) followed by a newline.
-#[allow(dead_code)]
 pub(crate) fn format_record(record: &Record) -> String {
     let mut text = String::new();
     text.push_str(&record.recorded);

--- a/src/engraving/store.rs
+++ b/src/engraving/store.rs
@@ -12,7 +12,6 @@ use super::record::{Record, RunId, State, Supplied, format_record, parse_record,
 
 /// On-disk store of runs, rooted at some base directory (conventionally
 /// `.store/` relative to the user's current directory).
-#[allow(dead_code)]
 pub struct Store {
     base: PathBuf,
 }
@@ -20,10 +19,8 @@ pub struct Store {
 // Cap the number of times the allocator retries when another process has
 // taken the identifier we just computed. The race window is small; a
 // handful of retries is more than enough in practice.
-#[allow(dead_code)]
 const ALLOCATE_RETRIES: usize = 4;
 
-#[allow(dead_code)]
 impl Store {
     /// Build a handle to a store rooted at `base`. No I/O happens here; the
     /// directory is created on the first call to `allocate`.
@@ -278,13 +275,11 @@ enum Target {
 /// record for each step boundary and lifecycle event. Carries the
 /// `RunId` so callers can stamp it onto records.
 /// through every layer.
-#[allow(dead_code)]
 pub struct Appender {
     target: Target,
     run_id: RunId,
 }
 
-#[allow(dead_code)]
 impl Appender {
     /// Open the PFFTT file for append. The file must already exist (the
     /// runner writes the opening `Start` record first via `Store::create`).

--- a/src/engraving/store.rs
+++ b/src/engraving/store.rs
@@ -1,0 +1,378 @@
+//! The store of recorded runs: allocation of run identifiers, and the
+//! append-only PFFTT file each run is written to.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::value;
+
+use super::StoreError;
+use super::record::{Record, RunId, State, Supplied, format_record, parse_record, parse_records};
+
+/// On-disk store of runs, rooted at some base directory (conventionally
+/// `.store/` relative to the user's current directory).
+#[allow(dead_code)]
+pub struct Store {
+    base: PathBuf,
+}
+
+// Cap the number of times the allocator retries when another process has
+// taken the identifier we just computed. The race window is small; a
+// handful of retries is more than enough in practice.
+#[allow(dead_code)]
+const ALLOCATE_RETRIES: usize = 4;
+
+#[allow(dead_code)]
+impl Store {
+    /// Build a handle to a store rooted at `base`. No I/O happens here; the
+    /// directory is created on the first call to `allocate`.
+    pub fn new(base: PathBuf) -> Self {
+        Store { base }
+    }
+
+    /// Allocate a new run identifier and create its directory. Returns the
+    /// identifier and the path of the new directory.
+    pub fn allocate(&self) -> Result<(RunId, PathBuf), StoreError> {
+        // Make sure the store root exists before scanning for siblings.
+        if let Err(error) = std::fs::create_dir_all(&self.base) {
+            return Err(StoreError::Io {
+                path: self
+                    .base
+                    .clone(),
+                error,
+            });
+        }
+
+        for _ in 0..ALLOCATE_RETRIES {
+            let next = self.next_identifier()?;
+            let path = self
+                .base
+                .join(next.render());
+            match std::fs::create_dir(&path) {
+                Ok(()) => return Ok((next, path)),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(StoreError::Io { path, error }),
+            }
+        }
+
+        Err(StoreError::Io {
+            path: self
+                .base
+                .clone(),
+            error: io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "exhausted retries allocating a run identifier",
+            ),
+        })
+    }
+
+    /// Allocate a new run and write its opening `Start` record. The PFFTT
+    /// file is named after the source document's basename (e.g.
+    /// `NetworkProbe.pfftt`).
+    pub fn create(
+        &self,
+        document: &Path,
+        started: String,
+        libraries: &[String],
+    ) -> Result<(RunId, PathBuf), StoreError> {
+        let absolute = std::path::absolute(document).map_err(|error| StoreError::Io {
+            path: document.to_path_buf(),
+            error,
+        })?;
+        let (run_id, run_dir) = self.allocate()?;
+        let pfftt = construct_state_path(&run_dir, &absolute);
+        let mut uri = format!("file://{}", absolute.display());
+        if !libraries.is_empty() {
+            uri.push_str("?library=");
+            uri.push_str(&libraries.join(","));
+        }
+        let record = Record {
+            recorded: started,
+            run_id,
+            path: "/".to_string(),
+            state: State::Start { uri },
+        };
+        std::fs::write(&pfftt, format_record(&record))
+            .map_err(|error| StoreError::Io { path: pfftt, error })?;
+        Ok((run_id, run_dir))
+    }
+
+    /// Read an existing run's trail back into memory, every record in the
+    /// order it was written.
+    pub fn read(&self, run_id: RunId) -> Result<Vec<Record>, StoreError> {
+        let run_dir = self
+            .base
+            .join(run_id.render());
+        if !run_dir.is_dir() {
+            return Err(StoreError::NoSuchRun(run_id));
+        }
+        let pfftt = find_pfftt_file(&run_dir, run_id)?;
+        let content = std::fs::read_to_string(&pfftt).map_err(|error| StoreError::Io {
+            path: pfftt.clone(),
+            error,
+        })?;
+
+        parse_records(&content).map_err(|error| StoreError::MalformedRecord { run_id, error })
+    }
+
+    /// Open an existing run. Parses the leading `Start` record to recover the
+    /// source document and the libraries it was run with, then replays
+    /// records into a map of completed step paths to the value each recorded
+    /// (`Done` with its value, `Skip`/`Fail` mapping to `Unitus`), used to
+    /// rehydrate bindings on resume. `Stop` and `Resume` records are passed
+    /// over.
+    pub fn open(
+        &self,
+        run_id: RunId,
+    ) -> Result<
+        (
+            PathBuf,
+            Vec<String>,
+            HashMap<String, value::Value>,
+            HashMap<String, Vec<Supplied>>,
+            PathBuf,
+        ),
+        StoreError,
+    > {
+        let run_dir = self
+            .base
+            .join(run_id.render());
+        if !run_dir.is_dir() {
+            return Err(StoreError::NoSuchRun(run_id));
+        }
+        let pfftt = find_pfftt_file(&run_dir, run_id)?;
+        let content = std::fs::read_to_string(&pfftt).map_err(|error| StoreError::Io {
+            path: pfftt.clone(),
+            error,
+        })?;
+
+        let mut lines = content
+            .lines()
+            .filter(|line| {
+                !line
+                    .trim()
+                    .is_empty()
+            });
+
+        let first = lines
+            .next()
+            .ok_or(StoreError::StartMissing(run_id))?;
+        let head =
+            parse_record(first).map_err(|error| StoreError::MalformedRecord { run_id, error })?;
+        let (document, libraries) = match head.state {
+            State::Start { uri, .. } => parse_run_uri(&uri),
+            _ => return Err(StoreError::StartMissing(run_id)),
+        };
+
+        let mut completed = HashMap::new();
+        let mut inputs: HashMap<String, Vec<Supplied>> = HashMap::new();
+        for line in lines {
+            let record = parse_record(line)
+                .map_err(|error| StoreError::MalformedRecord { run_id, error })?;
+            match record.state {
+                State::Done(value) => {
+                    completed.insert(record.path, value.unwrap_or(value::Value::Unitus));
+                }
+                State::Skip | State::Fail(_) => {
+                    completed.insert(record.path, value::Value::Unitus);
+                }
+                State::Input(supplied) => {
+                    inputs.insert(record.path, supplied);
+                }
+                State::Start { .. }
+                | State::Finish
+                | State::Stop
+                | State::Resume
+                | State::Invoke(_)
+                | State::Execute { .. }
+                | State::Return(_)
+                | State::Begin => {}
+            }
+        }
+        Ok((document, libraries, completed, inputs, run_dir))
+    }
+
+    // Scan the store for the highest existing run identifier and return
+    // one more. Entries whose names are not valid decimal integers are
+    // ignored, which keeps the allocator robust against editor scratch
+    // files left in `.store/`.
+    fn next_identifier(&self) -> Result<RunId, StoreError> {
+        let mut max: u32 = 0;
+        let entries = std::fs::read_dir(&self.base).map_err(|error| StoreError::Io {
+            path: self
+                .base
+                .clone(),
+            error,
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| StoreError::Io {
+                path: self
+                    .base
+                    .clone(),
+                error,
+            })?;
+            if let Some(name) = entry
+                .file_name()
+                .to_str()
+            {
+                if let Ok(n) = name.parse::<u32>() {
+                    if n > max {
+                        max = n;
+                    }
+                }
+            }
+        }
+        Ok(RunId(max + 1))
+    }
+}
+
+// Recover the source document's file path and the libraries that were
+// selected from a Start URI of the form
+//
+// file://{path}?library=a,b
+
+// written by `create` records. The query string parameters are optional.
+pub(crate) fn parse_run_uri(uri: &str) -> (PathBuf, Vec<String>) {
+    let (location, query) = match uri.split_once('?') {
+        Some((location, query)) => (location, Some(query)),
+        None => (uri, None),
+    };
+    let path = location
+        .strip_prefix("file://")
+        .unwrap_or(location);
+    let libraries = query
+        .and_then(|query| query.strip_prefix("library="))
+        .map(|names| {
+            names
+                .split(',')
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    (PathBuf::from(path), libraries)
+}
+
+// Compute the on-disk PFFTT file path for a run, named using the source
+// document's stem.
+pub(crate) fn construct_state_path(run_dir: &Path, document: &Path) -> PathBuf {
+    let stem = document
+        .file_stem()
+        .map(|s| s.to_os_string())
+        .unwrap_or_default();
+    let mut name = PathBuf::from(stem);
+    name.set_extension("pfftt");
+    run_dir.join(name)
+}
+
+/// Where an `Appender` sends its records, normally an append-only PFFTT file
+/// in the store, or an in-memory sink for test runs that keep no persistent
+/// state.
+enum Target {
+    File { file: std::fs::File, path: PathBuf },
+    Memory(String),
+    Discard,
+}
+
+/// Append-only writer for a PFFTT file. Used by the runner to append a
+/// record for each step boundary and lifecycle event. Carries the
+/// `RunId` so callers can stamp it onto records.
+/// through every layer.
+#[allow(dead_code)]
+pub struct Appender {
+    target: Target,
+    run_id: RunId,
+}
+
+#[allow(dead_code)]
+impl Appender {
+    /// Open the PFFTT file for append. The file must already exist (the
+    /// runner writes the opening `Start` record first via `Store::create`).
+    pub fn open(path: PathBuf, run_id: RunId) -> Result<Self, StoreError> {
+        let file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .map_err(|error| StoreError::Io {
+                path: path.clone(),
+                error,
+            })?;
+        Ok(Appender {
+            target: Target::File { file, path },
+            run_id,
+        })
+    }
+
+    /// An Appender that discards every record for use in tests.
+    pub fn sink() -> Self {
+        Appender {
+            target: Target::Discard,
+            run_id: RunId(0),
+        }
+    }
+
+    /// An Appender that captures every record in memory for use in tests,
+    /// readable afterwards with `contents()`. Touches no filesystem.
+    pub fn memory() -> Self {
+        Appender {
+            target: Target::Memory(String::new()),
+            run_id: RunId(0),
+        }
+    }
+
+    /// The records captured by an in-memory Appender (`memory()`), as the raw
+    /// PFFTT text; empty for a file or discarding Appender.
+    pub fn contents(&self) -> &str {
+        match &self.target {
+            Target::Memory(buffer) => buffer,
+            _ => "",
+        }
+    }
+
+    /// The `RunId` this Appender is writing records for.
+    pub fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    /// Append one record line. Flushes are left to the OS; on Quit the
+    /// runner drops the Appender, which closes the file.
+    pub fn append(&mut self, record: &Record) -> Result<(), StoreError> {
+        use std::io::Write;
+        let text = format_record(record);
+        match &mut self.target {
+            Target::File { file, path } => file
+                .write_all(text.as_bytes())
+                .map_err(|error| StoreError::Io {
+                    path: path.clone(),
+                    error,
+                }),
+            Target::Memory(buffer) => {
+                buffer.push_str(&text);
+                Ok(())
+            }
+            Target::Discard => Ok(()),
+        }
+    }
+}
+
+// Locate the single `*.pfftt` file in a run directory.
+fn find_pfftt_file(run_dir: &Path, run_id: RunId) -> Result<PathBuf, StoreError> {
+    let entries = std::fs::read_dir(run_dir).map_err(|error| StoreError::Io {
+        path: run_dir.to_path_buf(),
+        error,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| StoreError::Io {
+            path: run_dir.to_path_buf(),
+            error,
+        })?;
+        let path = entry.path();
+        if path
+            .extension()
+            .and_then(|s| s.to_str())
+            == Some("pfftt")
+        {
+            return Ok(path);
+        }
+    }
+    Err(StoreError::StartMissing(run_id))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod domain;
+pub mod engraving;
 pub mod formatting;
 pub mod highlighting;
 pub mod language;
@@ -6,6 +7,7 @@ pub mod linking;
 pub mod parsing;
 pub mod program;
 pub(crate) mod regex;
+pub mod reporting;
 pub mod resolution;
 pub mod runner;
 pub mod templating;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::builder::{PossibleValue, TypedValueParser};
+use clap::builder::{PossibleValue, PossibleValuesParser, TypedValueParser};
 use clap::value_parser;
 use clap::{Arg, ArgAction, Command};
 use owo_colors::OwoColorize;
@@ -118,6 +118,34 @@ impl TypedValueParser for PaperSizeParser {
     fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
         Some(Box::new(
             ["a4", "a5", "letter", "WxH"]
+                .into_iter()
+                .map(PossibleValue::new),
+        ))
+    }
+}
+
+// Custom clap parser so `--columns` yields Columns rather than names, with the
+// column vocabulary itself listed under "possible values" in help output.
+#[derive(Clone)]
+struct ColumnNameParser;
+
+impl TypedValueParser for ColumnNameParser {
+    type Value = Column;
+
+    fn parse_ref(
+        &self,
+        cmd: &Command,
+        arg: Option<&Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        PossibleValuesParser::new(Column::names())
+            .parse_ref(cmd, arg, value)
+            .map(|name: String| Column::parse(&name))
+    }
+
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+        Some(Box::new(
+            Column::names()
                 .into_iter()
                 .map(PossibleValue::new),
         ))
@@ -433,7 +461,7 @@ fn main() {
                     Arg::new("columns")
                         .long("columns")
                         .value_name("name,...")
-                        .value_parser(["timestamp", "run", "date", "time", "offset", "duration", "path", "short", "state", "value"])
+                        .value_parser(ColumnNameParser)
                         .value_delimiter(',')
                         .action(ArgAction::Set)
                         .help("Specify the fields of the PFFTT record to show, overriding the default associated with the chosen --output format. \
@@ -1183,7 +1211,7 @@ fn main() {
             // Each output form selects the columns that suit it; --columns,
             // when given, overrides that choice. PFFTT is the exception: its
             // fields are defined by the format.
-            let selected = submatches.get_many::<String>("columns");
+            let selected = submatches.get_many::<Column>("columns");
             let columns: Vec<Column> = match (selected, &output) {
                 (Some(_), Output::Store) => {
                     eprintln!(
@@ -1193,7 +1221,7 @@ fn main() {
                     std::process::exit(1);
                 }
                 (Some(names), _) => names
-                    .map(|name| Column::parse(name))
+                    .copied()
                     .collect(),
                 (None, Output::Json) => reporting::JSON_COLUMNS.to_vec(),
                 (None, Output::Store) => reporting::PFFTT_COLUMNS.to_vec(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,14 @@ use std::str::FromStr;
 use tracing::debug;
 use tracing_subscriber::{self, EnvFilter};
 
+use technique::engraving::RunId;
 use technique::formatting::{self, Identity};
 use technique::highlighting::{self, Terminal};
 use technique::linking;
-use technique::logging::{self, Column};
 use technique::parsing;
+use technique::reporting::{self, Column};
 use technique::resolution;
-use technique::runner::{self, Builtin, Conclusion, Library, Mode, Outcome, RunId};
+use technique::runner::{self, Builtin, Conclusion, Library, Mode, Outcome};
 use technique::templating::{self, Checklist, NasaEsaIss, Procedure, Recipe, Source};
 use technique::translation;
 
@@ -1038,7 +1039,7 @@ fn main() {
             let run_id = match RunId::parse(id) {
                 Ok(run_id) => run_id,
                 Err(error) => {
-                    eprintln!("{}", problem::concise_runner_error(&error, &Terminal));
+                    eprintln!("{}", problem::concise_store_error(&error, &Terminal));
                     std::process::exit(1);
                 }
             };
@@ -1161,7 +1162,7 @@ fn main() {
             let run_id = match RunId::parse(id) {
                 Ok(run_id) => run_id,
                 Err(error) => {
-                    eprintln!("{}", problem::concise_runner_error(&error, &Terminal));
+                    eprintln!("{}", problem::concise_store_error(&error, &Terminal));
                     std::process::exit(1);
                 }
             };
@@ -1194,9 +1195,9 @@ fn main() {
                 (Some(names), _) => names
                     .map(|name| Column::parse(name))
                     .collect(),
-                (None, Output::Json) => logging::JSON_COLUMNS.to_vec(),
-                (None, Output::Store) => logging::PFFTT_COLUMNS.to_vec(),
-                (None, _) => logging::CONSOLE_COLUMNS.to_vec(),
+                (None, Output::Json) => reporting::JSON_COLUMNS.to_vec(),
+                (None, Output::Store) => reporting::PFFTT_COLUMNS.to_vec(),
+                (None, _) => reporting::CONSOLE_COLUMNS.to_vec(),
             };
 
             debug!(?columns);
@@ -1205,7 +1206,7 @@ fn main() {
                 .get_one::<bool>("raw-control-chars")
                 .unwrap(); // flags are always present since SetTrue implies default_value
 
-            let (_, records) = match runner::review(run_id) {
+            let records = match runner::load(run_id) {
                 Ok(recorded) => recorded,
                 Err(error) => {
                     eprintln!("{}", problem::concise_runner_error(&error, &Terminal));
@@ -1215,19 +1216,19 @@ fn main() {
 
             match output {
                 Output::Store => {
-                    print!("{}", logging::render_pfftt(&records));
+                    print!("{}", reporting::render_pfftt(&records));
                 }
                 Output::Native => {
                     println!("{:#?}", records);
                 }
                 Output::Json => {
-                    print!("{}", logging::render_json(&records, &columns));
+                    print!("{}", reporting::render_json(&records, &columns));
                 }
                 _ => {
                     let result = if raw_output || std::io::stdout().is_terminal() {
-                        logging::render_console(&records, &columns, &Terminal)
+                        reporting::render_console(&records, &columns, &Terminal)
                     } else {
-                        logging::render_console(&records, &columns, &Identity)
+                        reporting::render_console(&records, &columns, &Identity)
                     };
                     print!("{}", result);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::{self, EnvFilter};
 use technique::formatting::{self, Identity};
 use technique::highlighting::{self, Terminal};
 use technique::linking;
+use technique::logging::{self, Column};
 use technique::parsing;
 use technique::resolution;
 use technique::runner::{self, Builtin, Conclusion, Library, Mode, Outcome, RunId};
@@ -28,6 +29,7 @@ enum Output {
     Native,
     Silent,
     Store,
+    Json,
 }
 
 #[derive(Eq, Debug, PartialEq)]
@@ -401,6 +403,55 @@ fn main() {
                     Arg::new("id")
                         .required(true)
                         .help("The identifier of the run to continue. Can be written as `000007` or just `7`."),
+                ),
+        )
+        .subcommand(
+            Command::new("log")
+                .about("Print the trace recorded for a procedure run.")
+                .long_about("Print the trace recorded when a Technique procedure was run. \
+                    Each line is one recorded event: entering a step, executing a command, \
+                    and the result the step settled on. Times are relative to the start of \
+                    the run, which is given in the heading.")
+                .arg(
+                    Arg::new("id")
+                        .required(true)
+                        .help("The identifier of the run to print. Can be written as `000007` or just `7`."),
+                )
+                .arg(
+                    Arg::new("output")
+                        .long("output")
+                        .value_parser(["console", "json", "pfftt", "native"])
+                        .default_value("console")
+                        .action(ArgAction::Set)
+                        .help("Change the output format. The default is to print a human-readable version of the trace to the terminal. \
+                            Other formats include a JSON array, with one object per record line; \
+                            the raw Procedure interchange Format For Transferring Techniques record lines as they are stored on disk; \
+                            or, (for debugging) the internal data structures the records were parsed back into)."),
+                )
+                .arg(
+                    Arg::new("columns")
+                        .long("columns")
+                        .value_name("name,...")
+                        .value_parser(["timestamp", "run", "date", "time", "offset", "duration", "path", "short", "state", "value"])
+                        .value_delimiter(',')
+                        .action(ArgAction::Set)
+                        .help("Specify the fields of the PFFTT record to show, overriding the default associated with the chosen --output format. \
+                            `timestamp` is the ISO 8601 start time of the event, in UTC. \
+                            `run` is the identifier of the run the record belongs to. \
+                            `date` and `time` are the start date and time respectively, shown in the local timezone. \
+                            `offset` gives the elapsed time since the beginning of the run, and \
+                            `duration` shows the amount of time taken by a completed step or scope. \
+                            `path` is the fully qualified path to the step, scope, or iteration. \
+                            `short` is the abbreviated version of the path as shown by the runner when executing a procedure. \
+                            `state` lists the kind of record line, and \
+                            `value` gives the result of a step or data associated with that line."),
+                )
+                .arg(
+                    Arg::new("raw-control-chars")
+                        .short('R')
+                        .long("raw-control-chars")
+                        .action(ArgAction::SetTrue)
+                        .help("Emit ANSI escape codes for syntax highlighting even if output is redirected to a pipe or file."),
                 ),
         )
         .subcommand(
@@ -1097,6 +1148,88 @@ fn main() {
                 Err(error) => {
                     eprintln!("{}", problem::concise_runner_error(&error, &Terminal));
                     std::process::exit(1);
+                }
+            }
+        }
+        Some(("log", submatches)) => {
+            let id = submatches
+                .get_one::<String>("id")
+                .unwrap();
+
+            debug!(id);
+
+            let run_id = match RunId::parse(id) {
+                Ok(run_id) => run_id,
+                Err(error) => {
+                    eprintln!("{}", problem::concise_runner_error(&error, &Terminal));
+                    std::process::exit(1);
+                }
+            };
+
+            let output = submatches
+                .get_one::<String>("output")
+                .unwrap();
+            let output = match output.as_str() {
+                "console" => Output::Terminal,
+                "json" => Output::Json,
+                "pfftt" => Output::Store,
+                "native" => Output::Native,
+                _ => panic!("Unrecognized --output value"),
+            };
+
+            debug!(?output);
+
+            // Each output form selects the columns that suit it; --columns,
+            // when given, overrides that choice. PFFTT is the exception: its
+            // fields are defined by the format.
+            let selected = submatches.get_many::<String>("columns");
+            let columns: Vec<Column> = match (selected, &output) {
+                (Some(_), Output::Store) => {
+                    eprintln!(
+                        "{}: --columns cannot be used with --output=pfftt",
+                        "error".bright_red()
+                    );
+                    std::process::exit(1);
+                }
+                (Some(names), _) => names
+                    .map(|name| Column::parse(name))
+                    .collect(),
+                (None, Output::Json) => logging::JSON_COLUMNS.to_vec(),
+                (None, Output::Store) => logging::PFFTT_COLUMNS.to_vec(),
+                (None, _) => logging::CONSOLE_COLUMNS.to_vec(),
+            };
+
+            debug!(?columns);
+
+            let raw_output = *submatches
+                .get_one::<bool>("raw-control-chars")
+                .unwrap(); // flags are always present since SetTrue implies default_value
+
+            let (_, records) = match runner::review(run_id) {
+                Ok(recorded) => recorded,
+                Err(error) => {
+                    eprintln!("{}", problem::concise_runner_error(&error, &Terminal));
+                    std::process::exit(1);
+                }
+            };
+
+            match output {
+                Output::Store => {
+                    print!("{}", logging::render_pfftt(&records));
+                }
+                Output::Native => {
+                    println!("{:#?}", records);
+                }
+                Output::Json => {
+                    print!("{}", logging::render_json(&records, &columns));
+                }
+                _ => {
+                    let result = if raw_output || std::io::stdout().is_terminal() {
+                        logging::render_console(&records, &columns, &Terminal)
+                    } else {
+                        logging::render_console(&records, &columns, &Identity)
+                    };
+                    print!("{}", result);
                 }
             }
         }

--- a/src/problem/format.rs
+++ b/src/problem/format.rs
@@ -1,12 +1,13 @@
 use super::messages::{
     generate_error_message, generate_linking_error, generate_resolution_error,
-    generate_runner_error, generate_translation_error,
+    generate_runner_error, generate_store_error, generate_translation_error,
 };
 use owo_colors::OwoColorize;
 use std::path::Path;
 use technique::{
-    formatting::Render, language::LoadingError, linking::LinkingError, parsing::ParsingError,
-    resolution::ResolutionError, runner::RunnerError, translation::TranslationError,
+    engraving::StoreError, formatting::Render, language::LoadingError, linking::LinkingError,
+    parsing::ParsingError, resolution::ResolutionError, runner::RunnerError,
+    translation::TranslationError,
 };
 
 /// Render an error with full source context: a header line, the offending
@@ -233,6 +234,12 @@ pub fn concise_linking_error<'i>(
 /// Format a runner error with concise single-line output.
 pub fn concise_runner_error(error: &RunnerError, renderer: &impl Render) -> String {
     let (problem, _) = generate_runner_error(error, renderer);
+    format!("{}: {}", "error".bright_red(), problem.bold())
+}
+
+/// Format a StoreError with concise single-line output
+pub fn concise_store_error(error: &StoreError, renderer: &impl Render) -> String {
+    let (problem, _) = generate_store_error(error, renderer);
     format!("{}: {}", "error".bright_red(), problem.bold())
 }
 

--- a/src/problem/messages.rs
+++ b/src/problem/messages.rs
@@ -1,7 +1,8 @@
 use crate::problem::Present;
 use technique::{
-    formatting::Render, language::*, linking::LinkingError, parsing::ParsingError,
-    resolution::ResolutionError, runner::RunnerError, translation::TranslationError,
+    engraving::StoreError, formatting::Render, language::*, linking::LinkingError,
+    parsing::ParsingError, resolution::ResolutionError, runner::RunnerError,
+    translation::TranslationError,
 };
 
 /// Generate problem and detail messages for parsing errors using AST construction
@@ -1467,24 +1468,24 @@ functions calls:
     }
 }
 
-/// Generate problem and detail messages for errors occurring when a procedure
-/// is being evaluated by the runner.
-pub fn generate_runner_error(error: &RunnerError, _renderer: &dyn Render) -> (String, String) {
+/// Generate problem and detail messages for errors reading from or writing to
+/// the store of recorded runs.
+pub fn generate_store_error(error: &StoreError, _renderer: &dyn Render) -> (String, String) {
     match error {
-        RunnerError::NoSuchRun(run_id) => (
+        StoreError::NoSuchRun(run_id) => (
             format!("No such run '{:06}'", run_id.0),
             "The directory for this run identifier was not found in the local state store."
                 .to_string(),
         ),
-        RunnerError::StoreError { path, error } => (
+        StoreError::Io { path, error } => (
             format!("I/O error with local state store at {}", path.display()),
             format!("{}", error),
         ),
-        RunnerError::MalformedRecord { run_id, .. } => (
+        StoreError::MalformedRecord { run_id, .. } => (
             format!("Malformed record for run '{:06}'", run_id.0),
             "The PFFTT state file for this run could not be parsed.".to_string(),
         ),
-        RunnerError::StartMissing(run_id) => (
+        StoreError::StartMissing(run_id) => (
             format!("Start record missing in run '{:06}'", run_id.0),
             r#"
 The state file is present but its first record (the Start event) is
@@ -1493,7 +1494,7 @@ missing or malformed.
             .trim_ascii()
             .to_string(),
         ),
-        RunnerError::InvalidRunId(text) => (
+        StoreError::InvalidRunId(text) => (
             format!("Invalid run identifier '{}'", text),
             r#"
 Run identifiers are integer values, conventionally rendered as six
@@ -1502,6 +1503,14 @@ zero-padded digits.
             .trim_ascii()
             .to_string(),
         ),
+    }
+}
+
+/// Generate problem and detail messages for errors occurring when a procedure
+/// is being evaluated by the runner.
+pub fn generate_runner_error(error: &RunnerError, _renderer: &dyn Render) -> (String, String) {
+    match error {
+        RunnerError::Store(error) => generate_store_error(error, _renderer),
         RunnerError::MissingEntryProcedure => (
             "No entry procedure".to_string(),
             r#"

--- a/src/reporting/checks/column.rs
+++ b/src/reporting/checks/column.rs
@@ -1,0 +1,285 @@
+use crate::engraving::{InvokeTarget, Record, RunId, State, Supplied};
+use crate::formatting::Identity;
+use crate::reporting::{Column, render_console, render_json};
+use crate::value::Value;
+
+fn record(recorded: &str, path: &str, state: State) -> Record {
+    Record {
+        recorded: recorded.to_string(),
+        run_id: RunId(7),
+        path: path.to_string(),
+        state,
+    }
+}
+
+fn trail() -> Vec<Record> {
+    vec![
+        record(
+            "2026-08-04T22:50:36.869Z",
+            "/",
+            State::Start {
+                uri: "file:///tmp/NetworkProbe.tq".to_string(),
+            },
+        ),
+        record(
+            "2026-08-04T22:50:36.870Z",
+            "/connectivity_check:",
+            State::Begin,
+        ),
+        record(
+            "2026-08-04T22:50:40.546Z",
+            "/connectivity_check:",
+            State::Done(Some(Value::Unitus)),
+        ),
+        record("2026-08-04T22:50:40.546Z", "/", State::Finish),
+    ]
+}
+
+// The heading carries the run and the document; the wall clock time it goes on
+// to give is in the local zone, so only its lead-in is pinned here.
+#[test]
+fn heading_names_the_run() {
+    let text = render_console(&trail(), &[Column::Short], &Identity);
+    let heading = text
+        .lines()
+        .next()
+        .unwrap();
+
+    assert!(heading.starts_with("NetworkProbe #000007 started "));
+}
+
+#[test]
+fn columns_align_in_the_order_given() {
+    let columns = [Column::Short, Column::Offset, Column::State, Column::Value];
+    let text = render_console(&trail(), &columns, &Identity);
+    let body: Vec<&str> = text
+        .lines()
+        .skip(2)
+        .collect();
+
+    assert_eq!(
+        body[0],
+        "/                         +0.0  Start   file:///tmp/NetworkProbe.tq"
+    );
+    assert_eq!(body[1], "connectivity_check:       +0.0  Begin");
+    assert_eq!(body[2], "connectivity_check:       +3.7  Done    ()");
+    assert_eq!(body[3], "/                         +3.7  Finish");
+}
+
+// The short column keeps a fixed width whatever the run contains, so the
+// columns beyond it stand in the same place from one run to the next. A step
+// named more deeply than that is cut at the front, keeping the tail.
+#[test]
+fn deep_paths_are_elided_at_the_front() {
+    let records = vec![
+        record(
+            "2026-08-04T22:50:36.869Z",
+            "/",
+            State::Start {
+                uri: "file:///tmp/NetworkProbe.tq".to_string(),
+            },
+        ),
+        record(
+            "2026-08-04T22:50:36.870Z",
+            "/connectivity_check:/VII/service_endpoint:/7/a",
+            State::Skip,
+        ),
+    ];
+    let columns = [Column::Short, Column::State];
+    let text = render_console(&records, &columns, &Identity);
+    let body: Vec<&str> = text
+        .lines()
+        .skip(2)
+        .collect();
+
+    assert_eq!(body[0], "/                         Start");
+    assert_eq!(body[1], "…I/service_endpoint:/7/a  Skip");
+}
+
+// A duration is how long a scope stayed open, and it is shown on the record
+// that closed it, beside the verdict: the Done paired with its Begin, the
+// Finish with the run's Start. The opening records carry none of their own.
+#[test]
+fn durations_fall_on_the_record_that_closed_the_scope() {
+    let columns = [Column::Duration, Column::Short, Column::State];
+    let text = render_console(&trail(), &columns, &Identity);
+    let body: Vec<&str> = text
+        .lines()
+        .skip(2)
+        .collect();
+
+    assert_eq!(body[0], "       /                         Start");
+    assert_eq!(body[1], "       connectivity_check:       Begin");
+    assert_eq!(body[2], "3.676  connectivity_check:       Done");
+    assert_eq!(body[3], "3.677  /                         Finish");
+}
+
+// The inputs a procedure was given close the asking for them, so an
+// invocation that had to wait on the user shows what that wait cost.
+#[test]
+fn inputs_carry_the_wait_to_supply_them() {
+    let records = vec![
+        record(
+            "2026-08-04T22:50:36.869Z",
+            "/",
+            State::Start {
+                uri: "file:///tmp/NetworkProbe.tq".to_string(),
+            },
+        ),
+        record(
+            "2026-08-04T22:50:36.869Z",
+            "/decomission_customer:/I",
+            State::Invoke(InvokeTarget::Procedure("delete_resources".to_string())),
+        ),
+        record(
+            "2026-08-04T22:50:45.615Z",
+            "/decomission_customer:/I/delete_resources:",
+            State::Input(vec![Supplied {
+                value: Value::Literali("Rebecca".to_string()),
+                name: Some("authority".to_string()),
+            }]),
+        ),
+        record(
+            "2026-08-04T22:50:45.615Z",
+            "/decomission_customer:/I/delete_resources:",
+            State::Begin,
+        ),
+    ];
+    let columns = [Column::Duration, Column::State];
+    let text = render_console(&records, &columns, &Identity);
+    let body: Vec<&str> = text
+        .lines()
+        .skip(2)
+        .collect();
+
+    assert_eq!(body[1], "       Invoke");
+    assert_eq!(body[2], "8.746  Input");
+}
+
+// An Execute is closed by the Return that carries what the host call produced,
+// so the Execute is where how long the call took is shown.
+#[test]
+fn executions_are_spanned_by_their_return() {
+    let records = vec![
+        record(
+            "2026-08-04T22:50:36.869Z",
+            "/",
+            State::Start {
+                uri: "file:///tmp/NetworkProbe.tq".to_string(),
+            },
+        ),
+        record(
+            "2026-08-04T22:50:36.870Z",
+            "/connectivity_check:/1",
+            State::Execute {
+                function: "exec".to_string(),
+            },
+        ),
+        record(
+            "2026-08-04T22:50:40.546Z",
+            "/connectivity_check:/1",
+            State::Return(Some(Value::Literali("done".to_string()))),
+        ),
+    ];
+    let columns = [Column::Short, Column::Duration, Column::State];
+    let text = render_console(&records, &columns, &Identity);
+    let body: Vec<&str> = text
+        .lines()
+        .skip(2)
+        .collect();
+
+    assert_eq!(body[1], "connectivity_check:/1            Execute");
+    assert_eq!(body[2], "connectivity_check:/1     3.676  Return");
+}
+
+// The fields come out in the order the columns were asked for, elapsed times
+// as seconds, and a record with nothing for a column gets null.
+#[test]
+fn json_carries_one_field_per_column() {
+    let columns = [Column::Short, Column::Duration, Column::State];
+    let text = render_json(&trail(), &columns);
+    let body: Vec<&str> = text
+        .lines()
+        .collect();
+
+    assert_eq!(body[0], "[");
+    assert_eq!(body[1], "  {");
+    assert_eq!(body[2], "    \"short\": \"/\",");
+    assert_eq!(body[3], "    \"duration\": null,");
+    assert_eq!(body[4], "    \"state\": \"Start\"");
+    assert_eq!(body[5], "  },");
+    assert_eq!(body[13], "    \"duration\": 3.676,");
+    assert_eq!(body[21], "]");
+}
+
+// The recorded forms, kept whole: the UTC instant the run wrote, and the path
+// as it appears in the file rather than the abbreviation the runner shows.
+#[test]
+fn timestamp_and_path_are_as_recorded() {
+    let columns = [Column::Timestamp, Column::Path, Column::State];
+    let text = render_console(&trail(), &columns, &Identity);
+    let body: Vec<&str> = text
+        .lines()
+        .skip(2)
+        .collect();
+
+    assert_eq!(
+        body[0],
+        "2026-08-04T22:50:36.869Z  /                     Start"
+    );
+    assert_eq!(
+        body[1],
+        "2026-08-04T22:50:36.870Z  /connectivity_check:  Begin"
+    );
+}
+
+// The keyword and the payload that followed it in the record occupy columns of
+// their own, so a run can be read for its shape or for its values.
+#[test]
+fn state_and_value_are_separate_columns() {
+    let records = vec![
+        record(
+            "2026-08-04T22:50:36.869Z",
+            "/",
+            State::Start {
+                uri: "file:///tmp/NetworkProbe.tq".to_string(),
+            },
+        ),
+        record(
+            "2026-08-04T22:50:36.870Z",
+            "/connectivity_check:",
+            State::Input(vec![Supplied {
+                value: Value::Quanticle(crate::value::Numeric::Integral(0)),
+                name: Some("s".to_string()),
+            }]),
+        ),
+        record(
+            "2026-08-04T22:50:36.871Z",
+            "/connectivity_check:/1",
+            State::Execute {
+                function: "exec".to_string(),
+            },
+        ),
+        record(
+            "2026-08-04T22:50:36.872Z",
+            "/connectivity_check:/1",
+            State::Fail(Some(Value::Literali("unreachable".to_string()))),
+        ),
+    ];
+    let columns = [Column::State, Column::Value];
+    let text = render_console(&records, &columns, &Identity);
+    let body: Vec<&str> = text
+        .lines()
+        .skip(2)
+        .collect();
+
+    assert_eq!(body[0], "Start    file:///tmp/NetworkProbe.tq");
+    assert_eq!(body[1], "Input    ( 0 ~ s )");
+    assert_eq!(body[2], "Execute  exec()");
+    assert_eq!(body[3], "Fail     \"unreachable\"");
+}
+
+#[test]
+fn empty_trail_renders_nothing() {
+    assert_eq!(render_console(&[], &[Column::Short], &Identity), "");
+}

--- a/src/reporting/column.rs
+++ b/src/reporting/column.rs
@@ -64,24 +64,38 @@ pub enum Column {
 }
 
 impl Column {
+    /// Every column, in the order they are offered to the user.
+    pub const ALL: [Column; 10] = [
+        Column::Timestamp,
+        Column::Run,
+        Column::Date,
+        Column::Time,
+        Column::Offset,
+        Column::Duration,
+        Column::Path,
+        Column::Short,
+        Column::State,
+        Column::Value,
+    ];
+
+    /// The names `--columns` accepts, for the command-line parser to offer.
+    pub fn names() -> [&'static str; 10] {
+        Column::ALL.map(|column| column.name())
+    }
+
     pub fn parse(name: &str) -> Column {
-        match name {
-            "timestamp" => Column::Timestamp,
-            "run" => Column::Run,
-            "date" => Column::Date,
-            "time" => Column::Time,
-            "offset" => Column::Offset,
-            "duration" => Column::Duration,
-            "path" => Column::Path,
-            "short" => Column::Short,
-            "state" => Column::State,
-            "value" => Column::Value,
+        match Column::ALL
+            .into_iter()
+            .find(|column| column.name() == name)
+        {
+            Some(column) => column,
             // the command-line parser restricts which names reach us
-            _ => unreachable!(),
+            None => unreachable!(),
         }
     }
 
-    /// Field names for JSON.
+    /// The name of this column, both as the value that `--columns` accepts
+    /// and for the field label in JSON objects.
     pub fn name(&self) -> &'static str {
         match self {
             Column::Timestamp => "timestamp",

--- a/src/reporting/column.rs
+++ b/src/reporting/column.rs
@@ -1,0 +1,620 @@
+//! Rendering of the trail recorded for a completed or interrupted run.
+
+use std::collections::HashMap;
+
+use time::{Date, Month, OffsetDateTime, UtcOffset};
+
+use crate::engraving::{
+    InvokeTarget, Record, State, display_path, format_record, format_supplied, parse_run_uri,
+    serialize_value,
+};
+use crate::formatting::{Render, Syntax};
+
+// The short column is held to this width so that the columns after it fall in
+// the same place from one run to the next. A path deeper than this is elided;
+// the path column, being the name as recorded, is never cut.
+const SHORT_WIDTH: usize = 24;
+
+/// The columns shown in the console by default.
+pub const CONSOLE_COLUMNS: [Column; 6] = [
+    Column::Time,
+    Column::Offset,
+    Column::Duration,
+    Column::Path,
+    Column::State,
+    Column::Value,
+];
+
+/// The fields a PFFTT record line carries, in the order they are written.
+/// Fixed: a line missing any of them does not parse back.
+pub const PFFTT_COLUMNS: [Column; 5] = [
+    Column::Timestamp,
+    Column::Run,
+    Column::Path,
+    Column::State,
+    Column::Value,
+];
+
+/// The columns shown by default when outputting JSON.
+pub const JSON_COLUMNS: [Column; 6] = [
+    Column::Timestamp,
+    Column::Offset,
+    Column::Duration,
+    Column::Path,
+    Column::State,
+    Column::Value,
+];
+
+/// Available raw data (such as `timestamp`, fully qualified `path`, and
+/// `state`) plus derived fields (such as `offset`, `duration`, and the
+/// `short` version of the path).
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Column {
+    Timestamp,
+    Run,
+    Date,
+    Time,
+    Offset,
+    Duration,
+    Path,
+    Short,
+    State,
+    Value,
+}
+
+impl Column {
+    pub fn parse(name: &str) -> Column {
+        match name {
+            "timestamp" => Column::Timestamp,
+            "run" => Column::Run,
+            "date" => Column::Date,
+            "time" => Column::Time,
+            "offset" => Column::Offset,
+            "duration" => Column::Duration,
+            "path" => Column::Path,
+            "short" => Column::Short,
+            "state" => Column::State,
+            "value" => Column::Value,
+            // the command-line parser restricts which names reach us
+            _ => unreachable!(),
+        }
+    }
+
+    /// Field names for JSON.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Column::Timestamp => "timestamp",
+            Column::Run => "run",
+            Column::Date => "date",
+            Column::Time => "time",
+            Column::Offset => "offset",
+            Column::Duration => "duration",
+            Column::Path => "path",
+            Column::Short => "short",
+            Column::State => "state",
+            Column::Value => "value",
+        }
+    }
+
+    // Elapsed times and other variable width numbers are right-alighned.
+    fn aligned_right(&self) -> bool {
+        match self {
+            Column::Offset | Column::Duration => true,
+            _ => false,
+        }
+    }
+
+    fn fixed(&self) -> Option<usize> {
+        match self {
+            Column::Short => Some(SHORT_WIDTH),
+            _ => None,
+        }
+    }
+}
+
+/// The content of one column before it is embellished for the console,
+/// serialized to JSON, etc.
+enum Cell {
+    Text(String),
+    Millis(i64),
+    Empty,
+}
+
+/// Render a run's records as a column-aligned stream, one line per record.
+pub fn render_console(records: &[Record], columns: &[Column], renderer: &dyn Render) -> String {
+    let mut text = String::new();
+
+    let first = match records.first() {
+        Some(first) => first,
+        None => return text,
+    };
+
+    let zone = local_offset();
+    let (stamps, spans) = measure_times(records);
+
+    render_heading(&mut text, first, zone, renderer);
+
+    let rows: Vec<Vec<(Syntax, String)>> = records
+        .iter()
+        .enumerate()
+        .map(|(i, record)| {
+            columns
+                .iter()
+                .map(|column| {
+                    let cell = extract(record, *column, stamps[i], stamps[0], spans[i], zone);
+                    (tint(*column, &record.state), shown(cell, *column))
+                })
+                .collect()
+        })
+        .collect();
+
+    let widths = measure(&rows, columns);
+
+    for row in &rows {
+        let mut line = String::new();
+        for (i, (syntax, cell)) in row
+            .iter()
+            .enumerate()
+        {
+            let padding = widths[i].saturating_sub(
+                cell.chars()
+                    .count(),
+            );
+            if columns[i].aligned_right() {
+                pad(&mut line, padding);
+            }
+            line.push_str(&renderer.style(*syntax, cell));
+            if i + 1 < row.len() {
+                if !columns[i].aligned_right() {
+                    pad(&mut line, padding);
+                }
+                line.push_str("  ");
+            }
+        }
+        // trim trailing padding if there was no value
+        text.push_str(line.trim_end());
+        text.push('\n');
+    }
+
+    text
+}
+
+/// Render a run's records as an array of JSON objects, one per record with a
+/// field per column, laid out over lines the way a person would indent it.
+/// Elapsed times are given as seconds, and a column a record has nothing for
+/// is null.
+pub fn render_json(records: &[Record], columns: &[Column]) -> String {
+    if records.is_empty() {
+        return "[]\n".to_string();
+    }
+
+    let zone = local_offset();
+    let (stamps, spans) = measure_times(records);
+
+    let objects: Vec<String> = records
+        .iter()
+        .enumerate()
+        .map(|(i, record)| {
+            // written field by field rather than through a Map so that the
+            // fields come out in the order the columns were asked for
+            let fields: Vec<String> = columns
+                .iter()
+                .map(|column| {
+                    let cell = extract(record, *column, stamps[i], stamps[0], spans[i], zone);
+                    format!("    \"{}\": {}", column.name(), encode(cell))
+                })
+                .collect();
+            format!("  {{\n{}\n  }}", fields.join(",\n"))
+        })
+        .collect();
+
+    format!("[\n{}\n]\n", objects.join(",\n"))
+}
+
+/// Render records back to PFFTT, through the same writer the runner records
+/// with, so the text is the format by construction rather than by imitation.
+pub fn render_pfftt(records: &[Record]) -> String {
+    records
+        .iter()
+        .map(format_record)
+        .collect()
+}
+
+// The line above the stream: `NetworkProbe #000001 started ...`, taking the
+// document's name from the URI the opening Start record carries.
+fn render_heading(out: &mut String, first: &Record, zone: UtcOffset, renderer: &dyn Render) {
+    let label = match &first.state {
+        State::Start { uri } => {
+            let (document, _) = parse_run_uri(uri);
+            document
+                .file_stem()
+                .map(|stem| {
+                    stem.to_string_lossy()
+                        .into_owned()
+                })
+                .unwrap_or_default()
+        }
+        _ => String::new(),
+    };
+
+    let started = parse_timestamp(&first.recorded)
+        .and_then(|millis| format_stamp(millis, zone))
+        .unwrap_or_else(|| {
+            first
+                .recorded
+                .clone()
+        });
+
+    out.push_str(&renderer.style(
+        Syntax::Neutral,
+        &format!(
+            "{} #{}",
+            label,
+            first
+                .run_id
+                .render()
+        ),
+    ));
+    out.push_str(&renderer.style(Syntax::Marker, &format!(" started {}", started)));
+    out.push_str("\n\n");
+}
+
+// What one column holds for one record.
+fn extract(
+    record: &Record,
+    column: Column,
+    recorded: Option<i64>,
+    start: Option<i64>,
+    span: Option<i64>,
+    zone: UtcOffset,
+) -> Cell {
+    match column {
+        Column::Timestamp => Cell::Text(
+            record
+                .recorded
+                .clone(),
+        ),
+        Column::Run => Cell::Text(
+            record
+                .run_id
+                .render(),
+        ),
+        Column::Date => optional(recorded.and_then(|millis| format_date(millis, zone))),
+        Column::Time => optional(recorded.and_then(|millis| format_clock(millis, zone))),
+        Column::Offset => match elapsed(start, recorded) {
+            Some(millis) => Cell::Millis(millis),
+            None => Cell::Empty,
+        },
+        Column::Duration => match span {
+            Some(millis) => Cell::Millis(millis),
+            None => Cell::Empty,
+        },
+        Column::Path => Cell::Text(
+            record
+                .path
+                .clone(),
+        ),
+        Column::Short => Cell::Text(shortened(&record.path)),
+        Column::State => Cell::Text(keyword(&record.state).to_string()),
+        Column::Value => optional(payload(&record.state)),
+    }
+}
+
+// A cell dressed for the console: elapsed times to the precision each column
+// carries, and the short path cut to the width it is held at.
+fn shown(cell: Cell, column: Column) -> String {
+    match cell {
+        Cell::Text(text) => match column {
+            Column::Short => elide(text, SHORT_WIDTH),
+            _ => text,
+        },
+        // the leading `+` marks the offset as a position in the run rather
+        // than a length of time
+        Cell::Millis(millis) => match column {
+            Column::Offset => {
+                let tenths = (millis + 50) / 100;
+                format!("+{}.{}", tenths / 10, (tenths % 10).abs())
+            }
+            _ => format!("{}.{:03}", millis / 1000, (millis % 1000).abs()),
+        },
+        Cell::Empty => String::new(),
+    }
+}
+
+// A cell as JSON: elapsed times become seconds, and a cell the record has
+// nothing for becomes null.
+fn encode(cell: Cell) -> serde_json::Value {
+    match cell {
+        Cell::Text(text) => serde_json::Value::String(text),
+        Cell::Millis(millis) => match serde_json::Number::from_f64(millis as f64 / 1000.0) {
+            Some(number) => serde_json::Value::Number(number),
+            None => serde_json::Value::Null,
+        },
+        Cell::Empty => serde_json::Value::Null,
+    }
+}
+
+fn optional(text: Option<String>) -> Cell {
+    match text {
+        Some(text) if !text.is_empty() => Cell::Text(text),
+        _ => Cell::Empty,
+    }
+}
+
+// Each record's instant, and on each closing record the span back to its
+// opener: Done, Skip, and Fail from the Begin at the same path, Return from
+// its Execute, Finish and Stop from Start, and Input from the record before.
+fn measure_times(records: &[Record]) -> (Vec<Option<i64>>, Vec<Option<i64>>) {
+    let stamps: Vec<Option<i64>> = records
+        .iter()
+        .map(|record| parse_timestamp(&record.recorded))
+        .collect();
+
+    let mut spans = vec![None; records.len()];
+    let mut begun: HashMap<&str, usize> = HashMap::new();
+    let mut executing: HashMap<&str, usize> = HashMap::new();
+    let mut started: Option<usize> = None;
+
+    for (i, record) in records
+        .iter()
+        .enumerate()
+    {
+        let path = record
+            .path
+            .as_str();
+        match &record.state {
+            State::Start { .. } => {
+                started = Some(i);
+            }
+            State::Begin => {
+                begun.insert(path, i);
+            }
+            State::Execute { .. } => {
+                executing.insert(path, i);
+            }
+            State::Done(_) | State::Skip | State::Fail(_) => {
+                if let Some(opened) = begun.remove(path) {
+                    spans[i] = elapsed(stamps[opened], stamps[i]);
+                }
+            }
+            State::Return(_) => {
+                if let Some(opened) = executing.remove(path) {
+                    spans[i] = elapsed(stamps[opened], stamps[i]);
+                }
+            }
+            State::Finish | State::Stop => {
+                if let Some(opened) = started {
+                    spans[i] = elapsed(stamps[opened], stamps[i]);
+                }
+            }
+            // The inputs a procedure was given close the asking for them: the
+            // dispatch recorded on arrival, or the run's Start for the entry
+            // procedure's own parameters. Either way the span is the wait for
+            // the user to supply them.
+            State::Input(_) => {
+                if i > 0 {
+                    spans[i] = elapsed(stamps[i - 1], stamps[i]);
+                }
+            }
+            State::Resume | State::Invoke(_) => {}
+        }
+    }
+
+    (stamps, spans)
+}
+
+// The abbreviated path the live trace shows, except at the root, which trims
+// away to nothing and is shown as the `/` it is recorded as.
+fn shortened(path: &str) -> String {
+    let text = display_path(path);
+    if text.is_empty() {
+        return path.to_string();
+    }
+    text
+}
+
+// Hold text to a maximum width, cutting from the front: the tail of a path is
+// the step it names, so that is the end to keep.
+fn elide(text: String, width: usize) -> String {
+    let count = text
+        .chars()
+        .count();
+    if count <= width {
+        return text;
+    }
+    let mut out = String::from("…");
+    out.extend(
+        text.chars()
+            .skip(count - width + 1),
+    );
+    out
+}
+
+// The keyword written into the record.
+fn keyword(state: &State) -> &'static str {
+    match state {
+        State::Start { .. } => "Start",
+        State::Finish => "Finish",
+        State::Stop => "Stop",
+        State::Resume => "Resume",
+        State::Invoke(_) => "Invoke",
+        State::Execute { .. } => "Execute",
+        State::Return(_) => "Return",
+        State::Input(_) => "Input",
+        State::Begin => "Begin",
+        State::Done(_) => "Done",
+        State::Skip => "Skip",
+        State::Fail(_) => "Fail",
+    }
+}
+
+// What followed that keyword in the record, so the two can occupy columns of
+// their own.
+fn payload(state: &State) -> Option<String> {
+    match state {
+        State::Start { uri } => Some(uri.clone()),
+        State::Invoke(InvokeTarget::Procedure(name)) => Some(format!("{}:", name)),
+        State::Invoke(InvokeTarget::Uri(uri)) => Some(uri.clone()),
+        State::Execute { function } => Some(format!("{}()", function)),
+        State::Return(value) | State::Done(value) | State::Fail(value) => value
+            .as_ref()
+            .map(serialize_value),
+        State::Input(supplied) => {
+            let mut text = String::new();
+            format_supplied(&mut text, supplied);
+            Some(text)
+        }
+        State::Finish | State::Stop | State::Resume | State::Begin | State::Skip => None,
+    }
+}
+
+// The three states a step settles in are coloured as they are when the run
+// was live; everything else is structural.
+fn tint(column: Column, state: &State) -> Syntax {
+    match column {
+        Column::Path | Column::Short | Column::Value => Syntax::Neutral,
+        Column::State => match state {
+            State::Done(_) => Syntax::Done,
+            State::Skip => Syntax::Skip,
+            State::Fail(_) => Syntax::Fail,
+            _ => Syntax::Marker,
+        },
+        _ => Syntax::Marker,
+    }
+}
+
+// Column widths are the widest cell in each, except where the column declares
+// a width of its own; the last column is left to run on.
+fn measure(rows: &[Vec<(Syntax, String)>], columns: &[Column]) -> Vec<usize> {
+    let mut widths = Vec::new();
+    for row in rows {
+        for (i, (_, cell)) in row
+            .iter()
+            .enumerate()
+        {
+            let width = cell
+                .chars()
+                .count();
+            match widths.get_mut(i) {
+                Some(existing) => {
+                    if width > *existing {
+                        *existing = width;
+                    }
+                }
+                None => widths.push(width),
+            }
+        }
+    }
+    for (i, column) in columns
+        .iter()
+        .enumerate()
+    {
+        if let Some(fixed) = column.fixed() {
+            if let Some(width) = widths.get_mut(i) {
+                *width = fixed;
+            }
+        }
+    }
+    widths
+}
+
+fn pad(out: &mut String, count: usize) {
+    for _ in 0..count {
+        out.push(' ');
+    }
+}
+
+// Milliseconds between two instants, unknown if either is.
+fn elapsed(from: Option<i64>, to: Option<i64>) -> Option<i64> {
+    match (from, to) {
+        (Some(from), Some(to)) => Some(to - from),
+        _ => None,
+    }
+}
+
+// Milliseconds since the Unix epoch for a PFFTT timestamp of the form
+// 2026-08-04T22:50:36.869Z, as written when the record was appended.
+fn parse_timestamp(recorded: &str) -> Option<i64> {
+    let year = recorded
+        .get(0..4)?
+        .parse::<i32>()
+        .ok()?;
+    let month = recorded
+        .get(5..7)?
+        .parse::<u8>()
+        .ok()?;
+    let day = recorded
+        .get(8..10)?
+        .parse::<u8>()
+        .ok()?;
+    let hour = recorded
+        .get(11..13)?
+        .parse::<u8>()
+        .ok()?;
+    let minute = recorded
+        .get(14..16)?
+        .parse::<u8>()
+        .ok()?;
+    let second = recorded
+        .get(17..19)?
+        .parse::<u8>()
+        .ok()?;
+    let milli = recorded
+        .get(20..23)?
+        .parse::<u16>()
+        .ok()?;
+
+    let date = Date::from_calendar_date(year, Month::try_from(month).ok()?, day).ok()?;
+    let moment = date
+        .with_hms_milli(hour, minute, second, milli)
+        .ok()?
+        .assume_utc();
+    i64::try_from(moment.unix_timestamp_nanos() / 1_000_000).ok()
+}
+
+// The zone times are displayed in, as configured in the environment; UTC if
+// the platform will not tell us.
+fn local_offset() -> UtcOffset {
+    UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC)
+}
+
+fn format_clock(millis: i64, zone: UtcOffset) -> Option<String> {
+    let moment = moment(millis, zone)?;
+    Some(format!(
+        "{:02}:{:02}:{:02}",
+        moment.hour(),
+        moment.minute(),
+        moment.second()
+    ))
+}
+
+fn format_date(millis: i64, zone: UtcOffset) -> Option<String> {
+    let moment = moment(millis, zone)?;
+    Some(format!(
+        "{:04}-{:02}-{:02}",
+        moment.year(),
+        u8::from(moment.month()),
+        moment.day()
+    ))
+}
+
+fn format_stamp(millis: i64, zone: UtcOffset) -> Option<String> {
+    let moment = moment(millis, zone)?;
+    let (hours, minutes, _) = moment
+        .offset()
+        .as_hms();
+    Some(format!(
+        "{} {} {}{:02}:{:02}",
+        format_date(millis, zone)?,
+        format_clock(millis, zone)?,
+        if hours < 0 || minutes < 0 { '-' } else { '+' },
+        hours.abs(),
+        minutes.abs()
+    ))
+}
+
+fn moment(millis: i64, zone: UtcOffset) -> Option<OffsetDateTime> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(millis) * 1_000_000)
+        .ok()
+        .map(|moment| moment.to_offset(zone))
+}

--- a/src/reporting/column.rs
+++ b/src/reporting/column.rs
@@ -2,7 +2,8 @@
 
 use std::collections::HashMap;
 
-use time::{Date, Month, OffsetDateTime, UtcOffset};
+use time::format_description::well_known::Rfc3339;
+use time::{OffsetDateTime, UtcOffset};
 
 use crate::engraving::{
     InvokeTarget, Record, State, display_path, format_record, format_supplied, parse_run_uri,
@@ -535,40 +536,7 @@ fn elapsed(from: Option<i64>, to: Option<i64>) -> Option<i64> {
 // Milliseconds since the Unix epoch for a PFFTT timestamp of the form
 // 2026-08-04T22:50:36.869Z, as written when the record was appended.
 fn parse_timestamp(recorded: &str) -> Option<i64> {
-    let year = recorded
-        .get(0..4)?
-        .parse::<i32>()
-        .ok()?;
-    let month = recorded
-        .get(5..7)?
-        .parse::<u8>()
-        .ok()?;
-    let day = recorded
-        .get(8..10)?
-        .parse::<u8>()
-        .ok()?;
-    let hour = recorded
-        .get(11..13)?
-        .parse::<u8>()
-        .ok()?;
-    let minute = recorded
-        .get(14..16)?
-        .parse::<u8>()
-        .ok()?;
-    let second = recorded
-        .get(17..19)?
-        .parse::<u8>()
-        .ok()?;
-    let milli = recorded
-        .get(20..23)?
-        .parse::<u16>()
-        .ok()?;
-
-    let date = Date::from_calendar_date(year, Month::try_from(month).ok()?, day).ok()?;
-    let moment = date
-        .with_hms_milli(hour, minute, second, milli)
-        .ok()?
-        .assume_utc();
+    let moment = OffsetDateTime::parse(recorded, &Rfc3339).ok()?;
     i64::try_from(moment.unix_timestamp_nanos() / 1_000_000).ok()
 }
 

--- a/src/reporting/column.rs
+++ b/src/reporting/column.rs
@@ -136,7 +136,7 @@ enum Cell {
 }
 
 /// Render a run's records as a column-aligned stream, one line per record.
-pub fn render_console(records: &[Record], columns: &[Column], renderer: &dyn Render) -> String {
+pub fn render_console(records: &[Record], columns: &[Column], renderer: &impl Render) -> String {
     let mut text = String::new();
 
     let first = match records.first() {

--- a/src/reporting/mod.rs
+++ b/src/reporting/mod.rs
@@ -1,0 +1,12 @@
+//! Present the trail of a recorded run. The PFFTT records are read back from
+//! the store then rendered to terminal.
+
+mod column;
+
+pub use column::{
+    CONSOLE_COLUMNS, Column, JSON_COLUMNS, PFFTT_COLUMNS, render_console, render_json, render_pfftt,
+};
+
+#[cfg(test)]
+#[path = "checks/column.rs"]
+mod check;

--- a/src/runner/checks/path.rs
+++ b/src/runner/checks/path.rs
@@ -1,5 +1,5 @@
 use crate::language::{Attribute, Identifier, Span};
-use crate::runner::path::{PathSegment, QualifiedPath, display_path};
+use crate::runner::path::{PathSegment, QualifiedPath};
 
 #[test]
 fn empty_stack_renders_root() {
@@ -117,35 +117,6 @@ fn procedure_segment() {
     stack.push(PathSegment::Procedure("inner"));
     stack.push(PathSegment::DependentStep("2"));
     assert_eq!(stack.render(), "/outer:/1/inner:/2");
-}
-
-#[test]
-fn display_trims_entry_head() {
-    // Within a section the entry head is dropped, the numeral anchors instead.
-    assert_eq!(
-        display_path("/connectivity_check:/VI/check_aws_health:/7"),
-        "VI/check_aws_health:/7"
-    );
-
-    // A flat entry with no section keeps its name; only the leading slash goes.
-    assert_eq!(
-        display_path("/connectivity_check:/1"),
-        "connectivity_check:/1"
-    );
-    assert_eq!(
-        display_path("/activate_crisis_management:/-1"),
-        "activate_crisis_management:/-1"
-    );
-
-    // An ` <invocation>` annotation on the numeral is kept; the head still drops.
-    assert_eq!(
-        display_path("/connectivity_check:/VII <service_endpoint>"),
-        "VII <service_endpoint>"
-    );
-
-    // An anonymous technique has no head to drop; the leading slash still goes.
-    assert_eq!(display_path("/I/1"), "I/1");
-    assert_eq!(display_path("/I"), "I");
 }
 
 #[test]

--- a/src/runner/checks/runner.rs
+++ b/src/runner/checks/runner.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::engraving::{Appender, InvokeTarget, State, Store, Supplied, parse_record};
 use crate::language;
 use crate::language::{Identifier, Numeric as LangNumeric};
 use crate::parsing;
@@ -15,7 +16,6 @@ use crate::runner::library::Library;
 use crate::runner::runner::{
     Conclusion, Outcome, Runner, RunnerError, bind_parameters, render_argument_echo,
 };
-use crate::runner::state::{Appender, InvokeTarget, State, Store, Supplied, parse_record};
 use crate::translation::translate;
 use crate::value::Value;
 
@@ -37,7 +37,7 @@ impl StoreFixture {
         let (run_id, run_dir) = store
             .create(&document, "2026-05-16T00:00:00Z".to_string(), &[])
             .expect("create");
-        let pfftt = crate::runner::state::construct_state_path(&run_dir, &document);
+        let pfftt = crate::engraving::construct_state_path(&run_dir, &document);
         let appender = Appender::open(pfftt, run_id).expect("open appender");
         StoreFixture {
             base,
@@ -826,18 +826,18 @@ cycle(s) : Situation -> Done
         "the callee's body must not run after the quit"
     );
     assert!(
-        !pfftt
+        pfftt
             .lines()
-            .any(|line| line.contains("Invoke")),
-        "declining at the prompt records no Invoke — the call never began"
+            .any(|line| line.contains("Invoke cycle:")),
+        "the dispatch is recorded on arrival, before the prompt the user quit at"
     );
 }
 
 #[test]
 fn skip_while_acquiring_records_the_skipped_invocation() {
-    // Skip at the implicit-argument prompt skips the invocation: a Skip is
-    // recorded at the callee's path (not silently swallowed) with no Invoke,
-    // and the callee's body never runs.
+    // Skip at the implicit-argument prompt skips the invocation: the dispatch
+    // is recorded, a Skip is recorded at the callee's path (not silently
+    // swallowed), and the callee's body never runs.
     let source = r#"
 % technique v1
 
@@ -877,10 +877,10 @@ cycle(s) : Situation -> Done
         "the skipped invocation is recorded at the callee's path"
     );
     assert!(
-        !pfftt
+        pfftt
             .lines()
-            .any(|line| line.contains("Invoke")),
-        "a declined call records no Invoke"
+            .any(|line| line.contains("Invoke cycle:")),
+        "the dispatch is recorded on arrival, the Skip standing as the decline"
     );
     assert!(
         !pfftt

--- a/src/runner/driver.rs
+++ b/src/runner/driver.rs
@@ -19,7 +19,7 @@ use crossterm::style::{
 use crossterm::terminal::{Clear, ClearType, disable_raw_mode, enable_raw_mode, size};
 use crossterm::{cursor, queue};
 
-use super::path::display_path;
+use crate::engraving::display_path;
 use crate::formatting::{Identity, Render, Syntax};
 use crate::highlighting::Terminal;
 use crate::value::Value;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -14,18 +14,16 @@ mod evaluator;
 mod library;
 mod path;
 mod runner;
-mod state;
 
 pub use context::Context;
 pub use driver::{Headless, Mode};
 pub use evaluator::Environment;
 pub use library::{Builtin, Library, Native, library_for};
 pub use runner::{Conclusion, Outcome, Runner, RunnerError};
-pub use state::{Appender, RecordError, RunId};
 
+use crate::engraving::{Appender, Record, RunId, State, Store, construct_state_path};
 use driver::{Automatic, Console, Transcript};
 use runner::{bind_parameters, now_iso8601};
-use state::{Record, State, Store, construct_state_path};
 
 const STORE_ROOT: &str = ".store";
 
@@ -132,6 +130,12 @@ pub fn locate(run_id: RunId) -> Result<(PathBuf, Vec<String>), RunnerError> {
     let store = Store::new(PathBuf::from(STORE_ROOT));
     let (document, libraries, _, _, _) = store.open(run_id)?;
     Ok((document, libraries))
+}
+
+/// Load an existing run's recorded trail back into memory.
+pub fn load(run_id: RunId) -> Result<Vec<Record>, RunnerError> {
+    let store = Store::new(PathBuf::from(STORE_ROOT));
+    Ok(store.read(run_id)?)
 }
 
 /// Open an existing run and walk the given program, short-circuiting

--- a/src/runner/path.rs
+++ b/src/runner/path.rs
@@ -83,34 +83,6 @@ impl<'i> QualifiedPath<'i> {
     }
 }
 
-/// Trim a rendered PFFTT path to the live-prompt form: drop the leading `/`,
-/// and the entry procedure's `name:` head when a section immediately follows.
-pub fn display_path(qualified: &str) -> String {
-    let body = qualified
-        .strip_prefix('/')
-        .unwrap_or(qualified);
-    let mut parts: Vec<&str> = body
-        .split('/')
-        .collect();
-    if parts.len() >= 2 && parts[0].ends_with(':') && is_section_component(parts[1]) {
-        parts.remove(0);
-    }
-    parts.join("/")
-}
-
-/// Leading token, not the whole component: an acquire label can glue an
-/// ` <invocation>` annotation after the numeral.
-fn is_section_component(part: &str) -> bool {
-    let token = part
-        .split_whitespace()
-        .next()
-        .unwrap_or("");
-    !token.is_empty()
-        && token
-            .bytes()
-            .all(|b| b"IVXLCDM".contains(&b))
-}
-
 /// Render a segment slice as a PFFTT absolute path, always rooted at `/`.
 pub fn render_path(segments: &[PathSegment]) -> String {
     let pieces: Vec<String> = segments

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -2,14 +2,13 @@
 
 use std::collections::HashMap;
 use std::io;
-use std::path::PathBuf;
 
 use super::context::Context;
 use super::driver::{Driver, Kind, Standing, UserInput};
 use super::evaluator::Environment;
 use super::library::{Library, Nature};
 use super::path::{PathSegment, QualifiedPath};
-use super::state::{Appender, InvokeTarget, Record, RecordError, RunId, State, Supplied};
+use crate::engraving::{Appender, InvokeTarget, Record, State, StoreError, Supplied};
 use crate::language;
 use crate::program::{
     Executable, ExecutableRef, Invocable, Locale, Operation, Ordinal, Program, Subroutine,
@@ -51,17 +50,7 @@ pub enum Failure {
 /// in `crate::problem` knows how to render each one.
 #[derive(Debug)]
 pub enum RunnerError {
-    NoSuchRun(RunId),
-    StoreError {
-        path: PathBuf,
-        error: io::Error,
-    },
-    MalformedRecord {
-        run_id: RunId,
-        error: RecordError,
-    },
-    StartMissing(RunId),
-    InvalidRunId(String),
+    Store(StoreError),
     MissingEntryProcedure,
     UnboundVariable(String),
     BindArityMismatch {
@@ -100,6 +89,12 @@ pub enum RunnerError {
     },
     TerminalRequired,
     UserQuit,
+}
+
+impl From<StoreError> for RunnerError {
+    fn from(error: StoreError) -> Self {
+        RunnerError::Store(error)
+    }
 }
 
 /// Execute a Technique interactively by walking the `Program` tree. Tracks
@@ -681,11 +676,28 @@ impl<'i, D: Driver> Runner<'i, D> {
                     }
 
                     // Acquire deferred arguments at the call site, in the
-                    // invocation's `<name>` form, before any Invoke is recorded.
+                    // invocation's `<name>` form.
                     let caller = self
                         .path
                         .render();
                     let invoked = format!("<{}>", name);
+
+                    // Record the dispatch on arrival, before any argument is
+                    // solicited, so that the time the user takes supplying one
+                    // falls between this and the Input that follows. Declining
+                    // at the prompt settles Skip or Fail at the callee's path,
+                    // which stands as the record of a call that was dispatched
+                    // and turned down.
+                    let run_id = self
+                        .appender
+                        .run_id();
+                    self.appender
+                        .append(&Record {
+                            recorded: now_iso8601(),
+                            run_id,
+                            path: caller.clone(),
+                            state: State::Invoke(InvokeTarget::Procedure(name.to_string())),
+                        })?;
 
                     let formae = render_parameter_formae(subroutine.signature);
 
@@ -785,21 +797,6 @@ impl<'i, D: Driver> Runner<'i, D> {
                             }
                         }
                     }
-
-                    // Record the dispatch once the arguments are in hand —
-                    // declining at the prompt above returns before this, so a
-                    // declined call records no Invoke. Recorded at answer-time,
-                    // so the gap from the previous event is the user wait.
-                    let run_id = self
-                        .appender
-                        .run_id();
-                    self.appender
-                        .append(&Record {
-                            recorded: now_iso8601(),
-                            run_id,
-                            path: caller,
-                            state: State::Invoke(InvokeTarget::Procedure(name.to_string())),
-                        })?;
 
                     // Record the prompted inputs (answered just now) before
                     // Begin, unless they were restored from a prior run (already
@@ -1625,7 +1622,8 @@ impl<'i, D: Driver> Runner<'i, D> {
                 run_id,
                 path: qualified.to_string(),
                 state: State::Input(supplied),
-            })
+            })?;
+        Ok(())
     }
 
     /// At a procedure's entry, restore its parameter bindings from a prior
@@ -1764,7 +1762,8 @@ impl<'i, D: Driver> Runner<'i, D> {
             state: State::Finish,
         };
         self.appender
-            .append(&record)
+            .append(&record)?;
+        Ok(())
     }
 
     /// Record a deliberate Stop at the root path and unwind the walk.
@@ -1953,7 +1952,7 @@ fn record_state(conclusion: &Conclusion) -> State {
                 // failure with no reason rather than an empty-string one.
                 State::Fail(None)
             } else {
-                State::Fail(Some(super::state::fail_reason(reason)))
+                State::Fail(Some(crate::engraving::fail_reason(reason)))
             }
         }
         Conclusion::Stopping => unreachable!(), // Stop is recorded as a lifecycle event, not a step result

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,6 +2,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 pub fn list_technique_documents(dir: &Path) -> Vec<PathBuf> {
+    list_files(dir, "tq")
+}
+
+pub fn list_files(dir: &Path, extension: &str) -> Vec<PathBuf> {
     assert!(dir.exists(), "samples directory missing");
 
     let entries = fs::read_dir(dir).expect("Failed to read samples directory");
@@ -14,12 +18,16 @@ pub fn list_technique_documents(dir: &Path) -> Vec<PathBuf> {
         if path
             .extension()
             .and_then(|s| s.to_str())
-            == Some("tq")
+            == Some(extension)
         {
             files.push(path);
         }
     }
 
-    assert!(!files.is_empty(), "No .tq files found in directory");
+    assert!(
+        !files.is_empty(),
+        "No .{} files found in directory",
+        extension
+    );
     files
 }

--- a/tests/engraving/mod.rs
+++ b/tests/engraving/mod.rs
@@ -1,0 +1,1 @@
+mod roundtrip;

--- a/tests/engraving/roundtrip.rs
+++ b/tests/engraving/roundtrip.rs
@@ -1,0 +1,45 @@
+use std::fs;
+use std::path::Path;
+
+use technique::engraving::parse_records;
+use technique::reporting::render_pfftt;
+
+use crate::common::list_files;
+
+/// Every recorded trail must survive being parsed back into records and
+/// rendered again, byte for byte. This is what lets `technique log
+/// --output=pfftt` claim to be the stored format when the records no longer
+/// come from a file: a codec that drops a field, reorders one, or loses an
+/// escape shows up here.
+#[test]
+fn ensure_records_render_as_stored() {
+    let dir = Path::new("tests/golden/runner/");
+    let files = list_files(dir, "pfftt");
+
+    let mut failures = Vec::new();
+
+    for file in &files {
+        let content = fs::read_to_string(file)
+            .unwrap_or_else(|e| panic!("Failed to read {:?}: {:?}", file, e));
+
+        let records = match parse_records(&content) {
+            Ok(records) => records,
+            Err(e) => {
+                println!("File {:?} failed to parse: {:?}", file, e);
+                failures.push(file.clone());
+                continue;
+            }
+        };
+
+        if render_pfftt(&records) != content {
+            println!("File {:?} did not render back as stored", file);
+            failures.push(file.clone());
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "trails failed to round-trip: {:?}",
+        failures
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 mod common;
+mod engraving;
 mod formatting;
 mod linking;
 mod parsing;

--- a/tests/runner/samples.rs
+++ b/tests/runner/samples.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
+use technique::engraving::Appender;
 use technique::parsing;
-use technique::runner::{
-    Appender, Conclusion, Context, Environment, Headless, Library, Outcome, Runner,
-};
+use technique::runner::{Conclusion, Context, Environment, Headless, Library, Outcome, Runner};
 use technique::translation;
 
 use crate::common::list_technique_documents;


### PR DESCRIPTION
Introduce the _technique log_ subcommand.

This prints a nicely formatted version of the trace of a run. Reading the Procedure interchange Format For Transferring Techniques data from the _.pfftt_ file in the local store corresponding to the given run, render a more human readable version to the console.

In addition to the default `console`, there are also `--output` options for `pfftt` (as written on disk), `json` (to output an array of JSON objects), and finally as with other commands a `native` variant (for debugging the internal data structures if necessary).

The command offers the ability to select the columns being displayed using the `--columns` option.